### PR TITLE
When selecting a new note, reset the scroll position to the top.

### DIFF
--- a/src/ui/edit_view/edit_view.vala
+++ b/src/ui/edit_view/edit_view.vala
@@ -405,4 +405,12 @@ public class Folio.EditView : Gtk.Box {
 			}
 		}
 	}
+
+	public void reset_scroll_position () {
+		Gtk.TextIter start;
+		markdown_view.buffer.get_start_iter (out start);
+		markdown_view.buffer.place_cursor (start);
+		scrolled_window.set_vadjustment (null);
+		markdown_view.grab_focus ();
+	}
 }

--- a/src/ui/window/window.vala
+++ b/src/ui/window/window.vala
@@ -195,6 +195,7 @@ public class Folio.Window : Adw.ApplicationWindow {
 		update_note_title ();
 		update_editability ();
 		edit_view.buffer = window_model.current_buffer;
+		edit_view.reset_scroll_position ();
 		if (note != null) {
 			edit_view.text_mode = !note.is_markdown;
 			if (!note.is_markdown) {


### PR DESCRIPTION
Resolves #34 