### PR TITLE
When saving a note, update the notes list with the new timestamp.

### DIFF
--- a/lib/note.vala
+++ b/lib/note.vala
@@ -73,6 +73,7 @@ public class Folio.Note : Object {
 
 	public void save (string text) {
 		FileUtils.save_to (File.new_for_path (path), text);
+		this._time_modified = new DateTime.now ();
 	}
 
 	public bool equals (Note other) {


### PR DESCRIPTION
Make sure to update the timestamp after saving and don't save the note if it doesn't need to be.

Resolves #33 