### PR TITLE
Fix title styles bleeding into subsequent lines in some cases

### DIFF
--- a/src/ui/widgets/markdown/markdown_view.vala
+++ b/src/ui/widgets/markdown/markdown_view.vala
@@ -90,7 +90,8 @@ public class GtkMarkdown.View : GtkSource.View {
 		Gtk.TextIter start;
 		Gtk.TextIter end;
 		buffer.get_iter_at_line (out start, (int) line);
-		buffer.get_iter_at_line (out end, (int) line + 1);
+		end = start.copy ();
+		end.forward_to_line_end ();
 		var str = start.get_text (end);
 		var i = 0;
 		while (i < 6 && i < str.length) {
@@ -706,7 +707,8 @@ public class GtkMarkdown.View : GtkSource.View {
 				if (title_level != 0) {
 					Gtk.TextIter start, end;
 					buffer.get_iter_at_line (out start, line);
-					buffer.get_iter_at_line (out end, line + 1);
+					end = start.copy ();
+					end.forward_to_line_end ();
 					buffer.apply_tag (text_tags_title[title_level - 1], start, end);
 				}
 			}


### PR DESCRIPTION
Currently when the text cursor is located below a line with a title style applied, the style will bleed into subsequent lines.

[Skærmoptagelse fra 2024-03-19 09-44-31.webm](https://github.com/toolstack/Folio/assets/27958428/3f3b0e5c-72bd-410b-b93e-e75a0a7c8908)

I have found that this patch appears to fix it, but I'm not entirely sure the actual reason for the broken behaviour.

Nevertheless the previous code was wrong as it would get the start of the next line rather than the end of the current one.