### PR TITLE
Fix typo in.toolstack.Folio.pot

### DIFF
--- a/po/com.toolstack.Folio.pot
+++ b/po/com.toolstack.Folio.pot
@@ -99,7 +99,7 @@ msgstr ""
 
 #: data/app.gschema.xml:32
 msgid ""
-"Adds a button to the markdown refrence sheet on the right of the formatting "
+"Adds a button to the markdown reference sheet on the right of the formatting "
 "toolbar"
 msgstr ""
 


### PR DESCRIPTION
On line 102, "reference" was typed as "refrence".
I fixed the missing "e".