### PR TITLE
Use display name instead of disk name for dirs and files.

### DIFF
--- a/lib/notebook/local_notebook.vala
+++ b/lib/notebook/local_notebook.vala
@@ -40,13 +40,13 @@ public class Folio.LocalNotebook : Object, ListModel, NoteContainer, Notebook {
 		_loaded_notes = new ArrayList<Note> ();
 		var dir = File.new_for_path (path);
 		try {
-			var enumerator = dir.enumerate_children (FileAttribute.STANDARD_NAME + "," + FileAttribute.TIME_MODIFIED + "," + FileAttribute.STANDARD_CONTENT_TYPE, 0);
+			var enumerator = dir.enumerate_children (FileAttribute.STANDARD_NAME + "," + FileAttribute.TIME_MODIFIED + "," + FileAttribute.STANDARD_CONTENT_TYPE + "," + FileAttribute.STANDARD_DISPLAY_NAME, 0);
 			FileInfo file_info;
 			while ((file_info = enumerator.next_file ()) != null) {
 				var content_type = file_info.get_content_type ();
 				if (content_type == null || !(content_type.has_prefix ("text") || content_type.has_prefix ("application")))
 					continue;
-				var name = file_info.get_name ();
+				var name = file_info.get_display_name ();
 				if (name[0] == '.')
 					continue;
 				var dot_i = name.last_index_of_char ('.');

--- a/lib/provider.vala
+++ b/lib/provider.vala
@@ -136,7 +136,7 @@ public class Folio.Provider : Object, ListModel {
 			try {
 				var enumerator = file.enumerate_children (FileAttribute.STANDARD_NAME, 0);
 				while ((file_info = enumerator.next_file ()) != null) {
-					var name = file_info.get_name ();
+					var name = file_info.get_display_name ();
 					var orig_file = enumerator.get_child (file_info);
 					var trashed_file = File.new_for_path (@"$trashed_path/$name");
 					orig_file.move (trashed_file, FileCopyFlags.OVERWRITE);
@@ -189,11 +189,11 @@ public class Folio.Provider : Object, ListModel {
 		var notebooks = new ArrayList<Notebook> ();
 		var dir = File.new_for_path (notes_dir);
 		try {
-			var enumerator = dir.enumerate_children (FileAttribute.STANDARD_NAME + "," + FileAttribute.STANDARD_TYPE + "," + FileAttribute.TIME_MODIFIED, 0);
+			var enumerator = dir.enumerate_children (FileAttribute.STANDARD_NAME + "," + FileAttribute.STANDARD_TYPE + "," + FileAttribute.TIME_MODIFIED + "," + FileAttribute.STANDARD_DISPLAY_NAME, 0);
 			FileInfo file_info;
 			while ((file_info = enumerator.next_file ()) != null) {
 				if (file_info.get_file_type () != FileType.DIRECTORY) continue;
-				var name = file_info.get_name ();
+				var name = file_info.get_display_name ();
 				var time = file_info.get_modification_date_time ();
 				if (disable_hidden_trash && name == "Trash") continue;
 				if (name[0] == '.') continue;
@@ -251,18 +251,18 @@ public class Folio.Provider : Object, ListModel {
 		while (written < l) {
 			written += data_stream.write (data[written:data.length]);
 		}
-		var notebooks_enumerator = File.new_for_path (notes_dir).enumerate_children (FileAttribute.STANDARD_NAME, 0);
+		var notebooks_enumerator = File.new_for_path (notes_dir).enumerate_children (FileAttribute.STANDARD_NAME + "," + FileAttribute.STANDARD_DISPLAY_NAME, 0);
 		FileInfo notebook_file_info;
 		while ((notebook_file_info = notebooks_enumerator.next_file ()) != null) {
-			var notebook_path = @"$notes_dir/$(notebook_file_info.get_name ())";
+			var notebook_path = @"$notes_dir/$(notebook_file_info.get_display_name ())";
 			var dir = File.new_for_path (notebook_path);
 			if (dir.query_file_type (0) != FileType.DIRECTORY)
 				continue;
 			try {
-				var enumerator = dir.enumerate_children (FileAttribute.STANDARD_NAME, 0);
+				var enumerator = dir.enumerate_children (FileAttribute.STANDARD_NAME + "," + FileAttribute.STANDARD_DISPLAY_NAME, 0);
 				FileInfo file_info;
 				while ((file_info = enumerator.next_file ()) != null) {
-					var name = file_info.get_name ();
+					var name = file_info.get_display_name ();
 					if (name != ".color") continue;
 					File.new_for_path (@"$notebook_path/.config/").make_directory ();
 					var dest = File.new_for_path (@"$notebook_path/.config/color");

--- a/lib/trash.vala
+++ b/lib/trash.vala
@@ -50,10 +50,10 @@ public class Folio.Trash : Object, ListModel, NoteContainer {
 			error (@"Trash directory $(dir.get_path ()) couldn't be created");
 		}
 		try {
-			var enumerator = dir.enumerate_children (FileAttribute.STANDARD_NAME, 0);
+			var enumerator = dir.enumerate_children (FileAttribute.STANDARD_NAME + "," + FileAttribute.STANDARD_DISPLAY_NAME, 0);
 			FileInfo file_info;
 			while ((file_info = enumerator.next_file ()) != null) {
-				var name = file_info.get_name ();
+				var name = file_info.get_display_name ();
 				if (name[0] == '.') continue;
 				var notebook = new TrashedNotebook (this, new NotebookInfo (name));
 				load_notebook (notebook);
@@ -70,13 +70,13 @@ public class Folio.Trash : Object, ListModel, NoteContainer {
 	private void load_notebook (TrashedNotebook notebook) {
 		var dir = File.new_for_path (notebook.path);
 		try {
-			var enumerator = dir.enumerate_children (FileAttribute.STANDARD_NAME + "," + FileAttribute.TIME_MODIFIED + "," + FileAttribute.STANDARD_CONTENT_TYPE, 0);
+			var enumerator = dir.enumerate_children (FileAttribute.STANDARD_NAME + "," + FileAttribute.TIME_MODIFIED + "," + FileAttribute.STANDARD_CONTENT_TYPE + "," + FileAttribute.STANDARD_DISPLAY_NAME, 0);
 			FileInfo file_info;
 			while ((file_info = enumerator.next_file ()) != null) {
 				var content_type = file_info.get_content_type ();
 				if (content_type == null || !content_type.has_prefix ("text"))
 					continue;
-				var name = file_info.get_name ();
+				var name = file_info.get_display_name ();
 				if (name[0] == '.')
 					continue;
 				var dot_i = name.last_index_of (".");


### PR DESCRIPTION
Some file system providers (like google drive) do not use the display name on disk, but instead a hash value, which breaks those locations for storage of notes.

Resolves #73 