### PR TITLE
Strip off stray formatting tags from urls when opening them.

### DIFF
--- a/src/ui/edit_view/edit_view.vala
+++ b/src/ui/edit_view/edit_view.vala
@@ -86,6 +86,17 @@ public class Folio.EditView : Gtk.Box {
 
 						url_text = markdown_view.buffer.get_slice (start_url, end_url, true);
 						url_text = url_text.chomp ().chug ();
+
+						var last_one = url_text.substring (-1, 1);
+						var last_two = url_text.substring (-2, 2);
+
+						// Strip off any markdown formating tags from the end of the url.
+						if (last_two == "**" || last_two == "__" || last_two == "~~" || last_two == "==") {
+							url_text = url_text.substring (0, url_text.length - 2);
+						}
+						if (last_two == "*" || last_two == "_") {
+							url_text = url_text.substring (0, url_text.length - 1);
+						}
 					}
 
 					// Check to see if we have an e-mail link to open.


### PR DESCRIPTION
Fixes #135 