### PR TITLE
Make sure for ordered lists we require a period after the number

### DIFF
--- a/src/ui/widgets/markdown/markdown_view.vala
+++ b/src/ui/widgets/markdown/markdown_view.vala
@@ -356,7 +356,7 @@ public class GtkMarkdown.View : GtkSource.View {
 			 * * list item
 			 * 0. list item
 			 */
-			is_list_row = new Regex ("^[\\t ]*([-*+]|[.0-9])+[\\t ]+", f | RegexCompileFlags.MULTILINE, 0);
+			is_list_row = new Regex ("^[\\t ]*([-*+]|[0-9]\\.)+[\\t ]+", f | RegexCompileFlags.MULTILINE, 0);
 
 			/* Examples:
 			 * |column 1|column 2|


### PR DESCRIPTION
Otherwise lines that start with numbers will be mis-detected as ordered list items.

Resolves #164 