### PR TITLE
Move to more modern widgets

### DIFF
--- a/po/ar.po
+++ b/po/ar.po
@@ -2,244 +2,18 @@
 # This file is distributed under the same license as the Folio package.
 msgid ""
 msgstr ""
+"Project-Id-Version: Folio\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-10-12 16:53+0200\n"
 "PO-Revision-Date: 2024-09-19 16:40:07+0000\n"
+"Language: ar\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=6; plural=(n == 0) ? 0 : ((n == 1) ? 1 : ((n == 2) ? 2 : ((n % 100 >= 3 && n % 100 <= 10) ? 3 : ((n % 100 >= 11 && n % 100 <= 99) ? 4 : 5))));\n"
+"Plural-Forms: nplurals=6; plural=(n == 0) ? 0 : ((n == 1) ? 1 : ((n == 2) ? "
+"2 : ((n % 100 >= 3 && n % 100 <= 10) ? 3 : ((n % 100 >= 11 && n % 100 <= "
+"99) ? 4 : 5))));\n"
 "X-Generator: GlotPress/4.0.1\n"
-"Language: ar\n"
-"Project-Id-Version: Folio\n"
-
-#: data/app.gschema.xml:76
-msgid "Notebook sort order"
-msgstr "ترتيب فرز الدفاتر"
-
-#: data/app.gschema.xml:77
-msgid "The sort order of the notebook list"
-msgstr "ترتيب الفرز لقائمة الدفاتر"
-
-#: src/ui/preferences/preferences.blp:145
-msgid "Sort Order For Notebooks"
-msgstr "ترتيب الفرز للدفاتر"
-
-#: data/app.gschema.xml:71
-msgid "Note sort order"
-msgstr "ترتيب فرز الملاحظات"
-
-#: data/app.gschema.xml:72
-msgid "The sort order of the note list"
-msgstr "ترتيب الفرز لقائمة الملاحظات"
-
-#: src/ui/preferences/preferences.blp:150
-msgid "Sort Order For Notes"
-msgstr "ترتيب الفرز للملاحظات"
-
-#: src/ui/strings.vala:62
-msgid "Modified Time - Ascending"
-msgstr "زمن التعديل - تصاعديًا"
-
-#: src/ui/strings.vala:63
-msgid "Modified Time - Descending"
-msgstr "زمن التعديل - تنازليًا"
-
-#: src/ui/strings.vala:64
-msgid "Alphabetical - Ascending"
-msgstr "أبجدي - تصاعديًا"
-
-#: src/ui/strings.vala:65
-msgid "Alphabetical - Descending"
-msgstr "أبجدي - تنازليًا"
-
-#: src/ui/popup/shortcut_window.blp:114
-msgid "Display"
-msgstr "العرض"
-
-#: src/ui/popup/shortcut_window.blp:117
-msgid "Full Screen"
-msgstr "ملء الشاشة"
-
-#: src/ui/popup/shortcut_window.blp:122
-msgid "Zoom In"
-msgstr "كبِّر"
-
-#: src/ui/popup/shortcut_window.blp:127
-msgid "Zoom Out"
-msgstr "صغِّر"
-
-#: src/ui/strings.vala:52
-msgid "Pick primary font for notes"
-msgstr "اختر الخط الأساسي للملاحظات"
-
-#: src/ui/strings.vala:53
-msgid "Pick monospace font for code"
-msgstr "اختر خطًا ثابت العرض للترميز"
-
-#: src/ui/strings.vala:54
-msgid "File Changed On Disk"
-msgstr "غُيِّر الملف على القرص"
-
-#: src/ui/strings.vala:55
-msgid ""
-"The file has changed on disk since it was last saved/loaded by Folio.\n"
-"\n"
-"You may do one of the following:\n"
-"\n"
-" • Reload the file (discarding any changes you have made in Folio)\n"
-" • Overwrite the file (discarding any changes made outside of Folio)\n"
-" • Cancel the operation and manually resolve the issue\n"
-"\n"
-"Note: Canceling the save if you have already moved to a new note/notebook will discard your changes."
-msgstr ""
-"غُيِّر الملف على القرص منذ آخر مرة حُفِظ/حُمِل بواسطة «مطوية».\n"
-"\n"
-"يمكنك القيام بأحد الأمور التالية:\n"
-"\n"
-" - أعِد تحميل الملف (تجاهل أي تغييرات أجريتها في «مطوية»)\n"
-" - اكتب فوق الملف (تجاهل أي تغييرات أجريت خارج «مطوية»)\n"
-" - ألغِ العملية وحل المشكلة يدويًا\n"
-"\n"
-"ملاحظة: في حال انتقلت إلى ملاحظة/دفتر جديد، فستتجاهل تغييراتك عند الحفظ."
-
-#: src/ui/strings.vala:56
-msgid "Reload"
-msgstr "أعِد التحميل"
-
-#: src/ui/strings.vala:57
-msgid "Overwrite"
-msgstr "اكتب فوق"
-
-#: src/ui/strings.vala:59
-msgid ""
-"The file has changed on disk by another application.\n"
-"\n"
-"You may do one of the following:\n"
-"\n"
-" • Reload the file (discarding any changes you have made in Folio)\n"
-" • Overwrite the file (discarding any changes made outside of Folio)"
-msgstr ""
-"غُيِّر الملف على القرص من قبل تطبيق آخر.\n"
-"\n"
-"يمكنك القيام بأحد الأمور التالية:\n"
-"\n"
-" - أعِد تحميل الملف (تجاهل أي تغييرات أجريتها في «مطوية»)\n"
-" - اكتب فوق الملف (تجاهل أي تغييرات أجريتها خارج «مطوية»)"
-
-#: src/ui/strings.vala:61
-msgid "Note %i"
-msgstr "ملاحظة %i"
-
-#: data/app.gschema.xml:46 src/ui/preferences/preferences.blp:213
-msgid "Trash Storage Location"
-msgstr "موضع تخزين المهملات"
-
-#: data/app.gschema.xml:47 src/ui/preferences/preferences.blp:214
-msgid "Where the trash folder is located (requires app restart)"
-msgstr "موضع مجلد المهملات (يتطلب إعادة تشغيل التطبيق)"
-
-#: src/ui/strings.vala:46
-msgid "Pick where the trash can will be stored"
-msgstr "اختر أين تخزن سلة المهملات"
-
-#: data/app.gschema.xml:16 src/ui/preferences/preferences.blp:128
-msgid "Use Fixed Width For Notes"
-msgstr "استخدام العرض الثابت للملاحظات"
-
-#: data/app.gschema.xml:17 src/ui/preferences/preferences.blp:129
-msgid "Use a fixed width for the text area of a note"
-msgstr "استخدام العرض الثابت لمساحة النص في الملاحظة"
-
-#: data/app.gschema.xml:37 src/ui/preferences/preferences.blp:118
-msgid "Expands the notebook list to include the notebook name"
-msgstr "وَسِّع قائمة الدفاتر لتشمل اسم الدفتر"
-
-#: data/app.gschema.xml:51 src/ui/preferences/preferences.blp:65
-msgid "Show line numbers"
-msgstr "أظهِر أرقام الأسطر"
-
-#: data/app.gschema.xml:52 src/ui/preferences/preferences.blp:66
-msgid "Displays line numbers at the left of the note"
-msgstr "عرض أرقام الأسطر على يسار الملاحظة"
-
-#: data/app.gschema.xml:56 src/ui/preferences/preferences.blp:76
-msgid "Show all notes"
-msgstr "أظهِر جميع الملاحظات"
-
-#: data/app.gschema.xml:57 src/ui/preferences/preferences.blp:77
-msgid "Displays the \"All Notes\" notebook at the top of the notebook list"
-msgstr "اعرض دفتر «جميع الملاحظات» فوق كافة الدفاتر في القائمة"
-
-#: data/app.gschema.xml:61 src/ui/preferences/preferences.blp:163
-msgid "Enable autosave"
-msgstr "فَعِّل الحفظ الآلي"
-
-#: data/app.gschema.xml:62 src/ui/preferences/preferences.blp:164
-msgid "Automatically saves the current note every 30 seconds if the contents have changed (requires app restart)"
-msgstr "احفظ الملاحظة الحالية كل 30 ثانية عند تغيير محتواها (يتطلب إعادة تشغيل التطبيق)"
-
-#: data/app.gschema.xml:66 src/ui/preferences/preferences.blp:174
-msgid "Don't hide the Trash folder"
-msgstr "لا تخفي مجلد المهملات"
-
-#: data/app.gschema.xml:67
-msgid "The trash folder is set as a hidden folder by default, this option makes it visible"
-msgstr "مجلد المهملات مخفي مبدئيًا، لكن هذا الخيار يجعله مرئيًأ"
-
-#: data/app.metainfo.xml.in:367
-msgid "Main Folio window in light mode"
-msgstr "نافذة «مطوية» الرئيسة في الوضع الفاتح"
-
-#: data/app.metainfo.xml.in:371
-msgid "Main Folio window in dark mode"
-msgstr "نافذة «مطوية» الرئيسة في الوضع الداكن"
-
-#: data/app.metainfo.xml.in:375
-msgid "Folio on small/mobile screens"
-msgstr "«مطوية» على الشاشات الصغيرة/المحمولة"
-
-#: data/app.metainfo.xml.in:379
-msgid "Folio preferences screen"
-msgstr "شاشة تفضيلات «مطوية»"
-
-#: data/app.metainfo.xml.in:383
-msgid "Folio in three pane mode"
-msgstr "«مطوية» في وضع الألواح الثلاثة"
-
-#: src/ui/preferences/preferences.blp:59
-msgid "Tools"
-msgstr "الأدوات"
-
-#: data/app.gschema.xml:27 src/ui/preferences/preferences.blp:88
-msgid "Displays the formatting toolbar at the bottom of the note"
-msgstr "يعرض شريط أدوات التنسيق أسفل الملاحظة"
-
-#: data/app.gschema.xml:32 src/ui/preferences/preferences.blp:99
-msgid "Adds a button to the markdown reference sheet on the right of the formatting toolbar"
-msgstr "يضيف زرًا لعرض مرجع «ماركداون» على يمين شريط أدوات التنسيق"
-
-#: src/ui/preferences/preferences.blp:111
-msgid "Layout"
-msgstr "التخطيط"
-
-#: src/ui/preferences/preferences.blp:139
-msgid "Fixed Width To Use For Notes"
-msgstr "العرض الثابت للاستخدام في الملاحظات"
-
-#: src/ui/preferences/preferences.blp:140
-msgid "Sets the fixed width size of a note in px"
-msgstr "يعين حجم العرض الثابت للملاحظة بالبكسل"
-
-#: src/ui/preferences/preferences.blp:157
-msgid "Files"
-msgstr "الملفات"
-
-#: src/ui/preferences/preferences.blp:175
-msgid "The trash folder is set as a hidden folder by default, this option makes it visible (requires app restart)"
-msgstr "مجلد المهملات مخفي مبدئيًا، لكن هذا الخيار يجعله مرئيًا (يتطلب إعادة تشغيل التطبيق)"
-
-#: src/ui/strings.vala:51
-msgid "Unable to recognize URI"
-msgstr "تعذر التعرف على معرف المورد النظامي (URI)"
 
 #: data/app.desktop.in:9 src/ui/strings.vala:3
 msgid "Folio"
@@ -255,21 +29,22 @@ msgstr "دوِّن الملاحظات"
 
 #: data/app.desktop.in:13
 msgid "Notebook;Note;Notes;Text;Markdown;Notepad;Write;School;Post-it;Sticky;"
-msgstr "دفتر;ملاحظة;ملاحظات;دفتر ملاحظات;ماركداون;كتابة;اكتب;مدرسة;كراسة;كشكول;فوليو;"
+msgstr ""
+"دفتر;ملاحظة;ملاحظات;دفتر ملاحظات;ماركداون;كتابة;اكتب;مدرسة;كراسة;كشكول;فوليو;"
 
 #: data/app.desktop.in:22 src/ui/popup/shortcut_window.blp:17
-#: src/ui/strings.vala:8 src/ui/window/window.blp:47
-#: src/ui/window/window.blp:124
+#: src/ui/strings.vala:8 src/ui/window/window.blp:54
+#: src/ui/window/window.blp:131
 msgid "New Note"
 msgstr "ملاحظة جديدة"
 
 #: data/app.desktop.in:26 src/ui/popup/shortcut_window.blp:37
-#: src/ui/strings.vala:14 src/ui/window/window.blp:149
+#: src/ui/strings.vala:14 src/ui/window/window.blp:189
 msgid "New Notebook"
 msgstr "دفتر جديد"
 
-#: data/app.desktop.in:30 src/ui/edit_view/toolbar/toolbar.blp:90
-#: src/ui/strings.vala:39 src/ui/window/window.blp:245
+#: data/app.desktop.in:30 src/ui/edit_view/toolbar/toolbar.blp:92
+#: src/ui/strings.vala:39 src/ui/window/window.blp:291
 msgid "Markdown Cheatsheet"
 msgstr "ورقة غش «ماركداون»"
 
@@ -277,25 +52,149 @@ msgstr "ورقة غش «ماركداون»"
 msgid "Preferences"
 msgstr "التفضيلات"
 
-#: data/app.gschema.xml:6 src/ui/preferences/preferences.blp:18
+#: data/app.gschema.xml:6 src/ui/preferences/preferences.blp:45
 msgid "Note Font"
 msgstr "خط الملاحظات"
 
-#: data/app.gschema.xml:7 src/ui/preferences/preferences.blp:19
+#: data/app.gschema.xml:7 src/ui/preferences/preferences.blp:46
 msgid "The font notes will be displayed in"
 msgstr "الخط المستخدم لعرض الملاحظات"
 
-#: data/app.gschema.xml:11 src/ui/preferences/preferences.blp:31
+#: data/app.gschema.xml:11 src/ui/preferences/preferences.blp:58
 msgid "Monospace Font"
 msgstr "الخط ثابت العرض"
 
-#: data/app.gschema.xml:12 src/ui/preferences/preferences.blp:32
+#: data/app.gschema.xml:12 src/ui/preferences/preferences.blp:59
 msgid "The font code will be displayed in"
 msgstr "الخط المستخدم لعرض الترميز"
 
-#: data/app.gschema.xml:21 src/ui/preferences/preferences.blp:46
+#: data/app.gschema.xml:16 src/ui/preferences/preferences.blp:150
+msgid "Use Fixed Width For Notes"
+msgstr "استخدام العرض الثابت للملاحظات"
+
+#: data/app.gschema.xml:17 src/ui/preferences/preferences.blp:151
+msgid "Use a fixed width for the text area of a note"
+msgstr "استخدام العرض الثابت لمساحة النص في الملاحظة"
+
+#: data/app.gschema.xml:21 src/ui/preferences/preferences.blp:18
 msgid "OLED Mode"
 msgstr "وضع ثنائي مساري عضوي باعث للضوء (OLED)"
+
+#: data/app.gschema.xml:22 src/ui/preferences/preferences.blp:19
+msgid "Makes the dark theme pitch black"
+msgstr "يجعل السمة المظلمة سوداء قاتمة"
+
+#: data/app.gschema.xml:26 src/ui/preferences/preferences.blp:109
+msgid "Enable Toolbar"
+msgstr "فَعِّل شريط الأدوات"
+
+#: data/app.gschema.xml:27 src/ui/preferences/preferences.blp:110
+msgid "Displays the formatting toolbar at the bottom of the note"
+msgstr "يعرض شريط أدوات التنسيق أسفل الملاحظة"
+
+#: data/app.gschema.xml:31 src/ui/preferences/preferences.blp:120
+msgid "Enable Cheatsheet"
+msgstr "فَعِّل ورقة الغش"
+
+#: data/app.gschema.xml:32 src/ui/preferences/preferences.blp:121
+msgid ""
+"Adds a button to the markdown reference sheet on the right of the formatting "
+"toolbar"
+msgstr "يضيف زرًا لعرض مرجع «ماركداون» على يمين شريط أدوات التنسيق"
+
+#: data/app.gschema.xml:36 src/ui/preferences/preferences.blp:139
+msgid "3-Pane Layout"
+msgstr "تخطيط 3 ألواح"
+
+#: data/app.gschema.xml:37 src/ui/preferences/preferences.blp:140
+msgid "Expands the notebook list to include the notebook name"
+msgstr "وَسِّع قائمة الدفاتر لتشمل اسم الدفتر"
+
+#: data/app.gschema.xml:41 src/ui/preferences/preferences.blp:207
+msgid "Notes Storage Location"
+msgstr "موضع تخزين الملاحظات"
+
+#: data/app.gschema.xml:42 src/ui/preferences/preferences.blp:208
+msgid "Where the notebooks are stored (requires app restart)"
+msgstr "حيث تخزن الدفاتر (يتطلب إعادة تشغيل التطبيق)"
+
+#: data/app.gschema.xml:46 src/ui/preferences/preferences.blp:235
+msgid "Trash Storage Location"
+msgstr "موضع تخزين المهملات"
+
+#: data/app.gschema.xml:47 src/ui/preferences/preferences.blp:236
+msgid "Where the trash folder is located (requires app restart)"
+msgstr "موضع مجلد المهملات (يتطلب إعادة تشغيل التطبيق)"
+
+#: data/app.gschema.xml:51 src/ui/preferences/preferences.blp:87
+msgid "Show line numbers"
+msgstr "أظهِر أرقام الأسطر"
+
+#: data/app.gschema.xml:52 src/ui/preferences/preferences.blp:88
+msgid "Displays line numbers at the left of the note"
+msgstr "عرض أرقام الأسطر على يسار الملاحظة"
+
+#: data/app.gschema.xml:56 src/ui/preferences/preferences.blp:98
+msgid "Show all notes"
+msgstr "أظهِر جميع الملاحظات"
+
+#: data/app.gschema.xml:57 src/ui/preferences/preferences.blp:99
+msgid "Displays the \"All Notes\" notebook at the top of the notebook list"
+msgstr "اعرض دفتر «جميع الملاحظات» فوق كافة الدفاتر في القائمة"
+
+#: data/app.gschema.xml:61 src/ui/preferences/preferences.blp:185
+msgid "Enable autosave"
+msgstr "فَعِّل الحفظ الآلي"
+
+#: data/app.gschema.xml:62 src/ui/preferences/preferences.blp:186
+msgid ""
+"Automatically saves the current note every 30 seconds if the contents have "
+"changed (requires app restart)"
+msgstr ""
+"احفظ الملاحظة الحالية كل 30 ثانية عند تغيير محتواها (يتطلب إعادة تشغيل "
+"التطبيق)"
+
+#: data/app.gschema.xml:66 src/ui/preferences/preferences.blp:196
+msgid "Don't hide the Trash folder"
+msgstr "لا تخفي مجلد المهملات"
+
+#: data/app.gschema.xml:67
+msgid ""
+"The trash folder is set as a hidden folder by default, this option makes it "
+"visible"
+msgstr "مجلد المهملات مخفي مبدئيًا، لكن هذا الخيار يجعله مرئيًأ"
+
+#: data/app.gschema.xml:71
+msgid "Note sort order"
+msgstr "ترتيب فرز الملاحظات"
+
+#: data/app.gschema.xml:72
+msgid "The sort order of the note list"
+msgstr "ترتيب الفرز لقائمة الملاحظات"
+
+#: data/app.gschema.xml:76
+msgid "Notebook sort order"
+msgstr "ترتيب فرز الدفاتر"
+
+#: data/app.gschema.xml:77
+msgid "The sort order of the notebook list"
+msgstr "ترتيب الفرز لقائمة الدفاتر"
+
+#: data/app.gschema.xml:81
+msgid "URL detection level"
+msgstr ""
+
+#: data/app.gschema.xml:82
+msgid "How agressive to look for URLs in markdown text"
+msgstr ""
+
+#: data/app.gschema.xml:86
+msgid "Line spacing"
+msgstr ""
+
+#: data/app.gschema.xml:87 src/ui/preferences/preferences.blp:74
+msgid "The line spacing for the note text"
+msgstr ""
 
 #: data/app.metainfo.xml.in:5
 msgid "Take notes in Markdown"
@@ -329,103 +228,116 @@ msgstr "سمة التطبيق استنادًا إلى لون الدفتر"
 msgid "Trash can"
 msgstr "سلة المهملات"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:23
-#: src/ui/edit_view/toolbar/toolbar.blp:131
+#: data/app.metainfo.xml.in:393
+msgid "Main Folio window in light mode"
+msgstr "نافذة «مطوية» الرئيسة في الوضع الفاتح"
+
+#: data/app.metainfo.xml.in:397
+msgid "Main Folio window in dark mode"
+msgstr "نافذة «مطوية» الرئيسة في الوضع الداكن"
+
+#: data/app.metainfo.xml.in:401
+msgid "Folio on small/mobile screens"
+msgstr "«مطوية» على الشاشات الصغيرة/المحمولة"
+
+#: data/app.metainfo.xml.in:405
+msgid "Folio preferences screen"
+msgstr "شاشة تفضيلات «مطوية»"
+
+#: data/app.metainfo.xml.in:409
+msgid "Folio in three pane mode"
+msgstr "«مطوية» في وضع الألواح الثلاثة"
+
+#: src/ui/edit_view/toolbar/toolbar.blp:6
 #: src/ui/widgets/markdown/heading_popover.blp:48
 msgid "Plain Text"
 msgstr "نص عادي"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:24
-#: src/ui/edit_view/toolbar/toolbar.blp:132
+#: src/ui/edit_view/toolbar/toolbar.blp:7
 #: src/ui/widgets/markdown/heading_popover.blp:12
 msgid "Heading 1"
 msgstr "عنوان 1"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:25
-#: src/ui/edit_view/toolbar/toolbar.blp:133
+#: src/ui/edit_view/toolbar/toolbar.blp:8
 #: src/ui/widgets/markdown/heading_popover.blp:18
 msgid "Heading 2"
 msgstr "عنوان 2"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:26
-#: src/ui/edit_view/toolbar/toolbar.blp:134
+#: src/ui/edit_view/toolbar/toolbar.blp:9
 #: src/ui/widgets/markdown/heading_popover.blp:24
 msgid "Heading 3"
 msgstr "عنوان 3"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:27
-#: src/ui/edit_view/toolbar/toolbar.blp:135
+#: src/ui/edit_view/toolbar/toolbar.blp:10
 #: src/ui/widgets/markdown/heading_popover.blp:30
 msgid "Heading 4"
 msgstr "عنوان 4"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:28
-#: src/ui/edit_view/toolbar/toolbar.blp:136
+#: src/ui/edit_view/toolbar/toolbar.blp:11
 #: src/ui/widgets/markdown/heading_popover.blp:36
 msgid "Heading 5"
 msgstr "عنوان 5"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:29
-#: src/ui/edit_view/toolbar/toolbar.blp:137
+#: src/ui/edit_view/toolbar/toolbar.blp:12
 #: src/ui/widgets/markdown/heading_popover.blp:42
 msgid "Heading 6"
 msgstr "عنوان 6"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:39
-#: src/ui/edit_view/toolbar/toolbar.blp:104
-#: src/ui/edit_view/toolbar/toolbar.blp:148
-#: src/ui/edit_view/toolbar/toolbar.blp:201 src/ui/popup/shortcut_window.blp:72
+#: src/ui/edit_view/toolbar/toolbar.blp:41
+#: src/ui/edit_view/toolbar/toolbar.blp:107
+#: src/ui/edit_view/toolbar/toolbar.blp:142
+#: src/ui/edit_view/toolbar/toolbar.blp:195 src/ui/popup/shortcut_window.blp:72
 msgid "Bold"
 msgstr "غليظ"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:45
-#: src/ui/edit_view/toolbar/toolbar.blp:111
-#: src/ui/edit_view/toolbar/toolbar.blp:155
-#: src/ui/edit_view/toolbar/toolbar.blp:202 src/ui/popup/shortcut_window.blp:77
+#: src/ui/edit_view/toolbar/toolbar.blp:47
+#: src/ui/edit_view/toolbar/toolbar.blp:114
+#: src/ui/edit_view/toolbar/toolbar.blp:149
+#: src/ui/edit_view/toolbar/toolbar.blp:196 src/ui/popup/shortcut_window.blp:77
 msgid "Italic"
 msgstr "مائل"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:51
-#: src/ui/edit_view/toolbar/toolbar.blp:162
-#: src/ui/edit_view/toolbar/toolbar.blp:203 src/ui/popup/shortcut_window.blp:82
+#: src/ui/edit_view/toolbar/toolbar.blp:53
+#: src/ui/edit_view/toolbar/toolbar.blp:156
+#: src/ui/edit_view/toolbar/toolbar.blp:197 src/ui/popup/shortcut_window.blp:82
 msgid "Strikethrough"
 msgstr "سطر وسطي"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:57
-#: src/ui/edit_view/toolbar/toolbar.blp:169
-#: src/ui/edit_view/toolbar/toolbar.blp:204 src/ui/popup/shortcut_window.blp:87
+#: src/ui/edit_view/toolbar/toolbar.blp:59
+#: src/ui/edit_view/toolbar/toolbar.blp:163
+#: src/ui/edit_view/toolbar/toolbar.blp:198 src/ui/popup/shortcut_window.blp:87
 msgid "Highlight"
 msgstr "بارز"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:67
-#: src/ui/edit_view/toolbar/toolbar.blp:193 src/ui/popup/shortcut_window.blp:92
+#: src/ui/edit_view/toolbar/toolbar.blp:69
+#: src/ui/edit_view/toolbar/toolbar.blp:187 src/ui/popup/shortcut_window.blp:92
 msgid "Insert Link"
 msgstr "أدرج رابطًا"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:73
-#: src/ui/edit_view/toolbar/toolbar.blp:194
+#: src/ui/edit_view/toolbar/toolbar.blp:75
+#: src/ui/edit_view/toolbar/toolbar.blp:188
 msgid "Insert Code"
 msgstr "أدرج رمزًا"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:79
-#: src/ui/edit_view/toolbar/toolbar.blp:195
+#: src/ui/edit_view/toolbar/toolbar.blp:81
+#: src/ui/edit_view/toolbar/toolbar.blp:189
 msgid "Insert Horizontal Rule"
 msgstr "أدرج قاعدة أفقية"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:118
+#: src/ui/edit_view/toolbar/toolbar.blp:121
 msgid "Format"
 msgstr "التنسيق"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:181
+#: src/ui/edit_view/toolbar/toolbar.blp:175
 msgid "Insert"
 msgstr "أدرج"
 
-#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:34
+#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:18
 #: src/ui/strings.vala:44 src/ui/strings.vala:58
 msgid "Cancel"
 msgstr "ألغِ"
 
-#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:39
+#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:23
 msgid "Confirm"
 msgstr "أكِد"
 
@@ -469,37 +381,87 @@ msgstr "التنسيق"
 msgid "Navigation"
 msgstr "التصفح"
 
-#: src/ui/popup/shortcut_window.blp:102 src/ui/window/window.blp:216
+#: src/ui/popup/shortcut_window.blp:102 src/ui/window/window.blp:268
 msgid "Toggle Sidebar"
 msgstr "بَدِّل الشريط الجانبي"
 
-#: src/ui/popup/shortcut_window.blp:107 src/ui/window/window.blp:63
+#: src/ui/popup/shortcut_window.blp:107 src/ui/window/window.blp:70
 msgid "Search Notes"
 msgstr "ابحث الملاحظات"
 
-#: data/app.gschema.xml:22 src/ui/preferences/preferences.blp:47
-msgid "Makes the dark theme pitch black"
-msgstr "يجعل السمة المظلمة سوداء قاتمة"
+#: src/ui/popup/shortcut_window.blp:114
+msgid "Display"
+msgstr "العرض"
 
-#: data/app.gschema.xml:26 src/ui/preferences/preferences.blp:87
-msgid "Enable Toolbar"
-msgstr "فَعِّل شريط الأدوات"
+#: src/ui/popup/shortcut_window.blp:117
+msgid "Full Screen"
+msgstr "ملء الشاشة"
 
-#: data/app.gschema.xml:31 src/ui/preferences/preferences.blp:98
-msgid "Enable Cheatsheet"
-msgstr "فَعِّل ورقة الغش"
+#: src/ui/popup/shortcut_window.blp:122
+msgid "Zoom In"
+msgstr "كبِّر"
 
-#: data/app.gschema.xml:36 src/ui/preferences/preferences.blp:117
-msgid "3-Pane Layout"
-msgstr "تخطيط 3 ألواح"
+#: src/ui/popup/shortcut_window.blp:127
+msgid "Zoom Out"
+msgstr "صغِّر"
 
-#: data/app.gschema.xml:41 src/ui/preferences/preferences.blp:185
-msgid "Notes Storage Location"
-msgstr "موضع تخزين الملاحظات"
+#: src/ui/preferences/preferences.blp:31
+#, fuzzy
+msgid "Markdown URL Detection"
+msgstr "ورقة غش «ماركداون»"
 
-#: data/app.gschema.xml:42 src/ui/preferences/preferences.blp:186
-msgid "Where the notebooks are stored (requires app restart)"
-msgstr "حيث تخزن الدفاتر (يتطلب إعادة تشغيل التطبيق)"
+#: src/ui/preferences/preferences.blp:32
+msgid ""
+"Determines the level of detection of URLs in\n"
+"free form text is used:\n"
+" - Aggressive tries to find all URLs\n"
+" - Strict requires a protocol identifier (ie http://)\n"
+" - Disabled turns detection off."
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:39
+msgid "Fonts"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:73
+msgid "Line Spacing"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:81
+msgid "Tools"
+msgstr "الأدوات"
+
+#: src/ui/preferences/preferences.blp:133
+msgid "Layout"
+msgstr "التخطيط"
+
+#: src/ui/preferences/preferences.blp:161
+msgid "Fixed Width To Use For Notes"
+msgstr "العرض الثابت للاستخدام في الملاحظات"
+
+#: src/ui/preferences/preferences.blp:162
+msgid "Sets the fixed width size of a note in px"
+msgstr "يعين حجم العرض الثابت للملاحظة بالبكسل"
+
+#: src/ui/preferences/preferences.blp:167
+msgid "Sort Order For Notebooks"
+msgstr "ترتيب الفرز للدفاتر"
+
+#: src/ui/preferences/preferences.blp:172
+msgid "Sort Order For Notes"
+msgstr "ترتيب الفرز للملاحظات"
+
+#: src/ui/preferences/preferences.blp:179
+msgid "Files"
+msgstr "الملفات"
+
+#: src/ui/preferences/preferences.blp:197
+msgid ""
+"The trash folder is set as a hidden folder by default, this option makes it "
+"visible (requires app restart)"
+msgstr ""
+"مجلد المهملات مخفي مبدئيًا، لكن هذا الخيار يجعله مرئيًا (يتطلب إعادة تشغيل "
+"التطبيق)"
 
 #: src/ui/strings.vala:4 src/ui/window/notebooks_bar/notebooks_bar.blp:129
 #: src/ui/window/notebooks_bar/notebooks_bar.blp:171
@@ -507,6 +469,7 @@ msgid "Trash"
 msgstr "المهملات"
 
 #: src/ui/strings.vala:5
+#, c-format
 msgid "%d Notes"
 msgstr "%d ملاحظات"
 
@@ -514,7 +477,7 @@ msgstr "%d ملاحظات"
 msgid "Are you sure you want to delete everything in the trash?"
 msgstr "أمتأكد من إفراغ سلة المهملات؟"
 
-#: src/ui/strings.vala:7 src/ui/window/window.blp:54
+#: src/ui/strings.vala:7 src/ui/window/window.blp:61
 msgid "Empty Trash"
 msgstr "سلة المهملات الفارغة"
 
@@ -551,10 +514,12 @@ msgid "Move"
 msgstr "انقل"
 
 #: src/ui/strings.vala:18
+#, c-format
 msgid "Note “%s” already exists in notebook “%s”"
 msgstr "الملاحظة «%s» موجودة بالفعل في الدفتر «%s»"
 
 #: src/ui/strings.vala:19
+#, c-format
 msgid "Are you sure you want to delete the note “%s”?"
 msgstr "أمتأكد من حذف الملاحظة «%s»؟"
 
@@ -563,6 +528,7 @@ msgid "Delete Note"
 msgstr "احذف الملاحظة"
 
 #: src/ui/strings.vala:21
+#, c-format
 msgid "Are you sure you want to delete the notebook “%s”?"
 msgstr "أمتأكد من حذف الدفتر «%s»؟"
 
@@ -571,34 +537,42 @@ msgid "Delete Notebook"
 msgstr "احذف الدفتر"
 
 #: src/ui/strings.vala:24
-msgid "Note name shouldn’t contain “.” or “/”"
+#, fuzzy
+msgid "Note names cannot contain a “/”"
 msgstr "يجب ألا يحتوي اسم الملاحظة على «.» أو «/»"
 
 #: src/ui/strings.vala:25
-msgid "Note name shouldn’t be blank"
+#, fuzzy
+msgid "Note names cannot be blank"
 msgstr "يجب ألا يكون اسم الملاحظة فارغًا"
 
 #: src/ui/strings.vala:26
+#, c-format
 msgid "Note “%s” already exists"
 msgstr "الملاحظة «%s» موجودة بالفعل"
 
 #: src/ui/strings.vala:27
-msgid "Couldn’t create note"
+#, fuzzy
+msgid "Could not create note"
 msgstr "تعذر إنشاء الملاحظة"
 
 #: src/ui/strings.vala:28
-msgid "Couldn’t change note"
+#, fuzzy
+msgid "Could not change note"
 msgstr "تعذر تغيير الملاحظة"
 
 #: src/ui/strings.vala:29
-msgid "Couldn’t delete note"
+#, fuzzy
+msgid "Could not delete note"
 msgstr "تعذر حذف الملاحظة"
 
 #: src/ui/strings.vala:30
-msgid "Couldn’t restore note"
+#, fuzzy
+msgid "Could not restore note"
 msgstr "تعذرت استعادة الملاحظة"
 
 #: src/ui/strings.vala:31
+#, c-format
 msgid "Saved “%s” to “%s”"
 msgstr "حُفِظ «%s» إلى «%s»"
 
@@ -607,27 +581,33 @@ msgid "Unknown error"
 msgstr "خطأ غير معروف"
 
 #: src/ui/strings.vala:33
-msgid "Notebook name shouldn’t contain “.” or “/”"
+#, fuzzy
+msgid "Notebook names cannot contain a “/”"
 msgstr "يجب ألا يحتوي اسم الدفتر على «.» أو «/»"
 
 #: src/ui/strings.vala:34
-msgid "Notebook name shouldn’t be blank"
+#, fuzzy
+msgid "Notebook names cannot be blank"
 msgstr "يجب ألا يكون اسم الدفتر فارغًا"
 
 #: src/ui/strings.vala:35
+#, c-format
 msgid "Notebook “%s” already exists"
 msgstr "الدفتر «%s» موجود بالفعل"
 
 #: src/ui/strings.vala:36
-msgid "Couldn’t create notebook"
+#, fuzzy
+msgid "Could not create notebook"
 msgstr "تعذر إنشاء الدفتر"
 
 #: src/ui/strings.vala:37
-msgid "Couldn’t change notebook"
+#, fuzzy
+msgid "Could not change notebook"
 msgstr "تعذر تغيير الدفتر"
 
 #: src/ui/strings.vala:38
-msgid "Couldn’t delete notebook"
+#, fuzzy
+msgid "Could not delete notebook"
 msgstr "تعذر حذف الدفتر"
 
 #: src/ui/strings.vala:40
@@ -639,7 +619,8 @@ msgid "Rename"
 msgstr "أعِد التسمية"
 
 #: src/ui/strings.vala:42
-msgid "Couldn’t find an app to handle file URIs"
+#, fuzzy
+msgid "Could not find an app to handle file URIs"
 msgstr "تعذر العثور على تطبيق للتعامل مع معرف المورد النظامي (URI) للملف"
 
 #: src/ui/strings.vala:43
@@ -649,6 +630,10 @@ msgstr "طَبِّق"
 #: src/ui/strings.vala:45
 msgid "Pick where the notebooks will be stored"
 msgstr "اختر موضع تخزين الدفاتر"
+
+#: src/ui/strings.vala:46
+msgid "Pick where the trash can will be stored"
+msgstr "اختر أين تخزن سلة المهملات"
 
 #: src/ui/strings.vala:47 src/ui/window/notebooks_bar/notebooks_bar.blp:59
 #: src/ui/window/notebooks_bar/notebooks_bar.blp:101
@@ -662,6 +647,127 @@ msgstr "آخر تعديل"
 #: src/ui/strings.vala:50
 msgid "Extension"
 msgstr "الامتداد"
+
+#: src/ui/strings.vala:51
+msgid "Unable to recognize URI"
+msgstr "تعذر التعرف على معرف المورد النظامي (URI)"
+
+#: src/ui/strings.vala:52
+msgid "Pick primary font for notes"
+msgstr "اختر الخط الأساسي للملاحظات"
+
+#: src/ui/strings.vala:53
+msgid "Pick monospace font for code"
+msgstr "اختر خطًا ثابت العرض للترميز"
+
+#: src/ui/strings.vala:54
+msgid "File Changed On Disk"
+msgstr "غُيِّر الملف على القرص"
+
+#: src/ui/strings.vala:55
+msgid ""
+"The file has changed on disk since it was last saved/loaded by Folio.\n"
+"\n"
+"You may do one of the following:\n"
+"\n"
+" • Reload the file (discarding any changes you have made in Folio)\n"
+" • Overwrite the file (discarding any changes made outside of Folio)\n"
+" • Cancel the operation and manually resolve the issue\n"
+"\n"
+"Note: Canceling the save if you have already moved to a new note/notebook "
+"will discard your changes."
+msgstr ""
+"غُيِّر الملف على القرص منذ آخر مرة حُفِظ/حُمِل بواسطة «مطوية».\n"
+"\n"
+"يمكنك القيام بأحد الأمور التالية:\n"
+"\n"
+" - أعِد تحميل الملف (تجاهل أي تغييرات أجريتها في «مطوية»)\n"
+" - اكتب فوق الملف (تجاهل أي تغييرات أجريت خارج «مطوية»)\n"
+" - ألغِ العملية وحل المشكلة يدويًا\n"
+"\n"
+"ملاحظة: في حال انتقلت إلى ملاحظة/دفتر جديد، فستتجاهل تغييراتك عند الحفظ."
+
+#: src/ui/strings.vala:56
+msgid "Reload"
+msgstr "أعِد التحميل"
+
+#: src/ui/strings.vala:57
+msgid "Overwrite"
+msgstr "اكتب فوق"
+
+#: src/ui/strings.vala:59
+msgid ""
+"The file has changed on disk by another application.\n"
+"\n"
+"You may do one of the following:\n"
+"\n"
+" • Reload the file (discarding any changes you have made in Folio)\n"
+" • Overwrite the file (discarding any changes made outside of Folio)"
+msgstr ""
+"غُيِّر الملف على القرص من قبل تطبيق آخر.\n"
+"\n"
+"يمكنك القيام بأحد الأمور التالية:\n"
+"\n"
+" - أعِد تحميل الملف (تجاهل أي تغييرات أجريتها في «مطوية»)\n"
+" - اكتب فوق الملف (تجاهل أي تغييرات أجريتها خارج «مطوية»)"
+
+#: src/ui/strings.vala:61
+#, c-format
+msgid "Note %i"
+msgstr "ملاحظة %i"
+
+#: src/ui/strings.vala:62
+msgid "Modified Time - Ascending"
+msgstr "زمن التعديل - تصاعديًا"
+
+#: src/ui/strings.vala:63
+msgid "Modified Time - Descending"
+msgstr "زمن التعديل - تنازليًا"
+
+#: src/ui/strings.vala:64
+msgid "Alphabetical - Ascending"
+msgstr "أبجدي - تصاعديًا"
+
+#: src/ui/strings.vala:65
+msgid "Alphabetical - Descending"
+msgstr "أبجدي - تنازليًا"
+
+#: src/ui/strings.vala:66
+#, fuzzy
+msgid "Natural - Ascending"
+msgstr "أبجدي - تصاعديًا"
+
+#: src/ui/strings.vala:67
+#, fuzzy
+msgid "Natural - Descending"
+msgstr "أبجدي - تنازليًا"
+
+#: src/ui/strings.vala:68
+#, c-format
+msgid "Unable to launch external application for file %s."
+msgstr ""
+
+#: src/ui/strings.vala:69
+msgid "Aggressive"
+msgstr ""
+
+#: src/ui/strings.vala:70
+msgid "Strict"
+msgstr ""
+
+#: src/ui/strings.vala:71
+msgid "Disabled"
+msgstr ""
+
+#: src/ui/strings.vala:72
+#, fuzzy, c-format
+msgid "“%s” moved to trash"
+msgstr "انقل إلى المهملات"
+
+#: src/ui/strings.vala:73
+#, c-format
+msgid "“%s” restored"
+msgstr ""
 
 #: src/ui/widgets/theme_selector/theme_selector.blp:15
 msgid "Follow system style"
@@ -692,40 +798,45 @@ msgid "_Keyboard Shortcuts"
 msgstr "ا_ختصارات لوحة المفاتيح"
 
 #: src/ui/window/app_menu/app_menu.blp:43
-msgid "_About"
+#, fuzzy
+msgid "_About Folio"
 msgstr "عَ_نْ"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:54
-msgid "Notebook Name"
-msgstr "اسم الدفتر"
-
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:66
-msgid "Duplicate notebook names are not allowed!"
-msgstr "لا يسمح استخدام أسماء دفاتر مكررة!"
-
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:82
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:6
 msgid "First Characters"
 msgstr "الأحرف الأولى"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:83
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:7
 msgid "Initials"
 msgstr "الأحرف البادئة"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:84
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:8
 msgid "Initials: camelCase"
 msgstr "الأحرف البادئة: camelCase"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:85
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:9
 msgid "Initials: snake_case"
 msgstr "الأحرف البادئة: snake_case"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:86
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:10
 msgid "Icon"
 msgstr "الأيقونة"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:116
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:11
+msgid "Custom"
+msgstr ""
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:16
 msgid "Notebook Color"
 msgstr "لون الدفتر"
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:58
+msgid "Notebook Name"
+msgstr "اسم الدفتر"
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:70
+msgid "Duplicate notebook names are not allowed!"
+msgstr "لا يسمح استخدام أسماء دفاتر مكررة!"
 
 #: src/ui/window/notebooks_bar/notebook_create_popup.blp:126
 msgid "Create Notebook"
@@ -743,11 +854,11 @@ msgstr "انقل الجميع إلى المهملات"
 msgid "Notebooks"
 msgstr "الدفاتر"
 
-#: src/ui/window/sidebar/note_create_popup.blp:37
+#: src/ui/window/sidebar/note_create_popup.blp:25
 msgid "Note Name"
 msgstr "اسم الملاحظة"
 
-#: src/ui/window/sidebar/note_create_popup.blp:45
+#: src/ui/window/sidebar/note_create_popup.blp:33
 msgid "Create Note"
 msgstr "أنشئ ملاحظة"
 
@@ -771,30 +882,37 @@ msgstr "انقل إلى المهملات"
 msgid "Open Containing Folder"
 msgstr "فتح المجلد المتضمن"
 
-#: src/ui/window/window.blp:118
+#: src/ui/window/window.blp:123
 msgid "Get started writing"
 msgstr "ابدأ بالكتابة"
 
-#: src/ui/window/window.blp:143
+#: src/ui/window/window.blp:152
+msgid "Open file in external application"
+msgstr ""
+
+#: src/ui/window/window.blp:160
+msgid "Open file"
+msgstr ""
+
+#: src/ui/window/window.blp:181
 msgid "Create a notebook"
 msgstr "أنشئ دفترًا"
 
-#: src/ui/window/window.blp:168
+#: src/ui/window/window.blp:210
 msgid "Trash is empty"
 msgstr "سلة المهملات فارغة"
 
-#: src/ui/window/window.blp:224
-msgid "Back"
-msgstr "عُد"
-
-#: src/ui/window/window.blp:239
+#: src/ui/window/window.blp:285
 msgid "Open in Notebook"
 msgstr "افتح في الدفتر"
 
-#: src/ui/window/window.blp:264
+#: src/ui/window/window.blp:312
 msgid "_Rename Note"
 msgstr "أ_عِد تسمية الملاحظة"
 
-#: src/ui/window/window.blp:270
+#: src/ui/window/window.blp:319
 msgid "_Export Note"
 msgstr "_صَدِّر الملاحظة"
+
+#~ msgid "Back"
+#~ msgstr "عُد"

--- a/po/cat.po
+++ b/po/cat.po
@@ -2,229 +2,16 @@
 # This file is distributed under the same license as the Folio package.
 msgid ""
 msgstr ""
+"Project-Id-Version: Folio\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-10-12 16:53+0200\n"
 "PO-Revision-Date: 2024-03-25 00:54:33+0000\n"
+"Language: cat\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: GlotPress/4.0.0\n"
-"Language: cat\n"
-"Project-Id-Version: Folio\n"
-
-#: data/app.gschema.xml:76
-msgid "Notebook sort order"
-msgstr "Ordre de classificació del quadern"
-
-#: data/app.gschema.xml:77
-msgid "The sort order of the notebook list"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:145
-msgid "Sort Order For Notebooks"
-msgstr ""
-
-#: data/app.gschema.xml:71
-msgid "Note sort order"
-msgstr ""
-
-#: data/app.gschema.xml:72
-msgid "The sort order of the note list"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:150
-msgid "Sort Order For Notes"
-msgstr ""
-
-#: src/ui/strings.vala:62
-msgid "Modified Time - Ascending"
-msgstr ""
-
-#: src/ui/strings.vala:63
-msgid "Modified Time - Descending"
-msgstr ""
-
-#: src/ui/strings.vala:64
-msgid "Alphabetical - Ascending"
-msgstr ""
-
-#: src/ui/strings.vala:65
-msgid "Alphabetical - Descending"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:114
-msgid "Display"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:117
-msgid "Full Screen"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:122
-msgid "Zoom In"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:127
-msgid "Zoom Out"
-msgstr ""
-
-#: src/ui/strings.vala:52
-msgid "Pick primary font for notes"
-msgstr ""
-
-#: src/ui/strings.vala:53
-msgid "Pick monospace font for code"
-msgstr ""
-
-#: src/ui/strings.vala:54
-msgid "File Changed On Disk"
-msgstr ""
-
-#: src/ui/strings.vala:55
-msgid ""
-"The file has changed on disk since it was last saved/loaded by Folio.\n"
-"\n"
-"You may do one of the following:\n"
-"\n"
-" • Reload the file (discarding any changes you have made in Folio)\n"
-" • Overwrite the file (discarding any changes made outside of Folio)\n"
-" • Cancel the operation and manually resolve the issue\n"
-"\n"
-"Note: Canceling the save if you have already moved to a new note/notebook will discard your changes."
-msgstr ""
-
-#: src/ui/strings.vala:56
-msgid "Reload"
-msgstr ""
-
-#: src/ui/strings.vala:57
-msgid "Overwrite"
-msgstr ""
-
-#: src/ui/strings.vala:59
-msgid ""
-"The file has changed on disk by another application.\n"
-"\n"
-"You may do one of the following:\n"
-"\n"
-" • Reload the file (discarding any changes you have made in Folio)\n"
-" • Overwrite the file (discarding any changes made outside of Folio)"
-msgstr ""
-
-#: src/ui/strings.vala:61
-msgid "Note %i"
-msgstr ""
-
-#: data/app.gschema.xml:46 src/ui/preferences/preferences.blp:213
-msgid "Trash Storage Location"
-msgstr ""
-
-#: data/app.gschema.xml:47 src/ui/preferences/preferences.blp:214
-msgid "Where the trash folder is located (requires app restart)"
-msgstr ""
-
-#: src/ui/strings.vala:46
-msgid "Pick where the trash can will be stored"
-msgstr ""
-
-#: data/app.gschema.xml:16 src/ui/preferences/preferences.blp:128
-msgid "Use Fixed Width For Notes"
-msgstr ""
-
-#: data/app.gschema.xml:17 src/ui/preferences/preferences.blp:129
-msgid "Use a fixed width for the text area of a note"
-msgstr ""
-
-#: data/app.gschema.xml:37 src/ui/preferences/preferences.blp:118
-msgid "Expands the notebook list to include the notebook name"
-msgstr ""
-
-#: data/app.gschema.xml:51 src/ui/preferences/preferences.blp:65
-msgid "Show line numbers"
-msgstr ""
-
-#: data/app.gschema.xml:52 src/ui/preferences/preferences.blp:66
-msgid "Displays line numbers at the left of the note"
-msgstr ""
-
-#: data/app.gschema.xml:56 src/ui/preferences/preferences.blp:76
-msgid "Show all notes"
-msgstr ""
-
-#: data/app.gschema.xml:57 src/ui/preferences/preferences.blp:77
-msgid "Displays the \"All Notes\" notebook at the top of the notebook list"
-msgstr ""
-
-#: data/app.gschema.xml:61 src/ui/preferences/preferences.blp:163
-msgid "Enable autosave"
-msgstr ""
-
-#: data/app.gschema.xml:62 src/ui/preferences/preferences.blp:164
-msgid "Automatically saves the current note every 30 seconds if the contents have changed (requires app restart)"
-msgstr ""
-
-#: data/app.gschema.xml:66 src/ui/preferences/preferences.blp:174
-msgid "Don't hide the Trash folder"
-msgstr ""
-
-#: data/app.gschema.xml:67
-msgid "The trash folder is set as a hidden folder by default, this option makes it visible"
-msgstr ""
-
-#: data/app.metainfo.xml.in:367
-msgid "Main Folio window in light mode"
-msgstr ""
-
-#: data/app.metainfo.xml.in:371
-msgid "Main Folio window in dark mode"
-msgstr ""
-
-#: data/app.metainfo.xml.in:375
-msgid "Folio on small/mobile screens"
-msgstr ""
-
-#: data/app.metainfo.xml.in:379
-msgid "Folio preferences screen"
-msgstr ""
-
-#: data/app.metainfo.xml.in:383
-msgid "Folio in three pane mode"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:59
-msgid "Tools"
-msgstr ""
-
-#: data/app.gschema.xml:27 src/ui/preferences/preferences.blp:88
-msgid "Displays the formatting toolbar at the bottom of the note"
-msgstr ""
-
-#: data/app.gschema.xml:32 src/ui/preferences/preferences.blp:99
-msgid "Adds a button to the markdown reference sheet on the right of the formatting toolbar"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:111
-msgid "Layout"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:139
-msgid "Fixed Width To Use For Notes"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:140
-msgid "Sets the fixed width size of a note in px"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:157
-msgid "Files"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:175
-msgid "The trash folder is set as a hidden folder by default, this option makes it visible (requires app restart)"
-msgstr ""
-
-#: src/ui/strings.vala:51
-msgid "Unable to recognize URI"
-msgstr ""
 
 #: data/app.desktop.in:9 src/ui/strings.vala:3
 msgid "Folio"
@@ -240,21 +27,23 @@ msgstr "Pren notes"
 
 #: data/app.desktop.in:13
 msgid "Notebook;Note;Notes;Text;Markdown;Notepad;Write;School;Post-it;Sticky;"
-msgstr "Lquadern;Nota;Notes;Text;Markdown;Notepad;Escriu;Cole;Col·legi;Post-it;Sticky;"
+msgstr ""
+"Lquadern;Nota;Notes;Text;Markdown;Notepad;Escriu;Cole;Col·legi;Post-it;"
+"Sticky;"
 
 #: data/app.desktop.in:22 src/ui/popup/shortcut_window.blp:17
-#: src/ui/strings.vala:8 src/ui/window/window.blp:47
-#: src/ui/window/window.blp:124
+#: src/ui/strings.vala:8 src/ui/window/window.blp:54
+#: src/ui/window/window.blp:131
 msgid "New Note"
 msgstr "Nota Nova"
 
 #: data/app.desktop.in:26 src/ui/popup/shortcut_window.blp:37
-#: src/ui/strings.vala:14 src/ui/window/window.blp:149
+#: src/ui/strings.vala:14 src/ui/window/window.blp:189
 msgid "New Notebook"
 msgstr "Quadern Nou"
 
-#: data/app.desktop.in:30 src/ui/edit_view/toolbar/toolbar.blp:90
-#: src/ui/strings.vala:39 src/ui/window/window.blp:245
+#: data/app.desktop.in:30 src/ui/edit_view/toolbar/toolbar.blp:92
+#: src/ui/strings.vala:39 src/ui/window/window.blp:291
 msgid "Markdown Cheatsheet"
 msgstr "Chuleta de Markdown"
 
@@ -262,25 +51,147 @@ msgstr "Chuleta de Markdown"
 msgid "Preferences"
 msgstr "Preferencies"
 
-#: data/app.gschema.xml:6 src/ui/preferences/preferences.blp:18
+#: data/app.gschema.xml:6 src/ui/preferences/preferences.blp:45
 msgid "Note Font"
 msgstr "Font de Notas"
 
-#: data/app.gschema.xml:7 src/ui/preferences/preferences.blp:19
+#: data/app.gschema.xml:7 src/ui/preferences/preferences.blp:46
 msgid "The font notes will be displayed in"
 msgstr "La font en la qual es mostraran les notes"
 
-#: data/app.gschema.xml:11 src/ui/preferences/preferences.blp:31
+#: data/app.gschema.xml:11 src/ui/preferences/preferences.blp:58
 msgid "Monospace Font"
 msgstr "Font de Codi"
 
-#: data/app.gschema.xml:12 src/ui/preferences/preferences.blp:32
+#: data/app.gschema.xml:12 src/ui/preferences/preferences.blp:59
 msgid "The font code will be displayed in"
 msgstr "La font en la qual es mostrarà el codi"
 
-#: data/app.gschema.xml:21 src/ui/preferences/preferences.blp:46
+#: data/app.gschema.xml:16 src/ui/preferences/preferences.blp:150
+msgid "Use Fixed Width For Notes"
+msgstr ""
+
+#: data/app.gschema.xml:17 src/ui/preferences/preferences.blp:151
+msgid "Use a fixed width for the text area of a note"
+msgstr ""
+
+#: data/app.gschema.xml:21 src/ui/preferences/preferences.blp:18
 msgid "OLED Mode"
 msgstr "Mode OLED"
+
+#: data/app.gschema.xml:22 src/ui/preferences/preferences.blp:19
+msgid "Makes the dark theme pitch black"
+msgstr "Fa el tema fosc de color negre"
+
+#: data/app.gschema.xml:26 src/ui/preferences/preferences.blp:109
+msgid "Enable Toolbar"
+msgstr "Activar la barra d'eines"
+
+#: data/app.gschema.xml:27 src/ui/preferences/preferences.blp:110
+msgid "Displays the formatting toolbar at the bottom of the note"
+msgstr ""
+
+#: data/app.gschema.xml:31 src/ui/preferences/preferences.blp:120
+msgid "Enable Cheatsheet"
+msgstr ""
+
+#: data/app.gschema.xml:32 src/ui/preferences/preferences.blp:121
+msgid ""
+"Adds a button to the markdown reference sheet on the right of the formatting "
+"toolbar"
+msgstr ""
+
+#: data/app.gschema.xml:36 src/ui/preferences/preferences.blp:139
+msgid "3-Pane Layout"
+msgstr "Disseny de 3 panells"
+
+#: data/app.gschema.xml:37 src/ui/preferences/preferences.blp:140
+msgid "Expands the notebook list to include the notebook name"
+msgstr ""
+
+#: data/app.gschema.xml:41 src/ui/preferences/preferences.blp:207
+msgid "Notes Storage Location"
+msgstr "Emmagatzematge de Notes"
+
+#: data/app.gschema.xml:42 src/ui/preferences/preferences.blp:208
+msgid "Where the notebooks are stored (requires app restart)"
+msgstr "On s'emmagatzemen els quaderns (requereix reiniciar la app)"
+
+#: data/app.gschema.xml:46 src/ui/preferences/preferences.blp:235
+msgid "Trash Storage Location"
+msgstr ""
+
+#: data/app.gschema.xml:47 src/ui/preferences/preferences.blp:236
+msgid "Where the trash folder is located (requires app restart)"
+msgstr ""
+
+#: data/app.gschema.xml:51 src/ui/preferences/preferences.blp:87
+msgid "Show line numbers"
+msgstr ""
+
+#: data/app.gschema.xml:52 src/ui/preferences/preferences.blp:88
+msgid "Displays line numbers at the left of the note"
+msgstr ""
+
+#: data/app.gschema.xml:56 src/ui/preferences/preferences.blp:98
+msgid "Show all notes"
+msgstr ""
+
+#: data/app.gschema.xml:57 src/ui/preferences/preferences.blp:99
+msgid "Displays the \"All Notes\" notebook at the top of the notebook list"
+msgstr ""
+
+#: data/app.gschema.xml:61 src/ui/preferences/preferences.blp:185
+msgid "Enable autosave"
+msgstr ""
+
+#: data/app.gschema.xml:62 src/ui/preferences/preferences.blp:186
+msgid ""
+"Automatically saves the current note every 30 seconds if the contents have "
+"changed (requires app restart)"
+msgstr ""
+
+#: data/app.gschema.xml:66 src/ui/preferences/preferences.blp:196
+msgid "Don't hide the Trash folder"
+msgstr ""
+
+#: data/app.gschema.xml:67
+msgid ""
+"The trash folder is set as a hidden folder by default, this option makes it "
+"visible"
+msgstr ""
+
+#: data/app.gschema.xml:71
+msgid "Note sort order"
+msgstr ""
+
+#: data/app.gschema.xml:72
+msgid "The sort order of the note list"
+msgstr ""
+
+#: data/app.gschema.xml:76
+msgid "Notebook sort order"
+msgstr "Ordre de classificació del quadern"
+
+#: data/app.gschema.xml:77
+msgid "The sort order of the notebook list"
+msgstr ""
+
+#: data/app.gschema.xml:81
+msgid "URL detection level"
+msgstr ""
+
+#: data/app.gschema.xml:82
+msgid "How agressive to look for URLs in markdown text"
+msgstr ""
+
+#: data/app.gschema.xml:86
+msgid "Line spacing"
+msgstr ""
+
+#: data/app.gschema.xml:87 src/ui/preferences/preferences.blp:74
+msgid "The line spacing for the note text"
+msgstr ""
 
 #: data/app.metainfo.xml.in:5
 msgid "Take notes in Markdown"
@@ -314,103 +225,116 @@ msgstr ""
 msgid "Trash can"
 msgstr "Paperera"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:23
-#: src/ui/edit_view/toolbar/toolbar.blp:131
+#: data/app.metainfo.xml.in:393
+msgid "Main Folio window in light mode"
+msgstr ""
+
+#: data/app.metainfo.xml.in:397
+msgid "Main Folio window in dark mode"
+msgstr ""
+
+#: data/app.metainfo.xml.in:401
+msgid "Folio on small/mobile screens"
+msgstr ""
+
+#: data/app.metainfo.xml.in:405
+msgid "Folio preferences screen"
+msgstr ""
+
+#: data/app.metainfo.xml.in:409
+msgid "Folio in three pane mode"
+msgstr ""
+
+#: src/ui/edit_view/toolbar/toolbar.blp:6
 #: src/ui/widgets/markdown/heading_popover.blp:48
 msgid "Plain Text"
 msgstr "Text Simple"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:24
-#: src/ui/edit_view/toolbar/toolbar.blp:132
+#: src/ui/edit_view/toolbar/toolbar.blp:7
 #: src/ui/widgets/markdown/heading_popover.blp:12
 msgid "Heading 1"
 msgstr "Encapçalat 1"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:25
-#: src/ui/edit_view/toolbar/toolbar.blp:133
+#: src/ui/edit_view/toolbar/toolbar.blp:8
 #: src/ui/widgets/markdown/heading_popover.blp:18
 msgid "Heading 2"
 msgstr "Encapçalat 2"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:26
-#: src/ui/edit_view/toolbar/toolbar.blp:134
+#: src/ui/edit_view/toolbar/toolbar.blp:9
 #: src/ui/widgets/markdown/heading_popover.blp:24
 msgid "Heading 3"
 msgstr "Encapçalat 3"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:27
-#: src/ui/edit_view/toolbar/toolbar.blp:135
+#: src/ui/edit_view/toolbar/toolbar.blp:10
 #: src/ui/widgets/markdown/heading_popover.blp:30
 msgid "Heading 4"
 msgstr "Encapçalat 4"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:28
-#: src/ui/edit_view/toolbar/toolbar.blp:136
+#: src/ui/edit_view/toolbar/toolbar.blp:11
 #: src/ui/widgets/markdown/heading_popover.blp:36
 msgid "Heading 5"
 msgstr "Encapçalat 5"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:29
-#: src/ui/edit_view/toolbar/toolbar.blp:137
+#: src/ui/edit_view/toolbar/toolbar.blp:12
 #: src/ui/widgets/markdown/heading_popover.blp:42
 msgid "Heading 6"
 msgstr "Encapçalat 6"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:39
-#: src/ui/edit_view/toolbar/toolbar.blp:104
-#: src/ui/edit_view/toolbar/toolbar.blp:148
-#: src/ui/edit_view/toolbar/toolbar.blp:201 src/ui/popup/shortcut_window.blp:72
+#: src/ui/edit_view/toolbar/toolbar.blp:41
+#: src/ui/edit_view/toolbar/toolbar.blp:107
+#: src/ui/edit_view/toolbar/toolbar.blp:142
+#: src/ui/edit_view/toolbar/toolbar.blp:195 src/ui/popup/shortcut_window.blp:72
 msgid "Bold"
 msgstr "Negreta"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:45
-#: src/ui/edit_view/toolbar/toolbar.blp:111
-#: src/ui/edit_view/toolbar/toolbar.blp:155
-#: src/ui/edit_view/toolbar/toolbar.blp:202 src/ui/popup/shortcut_window.blp:77
+#: src/ui/edit_view/toolbar/toolbar.blp:47
+#: src/ui/edit_view/toolbar/toolbar.blp:114
+#: src/ui/edit_view/toolbar/toolbar.blp:149
+#: src/ui/edit_view/toolbar/toolbar.blp:196 src/ui/popup/shortcut_window.blp:77
 msgid "Italic"
 msgstr "Itàlic"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:51
-#: src/ui/edit_view/toolbar/toolbar.blp:162
-#: src/ui/edit_view/toolbar/toolbar.blp:203 src/ui/popup/shortcut_window.blp:82
+#: src/ui/edit_view/toolbar/toolbar.blp:53
+#: src/ui/edit_view/toolbar/toolbar.blp:156
+#: src/ui/edit_view/toolbar/toolbar.blp:197 src/ui/popup/shortcut_window.blp:82
 msgid "Strikethrough"
 msgstr "Ratllat"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:57
-#: src/ui/edit_view/toolbar/toolbar.blp:169
-#: src/ui/edit_view/toolbar/toolbar.blp:204 src/ui/popup/shortcut_window.blp:87
+#: src/ui/edit_view/toolbar/toolbar.blp:59
+#: src/ui/edit_view/toolbar/toolbar.blp:163
+#: src/ui/edit_view/toolbar/toolbar.blp:198 src/ui/popup/shortcut_window.blp:87
 msgid "Highlight"
 msgstr "Subratllat"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:67
-#: src/ui/edit_view/toolbar/toolbar.blp:193 src/ui/popup/shortcut_window.blp:92
+#: src/ui/edit_view/toolbar/toolbar.blp:69
+#: src/ui/edit_view/toolbar/toolbar.blp:187 src/ui/popup/shortcut_window.blp:92
 msgid "Insert Link"
 msgstr "Inserir Enllaç"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:73
-#: src/ui/edit_view/toolbar/toolbar.blp:194
+#: src/ui/edit_view/toolbar/toolbar.blp:75
+#: src/ui/edit_view/toolbar/toolbar.blp:188
 msgid "Insert Code"
 msgstr "Inserir Codi"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:79
-#: src/ui/edit_view/toolbar/toolbar.blp:195
+#: src/ui/edit_view/toolbar/toolbar.blp:81
+#: src/ui/edit_view/toolbar/toolbar.blp:189
 msgid "Insert Horizontal Rule"
 msgstr "Inserir Separació horitzontal"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:118
+#: src/ui/edit_view/toolbar/toolbar.blp:121
 msgid "Format"
 msgstr "Format"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:181
+#: src/ui/edit_view/toolbar/toolbar.blp:175
 msgid "Insert"
 msgstr "Inserir"
 
-#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:34
+#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:18
 #: src/ui/strings.vala:44 src/ui/strings.vala:58
 msgid "Cancel"
 msgstr "Cancel·lar"
 
-#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:39
+#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:23
 msgid "Confirm"
 msgstr "Confirmar"
 
@@ -454,37 +378,85 @@ msgstr "Format"
 msgid "Navigation"
 msgstr "Navegació"
 
-#: src/ui/popup/shortcut_window.blp:102 src/ui/window/window.blp:216
+#: src/ui/popup/shortcut_window.blp:102 src/ui/window/window.blp:268
 msgid "Toggle Sidebar"
 msgstr "Alternar Barra Lateral"
 
-#: src/ui/popup/shortcut_window.blp:107 src/ui/window/window.blp:63
+#: src/ui/popup/shortcut_window.blp:107 src/ui/window/window.blp:70
 msgid "Search Notes"
 msgstr "Cercar Notes"
 
-#: data/app.gschema.xml:22 src/ui/preferences/preferences.blp:47
-msgid "Makes the dark theme pitch black"
-msgstr "Fa el tema fosc de color negre"
-
-#: data/app.gschema.xml:26 src/ui/preferences/preferences.blp:87
-msgid "Enable Toolbar"
-msgstr "Activar la barra d'eines"
-
-#: data/app.gschema.xml:31 src/ui/preferences/preferences.blp:98
-msgid "Enable Cheatsheet"
+#: src/ui/popup/shortcut_window.blp:114
+msgid "Display"
 msgstr ""
 
-#: data/app.gschema.xml:36 src/ui/preferences/preferences.blp:117
-msgid "3-Pane Layout"
-msgstr "Disseny de 3 panells"
+#: src/ui/popup/shortcut_window.blp:117
+msgid "Full Screen"
+msgstr ""
 
-#: data/app.gschema.xml:41 src/ui/preferences/preferences.blp:185
-msgid "Notes Storage Location"
-msgstr "Emmagatzematge de Notes"
+#: src/ui/popup/shortcut_window.blp:122
+msgid "Zoom In"
+msgstr ""
 
-#: data/app.gschema.xml:42 src/ui/preferences/preferences.blp:186
-msgid "Where the notebooks are stored (requires app restart)"
-msgstr "On s'emmagatzemen els quaderns (requereix reiniciar la app)"
+#: src/ui/popup/shortcut_window.blp:127
+msgid "Zoom Out"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:31
+#, fuzzy
+msgid "Markdown URL Detection"
+msgstr "Chuleta de Markdown"
+
+#: src/ui/preferences/preferences.blp:32
+msgid ""
+"Determines the level of detection of URLs in\n"
+"free form text is used:\n"
+" - Aggressive tries to find all URLs\n"
+" - Strict requires a protocol identifier (ie http://)\n"
+" - Disabled turns detection off."
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:39
+msgid "Fonts"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:73
+msgid "Line Spacing"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:81
+msgid "Tools"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:133
+msgid "Layout"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:161
+msgid "Fixed Width To Use For Notes"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:162
+msgid "Sets the fixed width size of a note in px"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:167
+msgid "Sort Order For Notebooks"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:172
+msgid "Sort Order For Notes"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:179
+msgid "Files"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:197
+msgid ""
+"The trash folder is set as a hidden folder by default, this option makes it "
+"visible (requires app restart)"
+msgstr ""
 
 #: src/ui/strings.vala:4 src/ui/window/notebooks_bar/notebooks_bar.blp:129
 #: src/ui/window/notebooks_bar/notebooks_bar.blp:171
@@ -492,6 +464,7 @@ msgid "Trash"
 msgstr "Paperera"
 
 #: src/ui/strings.vala:5
+#, c-format
 msgid "%d Notes"
 msgstr "%d Notes"
 
@@ -499,7 +472,7 @@ msgstr "%d Notes"
 msgid "Are you sure you want to delete everything in the trash?"
 msgstr "De veritat vol eliminar-ho tot en la paperera?"
 
-#: src/ui/strings.vala:7 src/ui/window/window.blp:54
+#: src/ui/strings.vala:7 src/ui/window/window.blp:61
 msgid "Empty Trash"
 msgstr "Buidar Paperera"
 
@@ -536,10 +509,12 @@ msgid "Move"
 msgstr "Moure"
 
 #: src/ui/strings.vala:18
+#, c-format
 msgid "Note “%s” already exists in notebook “%s”"
 msgstr "Nota “%s” ja existeix al quadern “%s”"
 
 #: src/ui/strings.vala:19
+#, c-format
 msgid "Are you sure you want to delete the note “%s”?"
 msgstr "De veritat vol eliminar la nota “%s”?"
 
@@ -548,6 +523,7 @@ msgid "Delete Note"
 msgstr "Eliminar Nota"
 
 #: src/ui/strings.vala:21
+#, c-format
 msgid "Are you sure you want to delete the notebook “%s”?"
 msgstr "De veritat vol eliminar el quadern “%s”?"
 
@@ -556,34 +532,42 @@ msgid "Delete Notebook"
 msgstr "Eliminar Quadern"
 
 #: src/ui/strings.vala:24
-msgid "Note name shouldn’t contain “.” or “/”"
+#, fuzzy
+msgid "Note names cannot contain a “/”"
 msgstr "Noms de notes no han de contenir “.” o “/”"
 
 #: src/ui/strings.vala:25
-msgid "Note name shouldn’t be blank"
+#, fuzzy
+msgid "Note names cannot be blank"
 msgstr "Noms de notes no han de ser buits"
 
 #: src/ui/strings.vala:26
+#, c-format
 msgid "Note “%s” already exists"
 msgstr "Nota “%s” ja existeix"
 
 #: src/ui/strings.vala:27
-msgid "Couldn’t create note"
+#, fuzzy
+msgid "Could not create note"
 msgstr "Nota no es va poder crear"
 
 #: src/ui/strings.vala:28
-msgid "Couldn’t change note"
+#, fuzzy
+msgid "Could not change note"
 msgstr "Nota no es va poder cambiar"
 
 #: src/ui/strings.vala:29
-msgid "Couldn’t delete note"
+#, fuzzy
+msgid "Could not delete note"
 msgstr "Nota no es va poder borrar"
 
 #: src/ui/strings.vala:30
-msgid "Couldn’t restore note"
+#, fuzzy
+msgid "Could not restore note"
 msgstr "Nota no es va poder recuperar"
 
 #: src/ui/strings.vala:31
+#, c-format
 msgid "Saved “%s” to “%s”"
 msgstr "“%s” se guardó en “%s”"
 
@@ -592,27 +576,33 @@ msgid "Unknown error"
 msgstr "Error desconocido"
 
 #: src/ui/strings.vala:33
-msgid "Notebook name shouldn’t contain “.” or “/”"
+#, fuzzy
+msgid "Notebook names cannot contain a “/”"
 msgstr "Noms de quaderns no han de contenir “.” o “/”"
 
 #: src/ui/strings.vala:34
-msgid "Notebook name shouldn’t be blank"
+#, fuzzy
+msgid "Notebook names cannot be blank"
 msgstr "Noms de quaderns no han de ser buits"
 
 #: src/ui/strings.vala:35
+#, c-format
 msgid "Notebook “%s” already exists"
 msgstr "Quadern “%s” ja existeix"
 
 #: src/ui/strings.vala:36
-msgid "Couldn’t create notebook"
+#, fuzzy
+msgid "Could not create notebook"
 msgstr "Quadern es va poder crear"
 
 #: src/ui/strings.vala:37
-msgid "Couldn’t change notebook"
+#, fuzzy
+msgid "Could not change notebook"
 msgstr "Quadern es va poder cambiar"
 
 #: src/ui/strings.vala:38
-msgid "Couldn’t delete notebook"
+#, fuzzy
+msgid "Could not delete notebook"
 msgstr "Quadern es va poder borrar"
 
 #: src/ui/strings.vala:40
@@ -624,7 +614,7 @@ msgid "Rename"
 msgstr "Reanomenar"
 
 #: src/ui/strings.vala:42
-msgid "Couldn’t find an app to handle file URIs"
+msgid "Could not find an app to handle file URIs"
 msgstr ""
 
 #: src/ui/strings.vala:43
@@ -634,6 +624,10 @@ msgstr "Aplicar"
 #: src/ui/strings.vala:45
 msgid "Pick where the notebooks will be stored"
 msgstr "Escull on s'emmagatzemen els quaderns"
+
+#: src/ui/strings.vala:46
+msgid "Pick where the trash can will be stored"
+msgstr ""
 
 #: src/ui/strings.vala:47 src/ui/window/notebooks_bar/notebooks_bar.blp:59
 #: src/ui/window/notebooks_bar/notebooks_bar.blp:101
@@ -646,6 +640,110 @@ msgstr ""
 
 #: src/ui/strings.vala:50
 msgid "Extension"
+msgstr ""
+
+#: src/ui/strings.vala:51
+msgid "Unable to recognize URI"
+msgstr ""
+
+#: src/ui/strings.vala:52
+msgid "Pick primary font for notes"
+msgstr ""
+
+#: src/ui/strings.vala:53
+msgid "Pick monospace font for code"
+msgstr ""
+
+#: src/ui/strings.vala:54
+msgid "File Changed On Disk"
+msgstr ""
+
+#: src/ui/strings.vala:55
+msgid ""
+"The file has changed on disk since it was last saved/loaded by Folio.\n"
+"\n"
+"You may do one of the following:\n"
+"\n"
+" • Reload the file (discarding any changes you have made in Folio)\n"
+" • Overwrite the file (discarding any changes made outside of Folio)\n"
+" • Cancel the operation and manually resolve the issue\n"
+"\n"
+"Note: Canceling the save if you have already moved to a new note/notebook "
+"will discard your changes."
+msgstr ""
+
+#: src/ui/strings.vala:56
+msgid "Reload"
+msgstr ""
+
+#: src/ui/strings.vala:57
+msgid "Overwrite"
+msgstr ""
+
+#: src/ui/strings.vala:59
+msgid ""
+"The file has changed on disk by another application.\n"
+"\n"
+"You may do one of the following:\n"
+"\n"
+" • Reload the file (discarding any changes you have made in Folio)\n"
+" • Overwrite the file (discarding any changes made outside of Folio)"
+msgstr ""
+
+#: src/ui/strings.vala:61
+#, c-format
+msgid "Note %i"
+msgstr ""
+
+#: src/ui/strings.vala:62
+msgid "Modified Time - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:63
+msgid "Modified Time - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:64
+msgid "Alphabetical - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:65
+msgid "Alphabetical - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:66
+msgid "Natural - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:67
+msgid "Natural - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:68
+#, c-format
+msgid "Unable to launch external application for file %s."
+msgstr ""
+
+#: src/ui/strings.vala:69
+msgid "Aggressive"
+msgstr ""
+
+#: src/ui/strings.vala:70
+msgid "Strict"
+msgstr ""
+
+#: src/ui/strings.vala:71
+msgid "Disabled"
+msgstr ""
+
+#: src/ui/strings.vala:72
+#, fuzzy, c-format
+msgid "“%s” moved to trash"
+msgstr "Moure a la Paperera"
+
+#: src/ui/strings.vala:73
+#, c-format
+msgid "“%s” restored"
 msgstr ""
 
 #: src/ui/widgets/theme_selector/theme_selector.blp:15
@@ -677,40 +775,45 @@ msgid "_Keyboard Shortcuts"
 msgstr "_Dreceres"
 
 #: src/ui/window/app_menu/app_menu.blp:43
-msgid "_About"
+#, fuzzy
+msgid "_About Folio"
 msgstr "_Sobre Paper"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:54
-msgid "Notebook Name"
-msgstr "Nom del Quadern"
-
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:66
-msgid "Duplicate notebook names are not allowed!"
-msgstr ""
-
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:82
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:6
 msgid "First Characters"
 msgstr "Primers Caràcters"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:83
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:7
 msgid "Initials"
 msgstr "Inicials"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:84
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:8
 msgid "Initials: camelCase"
 msgstr "Inicials: camelCase"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:85
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:9
 msgid "Initials: snake_case"
 msgstr "Inicials: snake_case"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:86
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:10
 msgid "Icon"
 msgstr "Icona"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:116
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:11
+msgid "Custom"
+msgstr ""
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:16
 msgid "Notebook Color"
 msgstr "Color del Quadern"
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:58
+msgid "Notebook Name"
+msgstr "Nom del Quadern"
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:70
+msgid "Duplicate notebook names are not allowed!"
+msgstr ""
 
 #: src/ui/window/notebooks_bar/notebook_create_popup.blp:126
 msgid "Create Notebook"
@@ -728,11 +831,11 @@ msgstr "Moure tot a la Paperera"
 msgid "Notebooks"
 msgstr ""
 
-#: src/ui/window/sidebar/note_create_popup.blp:37
+#: src/ui/window/sidebar/note_create_popup.blp:25
 msgid "Note Name"
 msgstr "Nom de Nota"
 
-#: src/ui/window/sidebar/note_create_popup.blp:45
+#: src/ui/window/sidebar/note_create_popup.blp:33
 msgid "Create Note"
 msgstr "Crear Nota"
 
@@ -756,30 +859,37 @@ msgstr "Moure a la Paperera"
 msgid "Open Containing Folder"
 msgstr "Veure en Carpeta"
 
-#: src/ui/window/window.blp:118
+#: src/ui/window/window.blp:123
 msgid "Get started writing"
 msgstr "Comença a escribir"
 
-#: src/ui/window/window.blp:143
+#: src/ui/window/window.blp:152
+msgid "Open file in external application"
+msgstr ""
+
+#: src/ui/window/window.blp:160
+msgid "Open file"
+msgstr ""
+
+#: src/ui/window/window.blp:181
 msgid "Create a notebook"
 msgstr "Crea un quadern"
 
-#: src/ui/window/window.blp:168
+#: src/ui/window/window.blp:210
 msgid "Trash is empty"
 msgstr "La paperera está buida"
 
-#: src/ui/window/window.blp:224
-msgid "Back"
-msgstr "Tornar"
-
-#: src/ui/window/window.blp:239
+#: src/ui/window/window.blp:285
 msgid "Open in Notebook"
 msgstr "Obrir al Quadern"
 
-#: src/ui/window/window.blp:264
+#: src/ui/window/window.blp:312
 msgid "_Rename Note"
 msgstr "_Reanomenar Nota"
 
-#: src/ui/window/window.blp:270
+#: src/ui/window/window.blp:319
 msgid "_Export Note"
 msgstr "_Exportar Nota"
+
+#~ msgid "Back"
+#~ msgstr "Tornar"

--- a/po/com.toolstack.Folio.pot
+++ b/po/com.toolstack.Folio.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.toolstack.Folio\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-03-24 21:02-0400\n"
+"POT-Creation-Date: 2024-10-12 16:53+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -34,18 +34,18 @@ msgid "Notebook;Note;Notes;Text;Markdown;Notepad;Write;School;Post-it;Sticky;"
 msgstr ""
 
 #: data/app.desktop.in:22 src/ui/popup/shortcut_window.blp:17
-#: src/ui/strings.vala:8 src/ui/window/window.blp:47
-#: src/ui/window/window.blp:124
+#: src/ui/strings.vala:8 src/ui/window/window.blp:54
+#: src/ui/window/window.blp:131
 msgid "New Note"
 msgstr ""
 
 #: data/app.desktop.in:26 src/ui/popup/shortcut_window.blp:37
-#: src/ui/strings.vala:14 src/ui/window/window.blp:149
+#: src/ui/strings.vala:14 src/ui/window/window.blp:189
 msgid "New Notebook"
 msgstr ""
 
-#: data/app.desktop.in:30 src/ui/edit_view/toolbar/toolbar.blp:90
-#: src/ui/strings.vala:39 src/ui/window/window.blp:245
+#: data/app.desktop.in:30 src/ui/edit_view/toolbar/toolbar.blp:92
+#: src/ui/strings.vala:39 src/ui/window/window.blp:291
 msgid "Markdown Cheatsheet"
 msgstr ""
 
@@ -53,107 +53,107 @@ msgstr ""
 msgid "Preferences"
 msgstr ""
 
-#: data/app.gschema.xml:6 src/ui/preferences/preferences.blp:18
+#: data/app.gschema.xml:6 src/ui/preferences/preferences.blp:45
 msgid "Note Font"
 msgstr ""
 
-#: data/app.gschema.xml:7 src/ui/preferences/preferences.blp:19
+#: data/app.gschema.xml:7 src/ui/preferences/preferences.blp:46
 msgid "The font notes will be displayed in"
 msgstr ""
 
-#: data/app.gschema.xml:11 src/ui/preferences/preferences.blp:31
+#: data/app.gschema.xml:11 src/ui/preferences/preferences.blp:58
 msgid "Monospace Font"
 msgstr ""
 
-#: data/app.gschema.xml:12 src/ui/preferences/preferences.blp:32
+#: data/app.gschema.xml:12 src/ui/preferences/preferences.blp:59
 msgid "The font code will be displayed in"
 msgstr ""
 
-#: data/app.gschema.xml:16 src/ui/preferences/preferences.blp:128
+#: data/app.gschema.xml:16 src/ui/preferences/preferences.blp:150
 msgid "Use Fixed Width For Notes"
 msgstr ""
 
-#: data/app.gschema.xml:17 src/ui/preferences/preferences.blp:129
+#: data/app.gschema.xml:17 src/ui/preferences/preferences.blp:151
 msgid "Use a fixed width for the text area of a note"
 msgstr ""
 
-#: data/app.gschema.xml:21 src/ui/preferences/preferences.blp:46
+#: data/app.gschema.xml:21 src/ui/preferences/preferences.blp:18
 msgid "OLED Mode"
 msgstr ""
 
-#: data/app.gschema.xml:22 src/ui/preferences/preferences.blp:47
+#: data/app.gschema.xml:22 src/ui/preferences/preferences.blp:19
 msgid "Makes the dark theme pitch black"
 msgstr ""
 
-#: data/app.gschema.xml:26 src/ui/preferences/preferences.blp:87
+#: data/app.gschema.xml:26 src/ui/preferences/preferences.blp:109
 msgid "Enable Toolbar"
 msgstr ""
 
-#: data/app.gschema.xml:27 src/ui/preferences/preferences.blp:88
+#: data/app.gschema.xml:27 src/ui/preferences/preferences.blp:110
 msgid "Displays the formatting toolbar at the bottom of the note"
 msgstr ""
 
-#: data/app.gschema.xml:31 src/ui/preferences/preferences.blp:98
+#: data/app.gschema.xml:31 src/ui/preferences/preferences.blp:120
 msgid "Enable Cheatsheet"
 msgstr ""
 
-#: data/app.gschema.xml:32 src/ui/preferences/preferences.blp:99
+#: data/app.gschema.xml:32 src/ui/preferences/preferences.blp:121
 msgid ""
 "Adds a button to the markdown reference sheet on the right of the formatting "
 "toolbar"
 msgstr ""
 
-#: data/app.gschema.xml:36 src/ui/preferences/preferences.blp:117
+#: data/app.gschema.xml:36 src/ui/preferences/preferences.blp:139
 msgid "3-Pane Layout"
 msgstr ""
 
-#: data/app.gschema.xml:37 src/ui/preferences/preferences.blp:118
+#: data/app.gschema.xml:37 src/ui/preferences/preferences.blp:140
 msgid "Expands the notebook list to include the notebook name"
 msgstr ""
 
-#: data/app.gschema.xml:41 src/ui/preferences/preferences.blp:185
+#: data/app.gschema.xml:41 src/ui/preferences/preferences.blp:207
 msgid "Notes Storage Location"
 msgstr ""
 
-#: data/app.gschema.xml:42 src/ui/preferences/preferences.blp:186
+#: data/app.gschema.xml:42 src/ui/preferences/preferences.blp:208
 msgid "Where the notebooks are stored (requires app restart)"
 msgstr ""
 
-#: data/app.gschema.xml:46 src/ui/preferences/preferences.blp:213
+#: data/app.gschema.xml:46 src/ui/preferences/preferences.blp:235
 msgid "Trash Storage Location"
 msgstr ""
 
-#: data/app.gschema.xml:47 src/ui/preferences/preferences.blp:214
+#: data/app.gschema.xml:47 src/ui/preferences/preferences.blp:236
 msgid "Where the trash folder is located (requires app restart)"
 msgstr ""
 
-#: data/app.gschema.xml:51 src/ui/preferences/preferences.blp:65
+#: data/app.gschema.xml:51 src/ui/preferences/preferences.blp:87
 msgid "Show line numbers"
 msgstr ""
 
-#: data/app.gschema.xml:52 src/ui/preferences/preferences.blp:66
+#: data/app.gschema.xml:52 src/ui/preferences/preferences.blp:88
 msgid "Displays line numbers at the left of the note"
 msgstr ""
 
-#: data/app.gschema.xml:56 src/ui/preferences/preferences.blp:76
+#: data/app.gschema.xml:56 src/ui/preferences/preferences.blp:98
 msgid "Show all notes"
 msgstr ""
 
-#: data/app.gschema.xml:57 src/ui/preferences/preferences.blp:77
+#: data/app.gschema.xml:57 src/ui/preferences/preferences.blp:99
 msgid "Displays the \"All Notes\" notebook at the top of the notebook list"
 msgstr ""
 
-#: data/app.gschema.xml:61 src/ui/preferences/preferences.blp:163
+#: data/app.gschema.xml:61 src/ui/preferences/preferences.blp:185
 msgid "Enable autosave"
 msgstr ""
 
-#: data/app.gschema.xml:62 src/ui/preferences/preferences.blp:164
+#: data/app.gschema.xml:62 src/ui/preferences/preferences.blp:186
 msgid ""
 "Automatically saves the current note every 30 seconds if the contents have "
 "changed (requires app restart)"
 msgstr ""
 
-#: data/app.gschema.xml:66 src/ui/preferences/preferences.blp:174
+#: data/app.gschema.xml:66 src/ui/preferences/preferences.blp:196
 msgid "Don't hide the Trash folder"
 msgstr ""
 
@@ -177,6 +177,22 @@ msgstr ""
 
 #: data/app.gschema.xml:77
 msgid "The sort order of the notebook list"
+msgstr ""
+
+#: data/app.gschema.xml:81
+msgid "URL detection level"
+msgstr ""
+
+#: data/app.gschema.xml:82
+msgid "How agressive to look for URLs in markdown text"
+msgstr ""
+
+#: data/app.gschema.xml:86
+msgid "Line spacing"
+msgstr ""
+
+#: data/app.gschema.xml:87 src/ui/preferences/preferences.blp:74
+msgid "The line spacing for the note text"
 msgstr ""
 
 #: data/app.metainfo.xml.in:5
@@ -211,123 +227,116 @@ msgstr ""
 msgid "Trash can"
 msgstr ""
 
-#: data/app.metainfo.xml.in:367
+#: data/app.metainfo.xml.in:393
 msgid "Main Folio window in light mode"
 msgstr ""
 
-#: data/app.metainfo.xml.in:371
+#: data/app.metainfo.xml.in:397
 msgid "Main Folio window in dark mode"
 msgstr ""
 
-#: data/app.metainfo.xml.in:375
+#: data/app.metainfo.xml.in:401
 msgid "Folio on small/mobile screens"
 msgstr ""
 
-#: data/app.metainfo.xml.in:379
+#: data/app.metainfo.xml.in:405
 msgid "Folio preferences screen"
 msgstr ""
 
-#: data/app.metainfo.xml.in:383
+#: data/app.metainfo.xml.in:409
 msgid "Folio in three pane mode"
 msgstr ""
 
-#: src/ui/edit_view/toolbar/toolbar.blp:23
-#: src/ui/edit_view/toolbar/toolbar.blp:131
+#: src/ui/edit_view/toolbar/toolbar.blp:6
 #: src/ui/widgets/markdown/heading_popover.blp:48
 msgid "Plain Text"
 msgstr ""
 
-#: src/ui/edit_view/toolbar/toolbar.blp:24
-#: src/ui/edit_view/toolbar/toolbar.blp:132
+#: src/ui/edit_view/toolbar/toolbar.blp:7
 #: src/ui/widgets/markdown/heading_popover.blp:12
 msgid "Heading 1"
 msgstr ""
 
-#: src/ui/edit_view/toolbar/toolbar.blp:25
-#: src/ui/edit_view/toolbar/toolbar.blp:133
+#: src/ui/edit_view/toolbar/toolbar.blp:8
 #: src/ui/widgets/markdown/heading_popover.blp:18
 msgid "Heading 2"
 msgstr ""
 
-#: src/ui/edit_view/toolbar/toolbar.blp:26
-#: src/ui/edit_view/toolbar/toolbar.blp:134
+#: src/ui/edit_view/toolbar/toolbar.blp:9
 #: src/ui/widgets/markdown/heading_popover.blp:24
 msgid "Heading 3"
 msgstr ""
 
-#: src/ui/edit_view/toolbar/toolbar.blp:27
-#: src/ui/edit_view/toolbar/toolbar.blp:135
+#: src/ui/edit_view/toolbar/toolbar.blp:10
 #: src/ui/widgets/markdown/heading_popover.blp:30
 msgid "Heading 4"
 msgstr ""
 
-#: src/ui/edit_view/toolbar/toolbar.blp:28
-#: src/ui/edit_view/toolbar/toolbar.blp:136
+#: src/ui/edit_view/toolbar/toolbar.blp:11
 #: src/ui/widgets/markdown/heading_popover.blp:36
 msgid "Heading 5"
 msgstr ""
 
-#: src/ui/edit_view/toolbar/toolbar.blp:29
-#: src/ui/edit_view/toolbar/toolbar.blp:137
+#: src/ui/edit_view/toolbar/toolbar.blp:12
 #: src/ui/widgets/markdown/heading_popover.blp:42
 msgid "Heading 6"
 msgstr ""
 
-#: src/ui/edit_view/toolbar/toolbar.blp:39
-#: src/ui/edit_view/toolbar/toolbar.blp:104
-#: src/ui/edit_view/toolbar/toolbar.blp:148
-#: src/ui/edit_view/toolbar/toolbar.blp:201 src/ui/popup/shortcut_window.blp:72
+#: src/ui/edit_view/toolbar/toolbar.blp:41
+#: src/ui/edit_view/toolbar/toolbar.blp:107
+#: src/ui/edit_view/toolbar/toolbar.blp:142
+#: src/ui/edit_view/toolbar/toolbar.blp:195 src/ui/popup/shortcut_window.blp:72
 msgid "Bold"
 msgstr ""
 
-#: src/ui/edit_view/toolbar/toolbar.blp:45
-#: src/ui/edit_view/toolbar/toolbar.blp:111
-#: src/ui/edit_view/toolbar/toolbar.blp:155
-#: src/ui/edit_view/toolbar/toolbar.blp:202 src/ui/popup/shortcut_window.blp:77
+#: src/ui/edit_view/toolbar/toolbar.blp:47
+#: src/ui/edit_view/toolbar/toolbar.blp:114
+#: src/ui/edit_view/toolbar/toolbar.blp:149
+#: src/ui/edit_view/toolbar/toolbar.blp:196 src/ui/popup/shortcut_window.blp:77
 msgid "Italic"
 msgstr ""
 
-#: src/ui/edit_view/toolbar/toolbar.blp:51
-#: src/ui/edit_view/toolbar/toolbar.blp:162
-#: src/ui/edit_view/toolbar/toolbar.blp:203 src/ui/popup/shortcut_window.blp:82
+#: src/ui/edit_view/toolbar/toolbar.blp:53
+#: src/ui/edit_view/toolbar/toolbar.blp:156
+#: src/ui/edit_view/toolbar/toolbar.blp:197 src/ui/popup/shortcut_window.blp:82
 msgid "Strikethrough"
 msgstr ""
 
-#: src/ui/edit_view/toolbar/toolbar.blp:57
-#: src/ui/edit_view/toolbar/toolbar.blp:169
-#: src/ui/edit_view/toolbar/toolbar.blp:204 src/ui/popup/shortcut_window.blp:87
+#: src/ui/edit_view/toolbar/toolbar.blp:59
+#: src/ui/edit_view/toolbar/toolbar.blp:163
+#: src/ui/edit_view/toolbar/toolbar.blp:198 src/ui/popup/shortcut_window.blp:87
 msgid "Highlight"
 msgstr ""
 
-#: src/ui/edit_view/toolbar/toolbar.blp:67
-#: src/ui/edit_view/toolbar/toolbar.blp:193 src/ui/popup/shortcut_window.blp:92
+#: src/ui/edit_view/toolbar/toolbar.blp:69
+#: src/ui/edit_view/toolbar/toolbar.blp:187 src/ui/popup/shortcut_window.blp:92
 msgid "Insert Link"
 msgstr ""
 
-#: src/ui/edit_view/toolbar/toolbar.blp:73
-#: src/ui/edit_view/toolbar/toolbar.blp:194
+#: src/ui/edit_view/toolbar/toolbar.blp:75
+#: src/ui/edit_view/toolbar/toolbar.blp:188
 msgid "Insert Code"
 msgstr ""
 
-#: src/ui/edit_view/toolbar/toolbar.blp:79
-#: src/ui/edit_view/toolbar/toolbar.blp:195
+#: src/ui/edit_view/toolbar/toolbar.blp:81
+#: src/ui/edit_view/toolbar/toolbar.blp:189
 msgid "Insert Horizontal Rule"
 msgstr ""
 
-#: src/ui/edit_view/toolbar/toolbar.blp:118
+#: src/ui/edit_view/toolbar/toolbar.blp:121
 msgid "Format"
 msgstr ""
 
-#: src/ui/edit_view/toolbar/toolbar.blp:181
+#: src/ui/edit_view/toolbar/toolbar.blp:175
 msgid "Insert"
 msgstr ""
 
-#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:34
+#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:18
 #: src/ui/strings.vala:44 src/ui/strings.vala:58
 msgid "Cancel"
 msgstr ""
 
-#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:39
+#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:23
 msgid "Confirm"
 msgstr ""
 
@@ -371,11 +380,11 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
-#: src/ui/popup/shortcut_window.blp:102 src/ui/window/window.blp:216
+#: src/ui/popup/shortcut_window.blp:102 src/ui/window/window.blp:268
 msgid "Toggle Sidebar"
 msgstr ""
 
-#: src/ui/popup/shortcut_window.blp:107 src/ui/window/window.blp:63
+#: src/ui/popup/shortcut_window.blp:107 src/ui/window/window.blp:70
 msgid "Search Notes"
 msgstr ""
 
@@ -395,35 +404,56 @@ msgstr ""
 msgid "Zoom Out"
 msgstr ""
 
-#: src/ui/preferences/preferences.blp:59
+#: src/ui/preferences/preferences.blp:31
+msgid "Markdown URL Detection"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:32
+msgid ""
+"Determines the level of detection of URLs in\n"
+"free form text is used:\n"
+" - Aggressive tries to find all URLs\n"
+" - Strict requires a protocol identifier (ie http://)\n"
+" - Disabled turns detection off."
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:39
+msgid "Fonts"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:73
+msgid "Line Spacing"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:81
 msgid "Tools"
 msgstr ""
 
-#: src/ui/preferences/preferences.blp:111
+#: src/ui/preferences/preferences.blp:133
 msgid "Layout"
 msgstr ""
 
-#: src/ui/preferences/preferences.blp:139
+#: src/ui/preferences/preferences.blp:161
 msgid "Fixed Width To Use For Notes"
 msgstr ""
 
-#: src/ui/preferences/preferences.blp:140
+#: src/ui/preferences/preferences.blp:162
 msgid "Sets the fixed width size of a note in px"
 msgstr ""
 
-#: src/ui/preferences/preferences.blp:145
+#: src/ui/preferences/preferences.blp:167
 msgid "Sort Order For Notebooks"
 msgstr ""
 
-#: src/ui/preferences/preferences.blp:150
+#: src/ui/preferences/preferences.blp:172
 msgid "Sort Order For Notes"
 msgstr ""
 
-#: src/ui/preferences/preferences.blp:157
+#: src/ui/preferences/preferences.blp:179
 msgid "Files"
 msgstr ""
 
-#: src/ui/preferences/preferences.blp:175
+#: src/ui/preferences/preferences.blp:197
 msgid ""
 "The trash folder is set as a hidden folder by default, this option makes it "
 "visible (requires app restart)"
@@ -443,7 +473,7 @@ msgstr ""
 msgid "Are you sure you want to delete everything in the trash?"
 msgstr ""
 
-#: src/ui/strings.vala:7 src/ui/window/window.blp:54
+#: src/ui/strings.vala:7 src/ui/window/window.blp:61
 msgid "Empty Trash"
 msgstr ""
 
@@ -503,11 +533,11 @@ msgid "Delete Notebook"
 msgstr ""
 
 #: src/ui/strings.vala:24
-msgid "Note name shouldn’t contain “.” or “/”"
+msgid "Note names cannot contain a “/”"
 msgstr ""
 
 #: src/ui/strings.vala:25
-msgid "Note name shouldn’t be blank"
+msgid "Note names cannot be blank"
 msgstr ""
 
 #: src/ui/strings.vala:26
@@ -516,19 +546,19 @@ msgid "Note “%s” already exists"
 msgstr ""
 
 #: src/ui/strings.vala:27
-msgid "Couldn’t create note"
+msgid "Could not create note"
 msgstr ""
 
 #: src/ui/strings.vala:28
-msgid "Couldn’t change note"
+msgid "Could not change note"
 msgstr ""
 
 #: src/ui/strings.vala:29
-msgid "Couldn’t delete note"
+msgid "Could not delete note"
 msgstr ""
 
 #: src/ui/strings.vala:30
-msgid "Couldn’t restore note"
+msgid "Could not restore note"
 msgstr ""
 
 #: src/ui/strings.vala:31
@@ -541,11 +571,11 @@ msgid "Unknown error"
 msgstr ""
 
 #: src/ui/strings.vala:33
-msgid "Notebook name shouldn’t contain “.” or “/”"
+msgid "Notebook names cannot contain a “/”"
 msgstr ""
 
 #: src/ui/strings.vala:34
-msgid "Notebook name shouldn’t be blank"
+msgid "Notebook names cannot be blank"
 msgstr ""
 
 #: src/ui/strings.vala:35
@@ -554,15 +584,15 @@ msgid "Notebook “%s” already exists"
 msgstr ""
 
 #: src/ui/strings.vala:36
-msgid "Couldn’t create notebook"
+msgid "Could not create notebook"
 msgstr ""
 
 #: src/ui/strings.vala:37
-msgid "Couldn’t change notebook"
+msgid "Could not change notebook"
 msgstr ""
 
 #: src/ui/strings.vala:38
-msgid "Couldn’t delete notebook"
+msgid "Could not delete notebook"
 msgstr ""
 
 #: src/ui/strings.vala:40
@@ -574,7 +604,7 @@ msgid "Rename"
 msgstr ""
 
 #: src/ui/strings.vala:42
-msgid "Couldn’t find an app to handle file URIs"
+msgid "Could not find an app to handle file URIs"
 msgstr ""
 
 #: src/ui/strings.vala:43
@@ -671,6 +701,41 @@ msgstr ""
 msgid "Alphabetical - Descending"
 msgstr ""
 
+#: src/ui/strings.vala:66
+msgid "Natural - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:67
+msgid "Natural - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:68
+#, c-format
+msgid "Unable to launch external application for file %s."
+msgstr ""
+
+#: src/ui/strings.vala:69
+msgid "Aggressive"
+msgstr ""
+
+#: src/ui/strings.vala:70
+msgid "Strict"
+msgstr ""
+
+#: src/ui/strings.vala:71
+msgid "Disabled"
+msgstr ""
+
+#: src/ui/strings.vala:72
+#, c-format
+msgid "“%s” moved to trash"
+msgstr ""
+
+#: src/ui/strings.vala:73
+#, c-format
+msgid "“%s” restored"
+msgstr ""
+
 #: src/ui/widgets/theme_selector/theme_selector.blp:15
 msgid "Follow system style"
 msgstr ""
@@ -700,39 +765,43 @@ msgid "_Keyboard Shortcuts"
 msgstr ""
 
 #: src/ui/window/app_menu/app_menu.blp:43
-msgid "_About"
+msgid "_About Folio"
 msgstr ""
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:54
-msgid "Notebook Name"
-msgstr ""
-
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:66
-msgid "Duplicate notebook names are not allowed!"
-msgstr ""
-
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:82
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:6
 msgid "First Characters"
 msgstr ""
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:83
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:7
 msgid "Initials"
 msgstr ""
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:84
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:8
 msgid "Initials: camelCase"
 msgstr ""
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:85
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:9
 msgid "Initials: snake_case"
 msgstr ""
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:86
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:10
 msgid "Icon"
 msgstr ""
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:116
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:11
+msgid "Custom"
+msgstr ""
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:16
 msgid "Notebook Color"
+msgstr ""
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:58
+msgid "Notebook Name"
+msgstr ""
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:70
+msgid "Duplicate notebook names are not allowed!"
 msgstr ""
 
 #: src/ui/window/notebooks_bar/notebook_create_popup.blp:126
@@ -751,11 +820,11 @@ msgstr ""
 msgid "Notebooks"
 msgstr ""
 
-#: src/ui/window/sidebar/note_create_popup.blp:37
+#: src/ui/window/sidebar/note_create_popup.blp:25
 msgid "Note Name"
 msgstr ""
 
-#: src/ui/window/sidebar/note_create_popup.blp:45
+#: src/ui/window/sidebar/note_create_popup.blp:33
 msgid "Create Note"
 msgstr ""
 
@@ -779,30 +848,34 @@ msgstr ""
 msgid "Open Containing Folder"
 msgstr ""
 
-#: src/ui/window/window.blp:118
+#: src/ui/window/window.blp:123
 msgid "Get started writing"
 msgstr ""
 
-#: src/ui/window/window.blp:143
+#: src/ui/window/window.blp:152
+msgid "Open file in external application"
+msgstr ""
+
+#: src/ui/window/window.blp:160
+msgid "Open file"
+msgstr ""
+
+#: src/ui/window/window.blp:181
 msgid "Create a notebook"
 msgstr ""
 
-#: src/ui/window/window.blp:168
+#: src/ui/window/window.blp:210
 msgid "Trash is empty"
 msgstr ""
 
-#: src/ui/window/window.blp:224
-msgid "Back"
-msgstr ""
-
-#: src/ui/window/window.blp:239
+#: src/ui/window/window.blp:285
 msgid "Open in Notebook"
 msgstr ""
 
-#: src/ui/window/window.blp:264
+#: src/ui/window/window.blp:312
 msgid "_Rename Note"
 msgstr ""
 
-#: src/ui/window/window.blp:270
+#: src/ui/window/window.blp:319
 msgid "_Export Note"
 msgstr ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.toolstack.Folio\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-03-24 21:02-0400\n"
+"POT-Creation-Date: 2024-10-12 16:53+0200\n"
 "PO-Revision-Date: 2024-09-11 18:13+0200\n"
 "Last-Translator: Amerey <info@amerey.eu>\n"
 "Language-Team: \n"
@@ -37,18 +37,18 @@ msgstr ""
 "Poznámka;Poznámky;Poznámkový blok;Psaní;Škola;"
 
 #: data/app.desktop.in:22 src/ui/popup/shortcut_window.blp:17
-#: src/ui/strings.vala:8 src/ui/window/window.blp:47
-#: src/ui/window/window.blp:124
+#: src/ui/strings.vala:8 src/ui/window/window.blp:54
+#: src/ui/window/window.blp:131
 msgid "New Note"
 msgstr "Nová poznámka"
 
 #: data/app.desktop.in:26 src/ui/popup/shortcut_window.blp:37
-#: src/ui/strings.vala:14 src/ui/window/window.blp:149
+#: src/ui/strings.vala:14 src/ui/window/window.blp:189
 msgid "New Notebook"
 msgstr "Nový sešit"
 
-#: data/app.desktop.in:30 src/ui/edit_view/toolbar/toolbar.blp:90
-#: src/ui/strings.vala:39 src/ui/window/window.blp:245
+#: data/app.desktop.in:30 src/ui/edit_view/toolbar/toolbar.blp:92
+#: src/ui/strings.vala:39 src/ui/window/window.blp:291
 msgid "Markdown Cheatsheet"
 msgstr "Markdown nápověda"
 
@@ -56,101 +56,101 @@ msgstr "Markdown nápověda"
 msgid "Preferences"
 msgstr "Předvolby"
 
-#: data/app.gschema.xml:6 src/ui/preferences/preferences.blp:18
+#: data/app.gschema.xml:6 src/ui/preferences/preferences.blp:45
 msgid "Note Font"
 msgstr "Poznámka: Font"
 
-#: data/app.gschema.xml:7 src/ui/preferences/preferences.blp:19
+#: data/app.gschema.xml:7 src/ui/preferences/preferences.blp:46
 msgid "The font notes will be displayed in"
 msgstr "Poznámky budou zobrazeny písmem"
 
-#: data/app.gschema.xml:11 src/ui/preferences/preferences.blp:31
+#: data/app.gschema.xml:11 src/ui/preferences/preferences.blp:58
 msgid "Monospace Font"
 msgstr "Monospace: Font"
 
-#: data/app.gschema.xml:12 src/ui/preferences/preferences.blp:32
+#: data/app.gschema.xml:12 src/ui/preferences/preferences.blp:59
 msgid "The font code will be displayed in"
 msgstr "Kód bude zobrazen písmem"
 
-#: data/app.gschema.xml:16 src/ui/preferences/preferences.blp:128
+#: data/app.gschema.xml:16 src/ui/preferences/preferences.blp:150
 msgid "Use Fixed Width For Notes"
 msgstr "Použít pevnou šířku pro poznámky"
 
-#: data/app.gschema.xml:17 src/ui/preferences/preferences.blp:129
+#: data/app.gschema.xml:17 src/ui/preferences/preferences.blp:151
 msgid "Use a fixed width for the text area of a note"
 msgstr "Pro textovou oblast poznámky použijte pevnou šířku"
 
-#: data/app.gschema.xml:21 src/ui/preferences/preferences.blp:46
+#: data/app.gschema.xml:21 src/ui/preferences/preferences.blp:18
 msgid "OLED Mode"
 msgstr "Režim OLED"
 
-#: data/app.gschema.xml:22 src/ui/preferences/preferences.blp:47
+#: data/app.gschema.xml:22 src/ui/preferences/preferences.blp:19
 msgid "Makes the dark theme pitch black"
 msgstr "Tmavé téma se změní na černé"
 
-#: data/app.gschema.xml:26 src/ui/preferences/preferences.blp:87
+#: data/app.gschema.xml:26 src/ui/preferences/preferences.blp:109
 msgid "Enable Toolbar"
 msgstr "Povolit Panel nástrojů"
 
-#: data/app.gschema.xml:27 src/ui/preferences/preferences.blp:88
+#: data/app.gschema.xml:27 src/ui/preferences/preferences.blp:110
 msgid "Displays the formatting toolbar at the bottom of the note"
 msgstr "Zobrazí panel nástrojů pro formátování v dolní části poznámky"
 
-#: data/app.gschema.xml:31 src/ui/preferences/preferences.blp:98
+#: data/app.gschema.xml:31 src/ui/preferences/preferences.blp:120
 msgid "Enable Cheatsheet"
 msgstr "Povolit nápovědu"
 
-#: data/app.gschema.xml:32 src/ui/preferences/preferences.blp:99
+#: data/app.gschema.xml:32 src/ui/preferences/preferences.blp:121
 msgid ""
 "Adds a button to the markdown reference sheet on the right of the formatting "
 "toolbar"
 msgstr "Na pravé straně panelu nástrojů přidá tlačítko s markdown nápovědou"
 
-#: data/app.gschema.xml:36 src/ui/preferences/preferences.blp:117
+#: data/app.gschema.xml:36 src/ui/preferences/preferences.blp:139
 msgid "3-Pane Layout"
 msgstr "3-panelové rozvržení"
 
-#: data/app.gschema.xml:37 src/ui/preferences/preferences.blp:118
+#: data/app.gschema.xml:37 src/ui/preferences/preferences.blp:140
 msgid "Expands the notebook list to include the notebook name"
 msgstr "Seznam zápisníků bude obsahovat i jejich jméno"
 
-#: data/app.gschema.xml:41 src/ui/preferences/preferences.blp:185
+#: data/app.gschema.xml:41 src/ui/preferences/preferences.blp:207
 msgid "Notes Storage Location"
 msgstr "Umístění úložiště poznámek"
 
-#: data/app.gschema.xml:42 src/ui/preferences/preferences.blp:186
+#: data/app.gschema.xml:42 src/ui/preferences/preferences.blp:208
 msgid "Where the notebooks are stored (requires app restart)"
 msgstr "Kde jsou uloženy zápisníky (vyžaduje restart aplikace)"
 
-#: data/app.gschema.xml:46 src/ui/preferences/preferences.blp:213
+#: data/app.gschema.xml:46 src/ui/preferences/preferences.blp:235
 msgid "Trash Storage Location"
 msgstr "Umístění koše"
 
-#: data/app.gschema.xml:47 src/ui/preferences/preferences.blp:214
+#: data/app.gschema.xml:47 src/ui/preferences/preferences.blp:236
 msgid "Where the trash folder is located (requires app restart)"
 msgstr "Kde je umístěna složka koše (vyžaduje restartování aplikace)"
 
-#: data/app.gschema.xml:51 src/ui/preferences/preferences.blp:65
+#: data/app.gschema.xml:51 src/ui/preferences/preferences.blp:87
 msgid "Show line numbers"
 msgstr "Zobrazit čísla řádků"
 
-#: data/app.gschema.xml:52 src/ui/preferences/preferences.blp:66
+#: data/app.gschema.xml:52 src/ui/preferences/preferences.blp:88
 msgid "Displays line numbers at the left of the note"
 msgstr "Zobrazí čísla řádků na levé straně poznámky"
 
-#: data/app.gschema.xml:56 src/ui/preferences/preferences.blp:76
+#: data/app.gschema.xml:56 src/ui/preferences/preferences.blp:98
 msgid "Show all notes"
 msgstr "Zobrazit všechny poznámky"
 
-#: data/app.gschema.xml:57 src/ui/preferences/preferences.blp:77
+#: data/app.gschema.xml:57 src/ui/preferences/preferences.blp:99
 msgid "Displays the \"All Notes\" notebook at the top of the notebook list"
 msgstr "Zobrazí \"Všechny poznámky\" v horní části seznamu zápisníků"
 
-#: data/app.gschema.xml:61 src/ui/preferences/preferences.blp:163
+#: data/app.gschema.xml:61 src/ui/preferences/preferences.blp:185
 msgid "Enable autosave"
 msgstr "Povolit automatické ukládání"
 
-#: data/app.gschema.xml:62 src/ui/preferences/preferences.blp:164
+#: data/app.gschema.xml:62 src/ui/preferences/preferences.blp:186
 msgid ""
 "Automatically saves the current note every 30 seconds if the contents have "
 "changed (requires app restart)"
@@ -158,7 +158,7 @@ msgstr ""
 "Automaticky uloží aktuální poznámku každých 30 sekund, pokud se obsah změnil "
 "(vyžaduje restart aplikace)"
 
-#: data/app.gschema.xml:66 src/ui/preferences/preferences.blp:174
+#: data/app.gschema.xml:66 src/ui/preferences/preferences.blp:196
 msgid "Don't hide the Trash folder"
 msgstr "Neskrývat složku Koš"
 
@@ -184,6 +184,22 @@ msgstr "Pořadí řazení sešitů"
 #: data/app.gschema.xml:77
 msgid "The sort order of the notebook list"
 msgstr "Pořadí řazení seznamu sešitů"
+
+#: data/app.gschema.xml:81
+msgid "URL detection level"
+msgstr ""
+
+#: data/app.gschema.xml:82
+msgid "How agressive to look for URLs in markdown text"
+msgstr ""
+
+#: data/app.gschema.xml:86
+msgid "Line spacing"
+msgstr ""
+
+#: data/app.gschema.xml:87 src/ui/preferences/preferences.blp:74
+msgid "The line spacing for the note text"
+msgstr ""
 
 #: data/app.metainfo.xml.in:5
 msgid "Take notes in Markdown"
@@ -217,123 +233,116 @@ msgstr "Motiv aplikace založený na barvě sešitu"
 msgid "Trash can"
 msgstr "Koš"
 
-#: data/app.metainfo.xml.in:367
+#: data/app.metainfo.xml.in:393
 msgid "Main Folio window in light mode"
 msgstr "Hlavní okno ve světlém režimu"
 
-#: data/app.metainfo.xml.in:371
+#: data/app.metainfo.xml.in:397
 msgid "Main Folio window in dark mode"
 msgstr "Hlavní okno v tmavém režimu"
 
-#: data/app.metainfo.xml.in:375
+#: data/app.metainfo.xml.in:401
 msgid "Folio on small/mobile screens"
 msgstr "Folio na malých/mobilních obrazovkách"
 
-#: data/app.metainfo.xml.in:379
+#: data/app.metainfo.xml.in:405
 msgid "Folio preferences screen"
 msgstr "Obrazovka předvoleb"
 
-#: data/app.metainfo.xml.in:383
+#: data/app.metainfo.xml.in:409
 msgid "Folio in three pane mode"
 msgstr "Folio v režimu tří panelů"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:23
-#: src/ui/edit_view/toolbar/toolbar.blp:131
+#: src/ui/edit_view/toolbar/toolbar.blp:6
 #: src/ui/widgets/markdown/heading_popover.blp:48
 msgid "Plain Text"
 msgstr "Prostý text"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:24
-#: src/ui/edit_view/toolbar/toolbar.blp:132
+#: src/ui/edit_view/toolbar/toolbar.blp:7
 #: src/ui/widgets/markdown/heading_popover.blp:12
 msgid "Heading 1"
 msgstr "Nadpis 1"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:25
-#: src/ui/edit_view/toolbar/toolbar.blp:133
+#: src/ui/edit_view/toolbar/toolbar.blp:8
 #: src/ui/widgets/markdown/heading_popover.blp:18
 msgid "Heading 2"
 msgstr "Nadpis 2"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:26
-#: src/ui/edit_view/toolbar/toolbar.blp:134
+#: src/ui/edit_view/toolbar/toolbar.blp:9
 #: src/ui/widgets/markdown/heading_popover.blp:24
 msgid "Heading 3"
 msgstr "Nadpis 3"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:27
-#: src/ui/edit_view/toolbar/toolbar.blp:135
+#: src/ui/edit_view/toolbar/toolbar.blp:10
 #: src/ui/widgets/markdown/heading_popover.blp:30
 msgid "Heading 4"
 msgstr "Nadpis 4"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:28
-#: src/ui/edit_view/toolbar/toolbar.blp:136
+#: src/ui/edit_view/toolbar/toolbar.blp:11
 #: src/ui/widgets/markdown/heading_popover.blp:36
 msgid "Heading 5"
 msgstr "Nadpis 5"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:29
-#: src/ui/edit_view/toolbar/toolbar.blp:137
+#: src/ui/edit_view/toolbar/toolbar.blp:12
 #: src/ui/widgets/markdown/heading_popover.blp:42
 msgid "Heading 6"
 msgstr "Nadpis 6"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:39
-#: src/ui/edit_view/toolbar/toolbar.blp:104
-#: src/ui/edit_view/toolbar/toolbar.blp:148
-#: src/ui/edit_view/toolbar/toolbar.blp:201 src/ui/popup/shortcut_window.blp:72
+#: src/ui/edit_view/toolbar/toolbar.blp:41
+#: src/ui/edit_view/toolbar/toolbar.blp:107
+#: src/ui/edit_view/toolbar/toolbar.blp:142
+#: src/ui/edit_view/toolbar/toolbar.blp:195 src/ui/popup/shortcut_window.blp:72
 msgid "Bold"
 msgstr "Tučné"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:45
-#: src/ui/edit_view/toolbar/toolbar.blp:111
-#: src/ui/edit_view/toolbar/toolbar.blp:155
-#: src/ui/edit_view/toolbar/toolbar.blp:202 src/ui/popup/shortcut_window.blp:77
+#: src/ui/edit_view/toolbar/toolbar.blp:47
+#: src/ui/edit_view/toolbar/toolbar.blp:114
+#: src/ui/edit_view/toolbar/toolbar.blp:149
+#: src/ui/edit_view/toolbar/toolbar.blp:196 src/ui/popup/shortcut_window.blp:77
 msgid "Italic"
 msgstr "Kurzíva"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:51
-#: src/ui/edit_view/toolbar/toolbar.blp:162
-#: src/ui/edit_view/toolbar/toolbar.blp:203 src/ui/popup/shortcut_window.blp:82
+#: src/ui/edit_view/toolbar/toolbar.blp:53
+#: src/ui/edit_view/toolbar/toolbar.blp:156
+#: src/ui/edit_view/toolbar/toolbar.blp:197 src/ui/popup/shortcut_window.blp:82
 msgid "Strikethrough"
 msgstr "Přeškrtnutí"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:57
-#: src/ui/edit_view/toolbar/toolbar.blp:169
-#: src/ui/edit_view/toolbar/toolbar.blp:204 src/ui/popup/shortcut_window.blp:87
+#: src/ui/edit_view/toolbar/toolbar.blp:59
+#: src/ui/edit_view/toolbar/toolbar.blp:163
+#: src/ui/edit_view/toolbar/toolbar.blp:198 src/ui/popup/shortcut_window.blp:87
 msgid "Highlight"
 msgstr "Zvýraznění"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:67
-#: src/ui/edit_view/toolbar/toolbar.blp:193 src/ui/popup/shortcut_window.blp:92
+#: src/ui/edit_view/toolbar/toolbar.blp:69
+#: src/ui/edit_view/toolbar/toolbar.blp:187 src/ui/popup/shortcut_window.blp:92
 msgid "Insert Link"
 msgstr "Vložit odkaz"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:73
-#: src/ui/edit_view/toolbar/toolbar.blp:194
+#: src/ui/edit_view/toolbar/toolbar.blp:75
+#: src/ui/edit_view/toolbar/toolbar.blp:188
 msgid "Insert Code"
 msgstr "Vložit kód"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:79
-#: src/ui/edit_view/toolbar/toolbar.blp:195
+#: src/ui/edit_view/toolbar/toolbar.blp:81
+#: src/ui/edit_view/toolbar/toolbar.blp:189
 msgid "Insert Horizontal Rule"
 msgstr "Vložit vodorovnou čáru"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:118
+#: src/ui/edit_view/toolbar/toolbar.blp:121
 msgid "Format"
 msgstr "Formátovat"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:181
+#: src/ui/edit_view/toolbar/toolbar.blp:175
 msgid "Insert"
 msgstr "Vložit"
 
-#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:34
+#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:18
 #: src/ui/strings.vala:44 src/ui/strings.vala:58
 msgid "Cancel"
 msgstr "Zrušit"
 
-#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:39
+#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:23
 msgid "Confirm"
 msgstr "Potvrdit"
 
@@ -377,11 +386,11 @@ msgstr "Formátování"
 msgid "Navigation"
 msgstr "Navigace"
 
-#: src/ui/popup/shortcut_window.blp:102 src/ui/window/window.blp:216
+#: src/ui/popup/shortcut_window.blp:102 src/ui/window/window.blp:268
 msgid "Toggle Sidebar"
 msgstr "Přepnout postranní panel"
 
-#: src/ui/popup/shortcut_window.blp:107 src/ui/window/window.blp:63
+#: src/ui/popup/shortcut_window.blp:107 src/ui/window/window.blp:70
 msgid "Search Notes"
 msgstr "Hledat v poznámkách"
 
@@ -401,35 +410,57 @@ msgstr "Přiblížit"
 msgid "Zoom Out"
 msgstr "Oddálit"
 
-#: src/ui/preferences/preferences.blp:59
+#: src/ui/preferences/preferences.blp:31
+#, fuzzy
+msgid "Markdown URL Detection"
+msgstr "Markdown nápověda"
+
+#: src/ui/preferences/preferences.blp:32
+msgid ""
+"Determines the level of detection of URLs in\n"
+"free form text is used:\n"
+" - Aggressive tries to find all URLs\n"
+" - Strict requires a protocol identifier (ie http://)\n"
+" - Disabled turns detection off."
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:39
+msgid "Fonts"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:73
+msgid "Line Spacing"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:81
 msgid "Tools"
 msgstr "Nástroje"
 
-#: src/ui/preferences/preferences.blp:111
+#: src/ui/preferences/preferences.blp:133
 msgid "Layout"
 msgstr "Rozložení"
 
-#: src/ui/preferences/preferences.blp:139
+#: src/ui/preferences/preferences.blp:161
 msgid "Fixed Width To Use For Notes"
 msgstr "Pevná šířka pro poznámky"
 
-#: src/ui/preferences/preferences.blp:140
+#: src/ui/preferences/preferences.blp:162
 msgid "Sets the fixed width size of a note in px"
 msgstr "Nastaví pevnou šířku poznámky v pixelech"
 
-#: src/ui/preferences/preferences.blp:145
+#: src/ui/preferences/preferences.blp:167
 msgid "Sort Order For Notebooks"
 msgstr "Řazení sešitů"
 
-#: src/ui/preferences/preferences.blp:150
+#: src/ui/preferences/preferences.blp:172
 msgid "Sort Order For Notes"
 msgstr "Řazení poznámek"
 
-#: src/ui/preferences/preferences.blp:157
+#: src/ui/preferences/preferences.blp:179
 msgid "Files"
 msgstr "Soubory"
 
-#: src/ui/preferences/preferences.blp:175
+#: src/ui/preferences/preferences.blp:197
 msgid ""
 "The trash folder is set as a hidden folder by default, this option makes it "
 "visible (requires app restart)"
@@ -451,7 +482,7 @@ msgstr "Poznámky: %d"
 msgid "Are you sure you want to delete everything in the trash?"
 msgstr "Opravdu chcete smazat vše v koši?"
 
-#: src/ui/strings.vala:7 src/ui/window/window.blp:54
+#: src/ui/strings.vala:7 src/ui/window/window.blp:61
 msgid "Empty Trash"
 msgstr "Vyprázdnit koš"
 
@@ -511,11 +542,13 @@ msgid "Delete Notebook"
 msgstr "Smazat sešit"
 
 #: src/ui/strings.vala:24
-msgid "Note name shouldn’t contain “.” or “/”"
+#, fuzzy
+msgid "Note names cannot contain a “/”"
 msgstr "Název poznámky by neměl obsahovat „.“ nebo \"/\""
 
 #: src/ui/strings.vala:25
-msgid "Note name shouldn’t be blank"
+#, fuzzy
+msgid "Note names cannot be blank"
 msgstr "Název poznámky by neměl být prázdný"
 
 #: src/ui/strings.vala:26
@@ -524,19 +557,23 @@ msgid "Note “%s” already exists"
 msgstr "Poznámka „%s“ již existuje"
 
 #: src/ui/strings.vala:27
-msgid "Couldn’t create note"
+#, fuzzy
+msgid "Could not create note"
 msgstr "Poznámku se nepodařilo vytvořit"
 
 #: src/ui/strings.vala:28
-msgid "Couldn’t change note"
+#, fuzzy
+msgid "Could not change note"
 msgstr "Poznámku se nepodařilo změnit"
 
 #: src/ui/strings.vala:29
-msgid "Couldn’t delete note"
+#, fuzzy
+msgid "Could not delete note"
 msgstr "Poznámku se nepodařilo smazat"
 
 #: src/ui/strings.vala:30
-msgid "Couldn’t restore note"
+#, fuzzy
+msgid "Could not restore note"
 msgstr "Poznámku se nepodařilo obnovit"
 
 #: src/ui/strings.vala:31
@@ -549,11 +586,13 @@ msgid "Unknown error"
 msgstr "Neznámá chyba"
 
 #: src/ui/strings.vala:33
-msgid "Notebook name shouldn’t contain “.” or “/”"
+#, fuzzy
+msgid "Notebook names cannot contain a “/”"
 msgstr "Název sešitu by neměl obsahovat „.“ nebo \"/\""
 
 #: src/ui/strings.vala:34
-msgid "Notebook name shouldn’t be blank"
+#, fuzzy
+msgid "Notebook names cannot be blank"
 msgstr "Název sešitu by neměl být prázdný"
 
 #: src/ui/strings.vala:35
@@ -562,15 +601,18 @@ msgid "Notebook “%s” already exists"
 msgstr "Sešit „%s“ již existuje"
 
 #: src/ui/strings.vala:36
-msgid "Couldn’t create notebook"
+#, fuzzy
+msgid "Could not create notebook"
 msgstr "Sešit se nepodařilo vytvořit"
 
 #: src/ui/strings.vala:37
-msgid "Couldn’t change notebook"
+#, fuzzy
+msgid "Could not change notebook"
 msgstr "Sešit se nepodařilo změnit"
 
 #: src/ui/strings.vala:38
-msgid "Couldn’t delete notebook"
+#, fuzzy
+msgid "Could not delete notebook"
 msgstr "Sešit se nepodařilo smazat"
 
 #: src/ui/strings.vala:40
@@ -582,7 +624,8 @@ msgid "Rename"
 msgstr "Přejmenovat"
 
 #: src/ui/strings.vala:42
-msgid "Couldn’t find an app to handle file URIs"
+#, fuzzy
+msgid "Could not find an app to handle file URIs"
 msgstr "Nepodařilo se najít aplikaci pro práci s identifikátory URI souborů"
 
 #: src/ui/strings.vala:43
@@ -695,6 +738,43 @@ msgstr "Abecedně – vzestupně"
 msgid "Alphabetical - Descending"
 msgstr "Abecedně - sestupně"
 
+#: src/ui/strings.vala:66
+#, fuzzy
+msgid "Natural - Ascending"
+msgstr "Abecedně – vzestupně"
+
+#: src/ui/strings.vala:67
+#, fuzzy
+msgid "Natural - Descending"
+msgstr "Abecedně - sestupně"
+
+#: src/ui/strings.vala:68
+#, c-format
+msgid "Unable to launch external application for file %s."
+msgstr ""
+
+#: src/ui/strings.vala:69
+msgid "Aggressive"
+msgstr ""
+
+#: src/ui/strings.vala:70
+msgid "Strict"
+msgstr ""
+
+#: src/ui/strings.vala:71
+msgid "Disabled"
+msgstr ""
+
+#: src/ui/strings.vala:72
+#, fuzzy, c-format
+msgid "“%s” moved to trash"
+msgstr "Přesunout do koše"
+
+#: src/ui/strings.vala:73
+#, c-format
+msgid "“%s” restored"
+msgstr ""
+
 #: src/ui/widgets/theme_selector/theme_selector.blp:15
 msgid "Follow system style"
 msgstr "Motiv systému"
@@ -724,40 +804,45 @@ msgid "_Keyboard Shortcuts"
 msgstr "_Klávesové zkratky"
 
 #: src/ui/window/app_menu/app_menu.blp:43
-msgid "_About"
+#, fuzzy
+msgid "_About Folio"
 msgstr "_O aplikaci"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:54
-msgid "Notebook Name"
-msgstr "Název sešitu"
-
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:66
-msgid "Duplicate notebook names are not allowed!"
-msgstr "Duplicitní názvy sešitů nejsou povoleny!"
-
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:82
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:6
 msgid "First Characters"
 msgstr "První znaky"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:83
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:7
 msgid "Initials"
 msgstr "Iniciály"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:84
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:8
 msgid "Initials: camelCase"
 msgstr "Iniciály: camelCase"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:85
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:9
 msgid "Initials: snake_case"
 msgstr "Iniciály: snake_case"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:86
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:10
 msgid "Icon"
 msgstr "Ikona"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:116
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:11
+msgid "Custom"
+msgstr ""
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:16
 msgid "Notebook Color"
 msgstr "Barva sešitu"
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:58
+msgid "Notebook Name"
+msgstr "Název sešitu"
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:70
+msgid "Duplicate notebook names are not allowed!"
+msgstr "Duplicitní názvy sešitů nejsou povoleny!"
 
 #: src/ui/window/notebooks_bar/notebook_create_popup.blp:126
 msgid "Create Notebook"
@@ -775,11 +860,11 @@ msgstr "Přesunout vše do koše"
 msgid "Notebooks"
 msgstr "Sešity"
 
-#: src/ui/window/sidebar/note_create_popup.blp:37
+#: src/ui/window/sidebar/note_create_popup.blp:25
 msgid "Note Name"
 msgstr "Název poznámky"
 
-#: src/ui/window/sidebar/note_create_popup.blp:45
+#: src/ui/window/sidebar/note_create_popup.blp:33
 msgid "Create Note"
 msgstr "Vytvořit poznámku"
 
@@ -803,30 +888,37 @@ msgstr "Přesunout do koše"
 msgid "Open Containing Folder"
 msgstr "Otevřít nadřazenou složku"
 
-#: src/ui/window/window.blp:118
+#: src/ui/window/window.blp:123
 msgid "Get started writing"
 msgstr "Začněte psát"
 
-#: src/ui/window/window.blp:143
+#: src/ui/window/window.blp:152
+msgid "Open file in external application"
+msgstr ""
+
+#: src/ui/window/window.blp:160
+msgid "Open file"
+msgstr ""
+
+#: src/ui/window/window.blp:181
 msgid "Create a notebook"
 msgstr "Vytvořte sešit"
 
-#: src/ui/window/window.blp:168
+#: src/ui/window/window.blp:210
 msgid "Trash is empty"
 msgstr "Koš je prázdný"
 
-#: src/ui/window/window.blp:224
-msgid "Back"
-msgstr "Zpět"
-
-#: src/ui/window/window.blp:239
+#: src/ui/window/window.blp:285
 msgid "Open in Notebook"
 msgstr "Otevřít v sešitu"
 
-#: src/ui/window/window.blp:264
+#: src/ui/window/window.blp:312
 msgid "_Rename Note"
 msgstr "_Přejmenovat poznámku"
 
-#: src/ui/window/window.blp:270
+#: src/ui/window/window.blp:319
 msgid "_Export Note"
 msgstr "_Exportovat poznámku"
+
+#~ msgid "Back"
+#~ msgstr "Zpět"

--- a/po/de.po
+++ b/po/de.po
@@ -2,229 +2,16 @@
 # This file is distributed under the same license as the Folio package.
 msgid ""
 msgstr ""
+"Project-Id-Version: Folio\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-10-12 16:53+0200\n"
 "PO-Revision-Date: 2024-03-25 15:26:26+0000\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: GlotPress/4.0.0\n"
-"Language: de\n"
-"Project-Id-Version: Folio\n"
-
-#: data/app.gschema.xml:76
-msgid "Notebook sort order"
-msgstr "Sortierreihenfolge der Notizbücher"
-
-#: data/app.gschema.xml:77
-msgid "The sort order of the notebook list"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:145
-msgid "Sort Order For Notebooks"
-msgstr ""
-
-#: data/app.gschema.xml:71
-msgid "Note sort order"
-msgstr ""
-
-#: data/app.gschema.xml:72
-msgid "The sort order of the note list"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:150
-msgid "Sort Order For Notes"
-msgstr ""
-
-#: src/ui/strings.vala:62
-msgid "Modified Time - Ascending"
-msgstr ""
-
-#: src/ui/strings.vala:63
-msgid "Modified Time - Descending"
-msgstr ""
-
-#: src/ui/strings.vala:64
-msgid "Alphabetical - Ascending"
-msgstr ""
-
-#: src/ui/strings.vala:65
-msgid "Alphabetical - Descending"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:114
-msgid "Display"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:117
-msgid "Full Screen"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:122
-msgid "Zoom In"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:127
-msgid "Zoom Out"
-msgstr ""
-
-#: src/ui/strings.vala:52
-msgid "Pick primary font for notes"
-msgstr ""
-
-#: src/ui/strings.vala:53
-msgid "Pick monospace font for code"
-msgstr ""
-
-#: src/ui/strings.vala:54
-msgid "File Changed On Disk"
-msgstr ""
-
-#: src/ui/strings.vala:55
-msgid ""
-"The file has changed on disk since it was last saved/loaded by Folio.\n"
-"\n"
-"You may do one of the following:\n"
-"\n"
-" • Reload the file (discarding any changes you have made in Folio)\n"
-" • Overwrite the file (discarding any changes made outside of Folio)\n"
-" • Cancel the operation and manually resolve the issue\n"
-"\n"
-"Note: Canceling the save if you have already moved to a new note/notebook will discard your changes."
-msgstr ""
-
-#: src/ui/strings.vala:56
-msgid "Reload"
-msgstr ""
-
-#: src/ui/strings.vala:57
-msgid "Overwrite"
-msgstr ""
-
-#: src/ui/strings.vala:59
-msgid ""
-"The file has changed on disk by another application.\n"
-"\n"
-"You may do one of the following:\n"
-"\n"
-" • Reload the file (discarding any changes you have made in Folio)\n"
-" • Overwrite the file (discarding any changes made outside of Folio)"
-msgstr ""
-
-#: src/ui/strings.vala:61
-msgid "Note %i"
-msgstr ""
-
-#: data/app.gschema.xml:46 src/ui/preferences/preferences.blp:213
-msgid "Trash Storage Location"
-msgstr ""
-
-#: data/app.gschema.xml:47 src/ui/preferences/preferences.blp:214
-msgid "Where the trash folder is located (requires app restart)"
-msgstr ""
-
-#: src/ui/strings.vala:46
-msgid "Pick where the trash can will be stored"
-msgstr ""
-
-#: data/app.gschema.xml:16 src/ui/preferences/preferences.blp:128
-msgid "Use Fixed Width For Notes"
-msgstr ""
-
-#: data/app.gschema.xml:17 src/ui/preferences/preferences.blp:129
-msgid "Use a fixed width for the text area of a note"
-msgstr ""
-
-#: data/app.gschema.xml:37 src/ui/preferences/preferences.blp:118
-msgid "Expands the notebook list to include the notebook name"
-msgstr ""
-
-#: data/app.gschema.xml:51 src/ui/preferences/preferences.blp:65
-msgid "Show line numbers"
-msgstr ""
-
-#: data/app.gschema.xml:52 src/ui/preferences/preferences.blp:66
-msgid "Displays line numbers at the left of the note"
-msgstr ""
-
-#: data/app.gschema.xml:56 src/ui/preferences/preferences.blp:76
-msgid "Show all notes"
-msgstr ""
-
-#: data/app.gschema.xml:57 src/ui/preferences/preferences.blp:77
-msgid "Displays the \"All Notes\" notebook at the top of the notebook list"
-msgstr ""
-
-#: data/app.gschema.xml:61 src/ui/preferences/preferences.blp:163
-msgid "Enable autosave"
-msgstr ""
-
-#: data/app.gschema.xml:62 src/ui/preferences/preferences.blp:164
-msgid "Automatically saves the current note every 30 seconds if the contents have changed (requires app restart)"
-msgstr ""
-
-#: data/app.gschema.xml:66 src/ui/preferences/preferences.blp:174
-msgid "Don't hide the Trash folder"
-msgstr ""
-
-#: data/app.gschema.xml:67
-msgid "The trash folder is set as a hidden folder by default, this option makes it visible"
-msgstr ""
-
-#: data/app.metainfo.xml.in:367
-msgid "Main Folio window in light mode"
-msgstr ""
-
-#: data/app.metainfo.xml.in:371
-msgid "Main Folio window in dark mode"
-msgstr ""
-
-#: data/app.metainfo.xml.in:375
-msgid "Folio on small/mobile screens"
-msgstr ""
-
-#: data/app.metainfo.xml.in:379
-msgid "Folio preferences screen"
-msgstr ""
-
-#: data/app.metainfo.xml.in:383
-msgid "Folio in three pane mode"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:59
-msgid "Tools"
-msgstr ""
-
-#: data/app.gschema.xml:27 src/ui/preferences/preferences.blp:88
-msgid "Displays the formatting toolbar at the bottom of the note"
-msgstr ""
-
-#: data/app.gschema.xml:32 src/ui/preferences/preferences.blp:99
-msgid "Adds a button to the markdown reference sheet on the right of the formatting toolbar"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:111
-msgid "Layout"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:139
-msgid "Fixed Width To Use For Notes"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:140
-msgid "Sets the fixed width size of a note in px"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:157
-msgid "Files"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:175
-msgid "The trash folder is set as a hidden folder by default, this option makes it visible (requires app restart)"
-msgstr ""
-
-#: src/ui/strings.vala:51
-msgid "Unable to recognize URI"
-msgstr ""
 
 #: data/app.desktop.in:9 src/ui/strings.vala:3
 msgid "Folio"
@@ -240,21 +27,23 @@ msgstr "Notizen machen"
 
 #: data/app.desktop.in:13
 msgid "Notebook;Note;Notes;Text;Markdown;Notepad;Write;School;Post-it;Sticky;"
-msgstr "Notizbuch;Notizen;Erinnerungen;Text;Markdown;Notizblock;Schreiben;Schule;Post-It;Notizzettel"
+msgstr ""
+"Notizbuch;Notizen;Erinnerungen;Text;Markdown;Notizblock;Schreiben;Schule;"
+"Post-It;Notizzettel"
 
 #: data/app.desktop.in:22 src/ui/popup/shortcut_window.blp:17
-#: src/ui/strings.vala:8 src/ui/window/window.blp:47
-#: src/ui/window/window.blp:124
+#: src/ui/strings.vala:8 src/ui/window/window.blp:54
+#: src/ui/window/window.blp:131
 msgid "New Note"
 msgstr "Neue Notiz"
 
 #: data/app.desktop.in:26 src/ui/popup/shortcut_window.blp:37
-#: src/ui/strings.vala:14 src/ui/window/window.blp:149
+#: src/ui/strings.vala:14 src/ui/window/window.blp:189
 msgid "New Notebook"
 msgstr "Neues Notizbuch"
 
-#: data/app.desktop.in:30 src/ui/edit_view/toolbar/toolbar.blp:90
-#: src/ui/strings.vala:39 src/ui/window/window.blp:245
+#: data/app.desktop.in:30 src/ui/edit_view/toolbar/toolbar.blp:92
+#: src/ui/strings.vala:39 src/ui/window/window.blp:291
 msgid "Markdown Cheatsheet"
 msgstr "Markdown-Referenz"
 
@@ -262,25 +51,147 @@ msgstr "Markdown-Referenz"
 msgid "Preferences"
 msgstr "Einstellungen"
 
-#: data/app.gschema.xml:6 src/ui/preferences/preferences.blp:18
+#: data/app.gschema.xml:6 src/ui/preferences/preferences.blp:45
 msgid "Note Font"
 msgstr "Notizschriftart"
 
-#: data/app.gschema.xml:7 src/ui/preferences/preferences.blp:19
+#: data/app.gschema.xml:7 src/ui/preferences/preferences.blp:46
 msgid "The font notes will be displayed in"
 msgstr "Die Schriftart, in der Notizen dargestellt werden"
 
-#: data/app.gschema.xml:11 src/ui/preferences/preferences.blp:31
+#: data/app.gschema.xml:11 src/ui/preferences/preferences.blp:58
 msgid "Monospace Font"
 msgstr "Monospace-Schriftart"
 
-#: data/app.gschema.xml:12 src/ui/preferences/preferences.blp:32
+#: data/app.gschema.xml:12 src/ui/preferences/preferences.blp:59
 msgid "The font code will be displayed in"
 msgstr "Die Schriftart, in der Code dargestellt werden"
 
-#: data/app.gschema.xml:21 src/ui/preferences/preferences.blp:46
+#: data/app.gschema.xml:16 src/ui/preferences/preferences.blp:150
+msgid "Use Fixed Width For Notes"
+msgstr ""
+
+#: data/app.gschema.xml:17 src/ui/preferences/preferences.blp:151
+msgid "Use a fixed width for the text area of a note"
+msgstr ""
+
+#: data/app.gschema.xml:21 src/ui/preferences/preferences.blp:18
 msgid "OLED Mode"
 msgstr "OLED-Modus"
+
+#: data/app.gschema.xml:22 src/ui/preferences/preferences.blp:19
+msgid "Makes the dark theme pitch black"
+msgstr "Macht das dunkle Thema tiefschwarz"
+
+#: data/app.gschema.xml:26 src/ui/preferences/preferences.blp:109
+msgid "Enable Toolbar"
+msgstr "Werkzeugleiste aktivieren"
+
+#: data/app.gschema.xml:27 src/ui/preferences/preferences.blp:110
+msgid "Displays the formatting toolbar at the bottom of the note"
+msgstr ""
+
+#: data/app.gschema.xml:31 src/ui/preferences/preferences.blp:120
+msgid "Enable Cheatsheet"
+msgstr ""
+
+#: data/app.gschema.xml:32 src/ui/preferences/preferences.blp:121
+msgid ""
+"Adds a button to the markdown reference sheet on the right of the formatting "
+"toolbar"
+msgstr ""
+
+#: data/app.gschema.xml:36 src/ui/preferences/preferences.blp:139
+msgid "3-Pane Layout"
+msgstr "3-Leisten-Anordnung"
+
+#: data/app.gschema.xml:37 src/ui/preferences/preferences.blp:140
+msgid "Expands the notebook list to include the notebook name"
+msgstr ""
+
+#: data/app.gschema.xml:41 src/ui/preferences/preferences.blp:207
+msgid "Notes Storage Location"
+msgstr "Speicherort der Notizen"
+
+#: data/app.gschema.xml:42 src/ui/preferences/preferences.blp:208
+msgid "Where the notebooks are stored (requires app restart)"
+msgstr "Wo die Notizbücher gespeichert sind (erfordert Neustart des Programms)"
+
+#: data/app.gschema.xml:46 src/ui/preferences/preferences.blp:235
+msgid "Trash Storage Location"
+msgstr ""
+
+#: data/app.gschema.xml:47 src/ui/preferences/preferences.blp:236
+msgid "Where the trash folder is located (requires app restart)"
+msgstr ""
+
+#: data/app.gschema.xml:51 src/ui/preferences/preferences.blp:87
+msgid "Show line numbers"
+msgstr ""
+
+#: data/app.gschema.xml:52 src/ui/preferences/preferences.blp:88
+msgid "Displays line numbers at the left of the note"
+msgstr ""
+
+#: data/app.gschema.xml:56 src/ui/preferences/preferences.blp:98
+msgid "Show all notes"
+msgstr ""
+
+#: data/app.gschema.xml:57 src/ui/preferences/preferences.blp:99
+msgid "Displays the \"All Notes\" notebook at the top of the notebook list"
+msgstr ""
+
+#: data/app.gschema.xml:61 src/ui/preferences/preferences.blp:185
+msgid "Enable autosave"
+msgstr ""
+
+#: data/app.gschema.xml:62 src/ui/preferences/preferences.blp:186
+msgid ""
+"Automatically saves the current note every 30 seconds if the contents have "
+"changed (requires app restart)"
+msgstr ""
+
+#: data/app.gschema.xml:66 src/ui/preferences/preferences.blp:196
+msgid "Don't hide the Trash folder"
+msgstr ""
+
+#: data/app.gschema.xml:67
+msgid ""
+"The trash folder is set as a hidden folder by default, this option makes it "
+"visible"
+msgstr ""
+
+#: data/app.gschema.xml:71
+msgid "Note sort order"
+msgstr ""
+
+#: data/app.gschema.xml:72
+msgid "The sort order of the note list"
+msgstr ""
+
+#: data/app.gschema.xml:76
+msgid "Notebook sort order"
+msgstr "Sortierreihenfolge der Notizbücher"
+
+#: data/app.gschema.xml:77
+msgid "The sort order of the notebook list"
+msgstr ""
+
+#: data/app.gschema.xml:81
+msgid "URL detection level"
+msgstr ""
+
+#: data/app.gschema.xml:82
+msgid "How agressive to look for URLs in markdown text"
+msgstr ""
+
+#: data/app.gschema.xml:86
+msgid "Line spacing"
+msgstr ""
+
+#: data/app.gschema.xml:87 src/ui/preferences/preferences.blp:74
+msgid "The line spacing for the note text"
+msgstr ""
 
 #: data/app.metainfo.xml.in:5
 msgid "Take notes in Markdown"
@@ -314,103 +225,116 @@ msgstr ""
 msgid "Trash can"
 msgstr "Papierkorb"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:23
-#: src/ui/edit_view/toolbar/toolbar.blp:131
+#: data/app.metainfo.xml.in:393
+msgid "Main Folio window in light mode"
+msgstr ""
+
+#: data/app.metainfo.xml.in:397
+msgid "Main Folio window in dark mode"
+msgstr ""
+
+#: data/app.metainfo.xml.in:401
+msgid "Folio on small/mobile screens"
+msgstr ""
+
+#: data/app.metainfo.xml.in:405
+msgid "Folio preferences screen"
+msgstr ""
+
+#: data/app.metainfo.xml.in:409
+msgid "Folio in three pane mode"
+msgstr ""
+
+#: src/ui/edit_view/toolbar/toolbar.blp:6
 #: src/ui/widgets/markdown/heading_popover.blp:48
 msgid "Plain Text"
 msgstr "Reiner Text"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:24
-#: src/ui/edit_view/toolbar/toolbar.blp:132
+#: src/ui/edit_view/toolbar/toolbar.blp:7
 #: src/ui/widgets/markdown/heading_popover.blp:12
 msgid "Heading 1"
 msgstr "Überschrift 1"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:25
-#: src/ui/edit_view/toolbar/toolbar.blp:133
+#: src/ui/edit_view/toolbar/toolbar.blp:8
 #: src/ui/widgets/markdown/heading_popover.blp:18
 msgid "Heading 2"
 msgstr "Überschrift 2"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:26
-#: src/ui/edit_view/toolbar/toolbar.blp:134
+#: src/ui/edit_view/toolbar/toolbar.blp:9
 #: src/ui/widgets/markdown/heading_popover.blp:24
 msgid "Heading 3"
 msgstr "Überschrift 3"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:27
-#: src/ui/edit_view/toolbar/toolbar.blp:135
+#: src/ui/edit_view/toolbar/toolbar.blp:10
 #: src/ui/widgets/markdown/heading_popover.blp:30
 msgid "Heading 4"
 msgstr "Überschrift 4"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:28
-#: src/ui/edit_view/toolbar/toolbar.blp:136
+#: src/ui/edit_view/toolbar/toolbar.blp:11
 #: src/ui/widgets/markdown/heading_popover.blp:36
 msgid "Heading 5"
 msgstr "Überschrift 5"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:29
-#: src/ui/edit_view/toolbar/toolbar.blp:137
+#: src/ui/edit_view/toolbar/toolbar.blp:12
 #: src/ui/widgets/markdown/heading_popover.blp:42
 msgid "Heading 6"
 msgstr "Überschrift 6"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:39
-#: src/ui/edit_view/toolbar/toolbar.blp:104
-#: src/ui/edit_view/toolbar/toolbar.blp:148
-#: src/ui/edit_view/toolbar/toolbar.blp:201 src/ui/popup/shortcut_window.blp:72
+#: src/ui/edit_view/toolbar/toolbar.blp:41
+#: src/ui/edit_view/toolbar/toolbar.blp:107
+#: src/ui/edit_view/toolbar/toolbar.blp:142
+#: src/ui/edit_view/toolbar/toolbar.blp:195 src/ui/popup/shortcut_window.blp:72
 msgid "Bold"
 msgstr "Fett"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:45
-#: src/ui/edit_view/toolbar/toolbar.blp:111
-#: src/ui/edit_view/toolbar/toolbar.blp:155
-#: src/ui/edit_view/toolbar/toolbar.blp:202 src/ui/popup/shortcut_window.blp:77
+#: src/ui/edit_view/toolbar/toolbar.blp:47
+#: src/ui/edit_view/toolbar/toolbar.blp:114
+#: src/ui/edit_view/toolbar/toolbar.blp:149
+#: src/ui/edit_view/toolbar/toolbar.blp:196 src/ui/popup/shortcut_window.blp:77
 msgid "Italic"
 msgstr "Kursiv"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:51
-#: src/ui/edit_view/toolbar/toolbar.blp:162
-#: src/ui/edit_view/toolbar/toolbar.blp:203 src/ui/popup/shortcut_window.blp:82
+#: src/ui/edit_view/toolbar/toolbar.blp:53
+#: src/ui/edit_view/toolbar/toolbar.blp:156
+#: src/ui/edit_view/toolbar/toolbar.blp:197 src/ui/popup/shortcut_window.blp:82
 msgid "Strikethrough"
 msgstr "Durchgestrichen"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:57
-#: src/ui/edit_view/toolbar/toolbar.blp:169
-#: src/ui/edit_view/toolbar/toolbar.blp:204 src/ui/popup/shortcut_window.blp:87
+#: src/ui/edit_view/toolbar/toolbar.blp:59
+#: src/ui/edit_view/toolbar/toolbar.blp:163
+#: src/ui/edit_view/toolbar/toolbar.blp:198 src/ui/popup/shortcut_window.blp:87
 msgid "Highlight"
 msgstr "Hervorheben"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:67
-#: src/ui/edit_view/toolbar/toolbar.blp:193 src/ui/popup/shortcut_window.blp:92
+#: src/ui/edit_view/toolbar/toolbar.blp:69
+#: src/ui/edit_view/toolbar/toolbar.blp:187 src/ui/popup/shortcut_window.blp:92
 msgid "Insert Link"
 msgstr "Verweis einfügen"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:73
-#: src/ui/edit_view/toolbar/toolbar.blp:194
+#: src/ui/edit_view/toolbar/toolbar.blp:75
+#: src/ui/edit_view/toolbar/toolbar.blp:188
 msgid "Insert Code"
 msgstr "Code einfügen"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:79
-#: src/ui/edit_view/toolbar/toolbar.blp:195
+#: src/ui/edit_view/toolbar/toolbar.blp:81
+#: src/ui/edit_view/toolbar/toolbar.blp:189
 msgid "Insert Horizontal Rule"
 msgstr "Horizontale Linie einfügen"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:118
+#: src/ui/edit_view/toolbar/toolbar.blp:121
 msgid "Format"
 msgstr "Format"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:181
+#: src/ui/edit_view/toolbar/toolbar.blp:175
 msgid "Insert"
 msgstr "Einfg"
 
-#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:34
+#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:18
 #: src/ui/strings.vala:44 src/ui/strings.vala:58
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:39
+#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:23
 msgid "Confirm"
 msgstr "Bestätigen"
 
@@ -454,37 +378,85 @@ msgstr "Formatierung"
 msgid "Navigation"
 msgstr "Navigation"
 
-#: src/ui/popup/shortcut_window.blp:102 src/ui/window/window.blp:216
+#: src/ui/popup/shortcut_window.blp:102 src/ui/window/window.blp:268
 msgid "Toggle Sidebar"
 msgstr "Seitenleiste ein-/ausblenden"
 
-#: src/ui/popup/shortcut_window.blp:107 src/ui/window/window.blp:63
+#: src/ui/popup/shortcut_window.blp:107 src/ui/window/window.blp:70
 msgid "Search Notes"
 msgstr "Notizen durchsuchen"
 
-#: data/app.gschema.xml:22 src/ui/preferences/preferences.blp:47
-msgid "Makes the dark theme pitch black"
-msgstr "Macht das dunkle Thema tiefschwarz"
-
-#: data/app.gschema.xml:26 src/ui/preferences/preferences.blp:87
-msgid "Enable Toolbar"
-msgstr "Werkzeugleiste aktivieren"
-
-#: data/app.gschema.xml:31 src/ui/preferences/preferences.blp:98
-msgid "Enable Cheatsheet"
+#: src/ui/popup/shortcut_window.blp:114
+msgid "Display"
 msgstr ""
 
-#: data/app.gschema.xml:36 src/ui/preferences/preferences.blp:117
-msgid "3-Pane Layout"
-msgstr "3-Leisten-Anordnung"
+#: src/ui/popup/shortcut_window.blp:117
+msgid "Full Screen"
+msgstr ""
 
-#: data/app.gschema.xml:41 src/ui/preferences/preferences.blp:185
-msgid "Notes Storage Location"
-msgstr "Speicherort der Notizen"
+#: src/ui/popup/shortcut_window.blp:122
+msgid "Zoom In"
+msgstr ""
 
-#: data/app.gschema.xml:42 src/ui/preferences/preferences.blp:186
-msgid "Where the notebooks are stored (requires app restart)"
-msgstr "Wo die Notizbücher gespeichert sind (erfordert Neustart des Programms)"
+#: src/ui/popup/shortcut_window.blp:127
+msgid "Zoom Out"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:31
+#, fuzzy
+msgid "Markdown URL Detection"
+msgstr "Markdown-Referenz"
+
+#: src/ui/preferences/preferences.blp:32
+msgid ""
+"Determines the level of detection of URLs in\n"
+"free form text is used:\n"
+" - Aggressive tries to find all URLs\n"
+" - Strict requires a protocol identifier (ie http://)\n"
+" - Disabled turns detection off."
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:39
+msgid "Fonts"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:73
+msgid "Line Spacing"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:81
+msgid "Tools"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:133
+msgid "Layout"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:161
+msgid "Fixed Width To Use For Notes"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:162
+msgid "Sets the fixed width size of a note in px"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:167
+msgid "Sort Order For Notebooks"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:172
+msgid "Sort Order For Notes"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:179
+msgid "Files"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:197
+msgid ""
+"The trash folder is set as a hidden folder by default, this option makes it "
+"visible (requires app restart)"
+msgstr ""
 
 #: src/ui/strings.vala:4 src/ui/window/notebooks_bar/notebooks_bar.blp:129
 #: src/ui/window/notebooks_bar/notebooks_bar.blp:171
@@ -492,6 +464,7 @@ msgid "Trash"
 msgstr "Papierkorb"
 
 #: src/ui/strings.vala:5
+#, c-format
 msgid "%d Notes"
 msgstr "%d Notizen"
 
@@ -499,7 +472,7 @@ msgstr "%d Notizen"
 msgid "Are you sure you want to delete everything in the trash?"
 msgstr "Sind Sie sicher, dass Sie alles im Papierkorb löschen wollen?"
 
-#: src/ui/strings.vala:7 src/ui/window/window.blp:54
+#: src/ui/strings.vala:7 src/ui/window/window.blp:61
 msgid "Empty Trash"
 msgstr "Papierkorb leeren"
 
@@ -536,10 +509,12 @@ msgid "Move"
 msgstr "Verschieben"
 
 #: src/ui/strings.vala:18
+#, c-format
 msgid "Note “%s” already exists in notebook “%s”"
 msgstr "Notiz »%s« existiert bereits in Notizbuch »%s«"
 
 #: src/ui/strings.vala:19
+#, c-format
 msgid "Are you sure you want to delete the note “%s”?"
 msgstr "Sind Sie sicher, dass Sie die Notiz »%s« löschen wollen?"
 
@@ -548,6 +523,7 @@ msgid "Delete Note"
 msgstr "Notiz löschen"
 
 #: src/ui/strings.vala:21
+#, c-format
 msgid "Are you sure you want to delete the notebook “%s”?"
 msgstr "Sind Sie sicher, dass Sie das Notizbuch »%s« löschen wollen?"
 
@@ -556,34 +532,42 @@ msgid "Delete Notebook"
 msgstr "Notizbuch löschen"
 
 #: src/ui/strings.vala:24
-msgid "Note name shouldn’t contain “.” or “/”"
+#, fuzzy
+msgid "Note names cannot contain a “/”"
 msgstr "Notizname sollte kein ».« oder »/« enthalten"
 
 #: src/ui/strings.vala:25
-msgid "Note name shouldn’t be blank"
+#, fuzzy
+msgid "Note names cannot be blank"
 msgstr "Notizname sollte nicht leer sein"
 
 #: src/ui/strings.vala:26
+#, c-format
 msgid "Note “%s” already exists"
 msgstr "Notiz »%s« existiert bereits"
 
 #: src/ui/strings.vala:27
-msgid "Couldn’t create note"
+#, fuzzy
+msgid "Could not create note"
 msgstr "Notiz konnte nicht erstellt werden"
 
 #: src/ui/strings.vala:28
-msgid "Couldn’t change note"
+#, fuzzy
+msgid "Could not change note"
 msgstr "Notiz konnte nicht geändert werden"
 
 #: src/ui/strings.vala:29
-msgid "Couldn’t delete note"
+#, fuzzy
+msgid "Could not delete note"
 msgstr "Notiz konnte nicht gelöscht werden"
 
 #: src/ui/strings.vala:30
-msgid "Couldn’t restore note"
+#, fuzzy
+msgid "Could not restore note"
 msgstr "Notiz konnte nicht wiederhergestellt werden"
 
 #: src/ui/strings.vala:31
+#, c-format
 msgid "Saved “%s” to “%s”"
 msgstr "»%s« wurde nach »%s« gespeichert"
 
@@ -592,27 +576,33 @@ msgid "Unknown error"
 msgstr "Unbekannter Fehler"
 
 #: src/ui/strings.vala:33
-msgid "Notebook name shouldn’t contain “.” or “/”"
+#, fuzzy
+msgid "Notebook names cannot contain a “/”"
 msgstr "Notizbuchname sollte kein ».« oder »/« enthalten"
 
 #: src/ui/strings.vala:34
-msgid "Notebook name shouldn’t be blank"
+#, fuzzy
+msgid "Notebook names cannot be blank"
 msgstr "Notizbuchname sollte nicht leer sein"
 
 #: src/ui/strings.vala:35
+#, c-format
 msgid "Notebook “%s” already exists"
 msgstr "Notizbuch »%s« existiert bereits"
 
 #: src/ui/strings.vala:36
-msgid "Couldn’t create notebook"
+#, fuzzy
+msgid "Could not create notebook"
 msgstr "Notizbuch konnte nicht erstellt werden"
 
 #: src/ui/strings.vala:37
-msgid "Couldn’t change notebook"
+#, fuzzy
+msgid "Could not change notebook"
 msgstr "Notizbuch konnte nicht geändert werden"
 
 #: src/ui/strings.vala:38
-msgid "Couldn’t delete notebook"
+#, fuzzy
+msgid "Could not delete notebook"
 msgstr "Notizbuch konnte nicht gelöscht werden"
 
 #: src/ui/strings.vala:40
@@ -624,7 +614,7 @@ msgid "Rename"
 msgstr "Umbenennen"
 
 #: src/ui/strings.vala:42
-msgid "Couldn’t find an app to handle file URIs"
+msgid "Could not find an app to handle file URIs"
 msgstr ""
 
 #: src/ui/strings.vala:43
@@ -634,6 +624,10 @@ msgstr "Anwenden"
 #: src/ui/strings.vala:45
 msgid "Pick where the notebooks will be stored"
 msgstr "Wählen Sie, wo die Notizbücher gespeichert werden"
+
+#: src/ui/strings.vala:46
+msgid "Pick where the trash can will be stored"
+msgstr ""
 
 #: src/ui/strings.vala:47 src/ui/window/notebooks_bar/notebooks_bar.blp:59
 #: src/ui/window/notebooks_bar/notebooks_bar.blp:101
@@ -646,6 +640,110 @@ msgstr ""
 
 #: src/ui/strings.vala:50
 msgid "Extension"
+msgstr ""
+
+#: src/ui/strings.vala:51
+msgid "Unable to recognize URI"
+msgstr ""
+
+#: src/ui/strings.vala:52
+msgid "Pick primary font for notes"
+msgstr ""
+
+#: src/ui/strings.vala:53
+msgid "Pick monospace font for code"
+msgstr ""
+
+#: src/ui/strings.vala:54
+msgid "File Changed On Disk"
+msgstr ""
+
+#: src/ui/strings.vala:55
+msgid ""
+"The file has changed on disk since it was last saved/loaded by Folio.\n"
+"\n"
+"You may do one of the following:\n"
+"\n"
+" • Reload the file (discarding any changes you have made in Folio)\n"
+" • Overwrite the file (discarding any changes made outside of Folio)\n"
+" • Cancel the operation and manually resolve the issue\n"
+"\n"
+"Note: Canceling the save if you have already moved to a new note/notebook "
+"will discard your changes."
+msgstr ""
+
+#: src/ui/strings.vala:56
+msgid "Reload"
+msgstr ""
+
+#: src/ui/strings.vala:57
+msgid "Overwrite"
+msgstr ""
+
+#: src/ui/strings.vala:59
+msgid ""
+"The file has changed on disk by another application.\n"
+"\n"
+"You may do one of the following:\n"
+"\n"
+" • Reload the file (discarding any changes you have made in Folio)\n"
+" • Overwrite the file (discarding any changes made outside of Folio)"
+msgstr ""
+
+#: src/ui/strings.vala:61
+#, c-format
+msgid "Note %i"
+msgstr ""
+
+#: src/ui/strings.vala:62
+msgid "Modified Time - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:63
+msgid "Modified Time - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:64
+msgid "Alphabetical - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:65
+msgid "Alphabetical - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:66
+msgid "Natural - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:67
+msgid "Natural - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:68
+#, c-format
+msgid "Unable to launch external application for file %s."
+msgstr ""
+
+#: src/ui/strings.vala:69
+msgid "Aggressive"
+msgstr ""
+
+#: src/ui/strings.vala:70
+msgid "Strict"
+msgstr ""
+
+#: src/ui/strings.vala:71
+msgid "Disabled"
+msgstr ""
+
+#: src/ui/strings.vala:72
+#, fuzzy, c-format
+msgid "“%s” moved to trash"
+msgstr "In den Papierkorb verschieben"
+
+#: src/ui/strings.vala:73
+#, c-format
+msgid "“%s” restored"
 msgstr ""
 
 #: src/ui/widgets/theme_selector/theme_selector.blp:15
@@ -677,40 +775,45 @@ msgid "_Keyboard Shortcuts"
 msgstr "_Tastenkombinationen"
 
 #: src/ui/window/app_menu/app_menu.blp:43
-msgid "_About"
+#, fuzzy
+msgid "_About Folio"
 msgstr "_Info"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:54
-msgid "Notebook Name"
-msgstr "Notizbuchname"
-
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:66
-msgid "Duplicate notebook names are not allowed!"
-msgstr ""
-
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:82
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:6
 msgid "First Characters"
 msgstr "Anfangsbuchstaben"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:83
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:7
 msgid "Initials"
 msgstr "Initialen"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:84
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:8
 msgid "Initials: camelCase"
 msgstr "Initialen: camelCase"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:85
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:9
 msgid "Initials: snake_case"
 msgstr "Initialen: snake_case"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:86
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:10
 msgid "Icon"
 msgstr "Symbol"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:116
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:11
+msgid "Custom"
+msgstr ""
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:16
 msgid "Notebook Color"
 msgstr "Notizbuchfarbe"
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:58
+msgid "Notebook Name"
+msgstr "Notizbuchname"
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:70
+msgid "Duplicate notebook names are not allowed!"
+msgstr ""
 
 #: src/ui/window/notebooks_bar/notebook_create_popup.blp:126
 msgid "Create Notebook"
@@ -728,11 +831,11 @@ msgstr "Alles in den Papierkorb verschieben"
 msgid "Notebooks"
 msgstr "Notizbücher"
 
-#: src/ui/window/sidebar/note_create_popup.blp:37
+#: src/ui/window/sidebar/note_create_popup.blp:25
 msgid "Note Name"
 msgstr "Notizname"
 
-#: src/ui/window/sidebar/note_create_popup.blp:45
+#: src/ui/window/sidebar/note_create_popup.blp:33
 msgid "Create Note"
 msgstr "Notiz erstellen"
 
@@ -756,30 +859,37 @@ msgstr "In den Papierkorb verschieben"
 msgid "Open Containing Folder"
 msgstr "Den beinhaltenden Ordner öffnen"
 
-#: src/ui/window/window.blp:118
+#: src/ui/window/window.blp:123
 msgid "Get started writing"
 msgstr "Beginnen Sie mit dem Schreiben"
 
-#: src/ui/window/window.blp:143
+#: src/ui/window/window.blp:152
+msgid "Open file in external application"
+msgstr ""
+
+#: src/ui/window/window.blp:160
+msgid "Open file"
+msgstr ""
+
+#: src/ui/window/window.blp:181
 msgid "Create a notebook"
 msgstr "Ein Notizbuch erstellen"
 
-#: src/ui/window/window.blp:168
+#: src/ui/window/window.blp:210
 msgid "Trash is empty"
 msgstr "Der Papierkorb ist leer"
 
-#: src/ui/window/window.blp:224
-msgid "Back"
-msgstr "Zurück"
-
-#: src/ui/window/window.blp:239
+#: src/ui/window/window.blp:285
 msgid "Open in Notebook"
 msgstr "In Notizbuch öffnen"
 
-#: src/ui/window/window.blp:264
+#: src/ui/window/window.blp:312
 msgid "_Rename Note"
 msgstr "Notiz _umbenennen"
 
-#: src/ui/window/window.blp:270
+#: src/ui/window/window.blp:319
 msgid "_Export Note"
 msgstr "Notiz ex_portieren"
+
+#~ msgid "Back"
+#~ msgstr "Zurück"

--- a/po/es.po
+++ b/po/es.po
@@ -2,229 +2,16 @@
 # This file is distributed under the same license as the Folio package.
 msgid ""
 msgstr ""
+"Project-Id-Version: Folio\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-10-12 16:53+0200\n"
 "PO-Revision-Date: 2024-07-05 01:50:29+0000\n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: GlotPress/4.0.1\n"
-"Language: es\n"
-"Project-Id-Version: Folio\n"
-
-#: data/app.gschema.xml:76
-msgid "Notebook sort order"
-msgstr ""
-
-#: data/app.gschema.xml:77
-msgid "The sort order of the notebook list"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:145
-msgid "Sort Order For Notebooks"
-msgstr ""
-
-#: data/app.gschema.xml:71
-msgid "Note sort order"
-msgstr ""
-
-#: data/app.gschema.xml:72
-msgid "The sort order of the note list"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:150
-msgid "Sort Order For Notes"
-msgstr ""
-
-#: src/ui/strings.vala:62
-msgid "Modified Time - Ascending"
-msgstr ""
-
-#: src/ui/strings.vala:63
-msgid "Modified Time - Descending"
-msgstr ""
-
-#: src/ui/strings.vala:64
-msgid "Alphabetical - Ascending"
-msgstr ""
-
-#: src/ui/strings.vala:65
-msgid "Alphabetical - Descending"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:114
-msgid "Display"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:117
-msgid "Full Screen"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:122
-msgid "Zoom In"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:127
-msgid "Zoom Out"
-msgstr ""
-
-#: src/ui/strings.vala:52
-msgid "Pick primary font for notes"
-msgstr ""
-
-#: src/ui/strings.vala:53
-msgid "Pick monospace font for code"
-msgstr ""
-
-#: src/ui/strings.vala:54
-msgid "File Changed On Disk"
-msgstr ""
-
-#: src/ui/strings.vala:55
-msgid ""
-"The file has changed on disk since it was last saved/loaded by Folio.\n"
-"\n"
-"You may do one of the following:\n"
-"\n"
-" • Reload the file (discarding any changes you have made in Folio)\n"
-" • Overwrite the file (discarding any changes made outside of Folio)\n"
-" • Cancel the operation and manually resolve the issue\n"
-"\n"
-"Note: Canceling the save if you have already moved to a new note/notebook will discard your changes."
-msgstr ""
-
-#: src/ui/strings.vala:56
-msgid "Reload"
-msgstr ""
-
-#: src/ui/strings.vala:57
-msgid "Overwrite"
-msgstr ""
-
-#: src/ui/strings.vala:59
-msgid ""
-"The file has changed on disk by another application.\n"
-"\n"
-"You may do one of the following:\n"
-"\n"
-" • Reload the file (discarding any changes you have made in Folio)\n"
-" • Overwrite the file (discarding any changes made outside of Folio)"
-msgstr ""
-
-#: src/ui/strings.vala:61
-msgid "Note %i"
-msgstr ""
-
-#: data/app.gschema.xml:46 src/ui/preferences/preferences.blp:213
-msgid "Trash Storage Location"
-msgstr ""
-
-#: data/app.gschema.xml:47 src/ui/preferences/preferences.blp:214
-msgid "Where the trash folder is located (requires app restart)"
-msgstr ""
-
-#: src/ui/strings.vala:46
-msgid "Pick where the trash can will be stored"
-msgstr ""
-
-#: data/app.gschema.xml:16 src/ui/preferences/preferences.blp:128
-msgid "Use Fixed Width For Notes"
-msgstr ""
-
-#: data/app.gschema.xml:17 src/ui/preferences/preferences.blp:129
-msgid "Use a fixed width for the text area of a note"
-msgstr ""
-
-#: data/app.gschema.xml:37 src/ui/preferences/preferences.blp:118
-msgid "Expands the notebook list to include the notebook name"
-msgstr ""
-
-#: data/app.gschema.xml:51 src/ui/preferences/preferences.blp:65
-msgid "Show line numbers"
-msgstr ""
-
-#: data/app.gschema.xml:52 src/ui/preferences/preferences.blp:66
-msgid "Displays line numbers at the left of the note"
-msgstr ""
-
-#: data/app.gschema.xml:56 src/ui/preferences/preferences.blp:76
-msgid "Show all notes"
-msgstr ""
-
-#: data/app.gschema.xml:57 src/ui/preferences/preferences.blp:77
-msgid "Displays the \"All Notes\" notebook at the top of the notebook list"
-msgstr ""
-
-#: data/app.gschema.xml:61 src/ui/preferences/preferences.blp:163
-msgid "Enable autosave"
-msgstr ""
-
-#: data/app.gschema.xml:62 src/ui/preferences/preferences.blp:164
-msgid "Automatically saves the current note every 30 seconds if the contents have changed (requires app restart)"
-msgstr ""
-
-#: data/app.gschema.xml:66 src/ui/preferences/preferences.blp:174
-msgid "Don't hide the Trash folder"
-msgstr ""
-
-#: data/app.gschema.xml:67
-msgid "The trash folder is set as a hidden folder by default, this option makes it visible"
-msgstr ""
-
-#: data/app.metainfo.xml.in:367
-msgid "Main Folio window in light mode"
-msgstr ""
-
-#: data/app.metainfo.xml.in:371
-msgid "Main Folio window in dark mode"
-msgstr ""
-
-#: data/app.metainfo.xml.in:375
-msgid "Folio on small/mobile screens"
-msgstr ""
-
-#: data/app.metainfo.xml.in:379
-msgid "Folio preferences screen"
-msgstr ""
-
-#: data/app.metainfo.xml.in:383
-msgid "Folio in three pane mode"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:59
-msgid "Tools"
-msgstr ""
-
-#: data/app.gschema.xml:27 src/ui/preferences/preferences.blp:88
-msgid "Displays the formatting toolbar at the bottom of the note"
-msgstr ""
-
-#: data/app.gschema.xml:32 src/ui/preferences/preferences.blp:99
-msgid "Adds a button to the markdown reference sheet on the right of the formatting toolbar"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:111
-msgid "Layout"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:139
-msgid "Fixed Width To Use For Notes"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:140
-msgid "Sets the fixed width size of a note in px"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:157
-msgid "Files"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:175
-msgid "The trash folder is set as a hidden folder by default, this option makes it visible (requires app restart)"
-msgstr ""
-
-#: src/ui/strings.vala:51
-msgid "Unable to recognize URI"
-msgstr ""
 
 #: data/app.desktop.in:9 src/ui/strings.vala:3
 msgid "Folio"
@@ -240,21 +27,23 @@ msgstr "Toma notas"
 
 #: data/app.desktop.in:13
 msgid "Notebook;Note;Notes;Text;Markdown;Notepad;Write;School;Post-it;Sticky;"
-msgstr "Libreta;Nota;Notas;Texto;Markdown;Notepad;Escribe;Cole;Colegio;Post-it;Sticky;"
+msgstr ""
+"Libreta;Nota;Notas;Texto;Markdown;Notepad;Escribe;Cole;Colegio;Post-it;"
+"Sticky;"
 
 #: data/app.desktop.in:22 src/ui/popup/shortcut_window.blp:17
-#: src/ui/strings.vala:8 src/ui/window/window.blp:47
-#: src/ui/window/window.blp:124
+#: src/ui/strings.vala:8 src/ui/window/window.blp:54
+#: src/ui/window/window.blp:131
 msgid "New Note"
 msgstr "Nota nueva"
 
 #: data/app.desktop.in:26 src/ui/popup/shortcut_window.blp:37
-#: src/ui/strings.vala:14 src/ui/window/window.blp:149
+#: src/ui/strings.vala:14 src/ui/window/window.blp:189
 msgid "New Notebook"
 msgstr "Libreta nueva"
 
-#: data/app.desktop.in:30 src/ui/edit_view/toolbar/toolbar.blp:90
-#: src/ui/strings.vala:39 src/ui/window/window.blp:245
+#: data/app.desktop.in:30 src/ui/edit_view/toolbar/toolbar.blp:92
+#: src/ui/strings.vala:39 src/ui/window/window.blp:291
 msgid "Markdown Cheatsheet"
 msgstr "Lista de funciones de Markdown"
 
@@ -262,25 +51,147 @@ msgstr "Lista de funciones de Markdown"
 msgid "Preferences"
 msgstr "Preferencias"
 
-#: data/app.gschema.xml:6 src/ui/preferences/preferences.blp:18
+#: data/app.gschema.xml:6 src/ui/preferences/preferences.blp:45
 msgid "Note Font"
 msgstr "Fuente para notas"
 
-#: data/app.gschema.xml:7 src/ui/preferences/preferences.blp:19
+#: data/app.gschema.xml:7 src/ui/preferences/preferences.blp:46
 msgid "The font notes will be displayed in"
 msgstr "La fuente en la que se mostrarán las notas"
 
-#: data/app.gschema.xml:11 src/ui/preferences/preferences.blp:31
+#: data/app.gschema.xml:11 src/ui/preferences/preferences.blp:58
 msgid "Monospace Font"
 msgstr "Fuente del código"
 
-#: data/app.gschema.xml:12 src/ui/preferences/preferences.blp:32
+#: data/app.gschema.xml:12 src/ui/preferences/preferences.blp:59
 msgid "The font code will be displayed in"
 msgstr "La fuente en la que se mostrará el código"
 
-#: data/app.gschema.xml:21 src/ui/preferences/preferences.blp:46
+#: data/app.gschema.xml:16 src/ui/preferences/preferences.blp:150
+msgid "Use Fixed Width For Notes"
+msgstr ""
+
+#: data/app.gschema.xml:17 src/ui/preferences/preferences.blp:151
+msgid "Use a fixed width for the text area of a note"
+msgstr ""
+
+#: data/app.gschema.xml:21 src/ui/preferences/preferences.blp:18
 msgid "OLED Mode"
 msgstr "Modo OLED"
+
+#: data/app.gschema.xml:22 src/ui/preferences/preferences.blp:19
+msgid "Makes the dark theme pitch black"
+msgstr "Cambia el tema oscuro a color negro"
+
+#: data/app.gschema.xml:26 src/ui/preferences/preferences.blp:109
+msgid "Enable Toolbar"
+msgstr "Activar barra de herramientas"
+
+#: data/app.gschema.xml:27 src/ui/preferences/preferences.blp:110
+msgid "Displays the formatting toolbar at the bottom of the note"
+msgstr ""
+
+#: data/app.gschema.xml:31 src/ui/preferences/preferences.blp:120
+msgid "Enable Cheatsheet"
+msgstr ""
+
+#: data/app.gschema.xml:32 src/ui/preferences/preferences.blp:121
+msgid ""
+"Adds a button to the markdown reference sheet on the right of the formatting "
+"toolbar"
+msgstr ""
+
+#: data/app.gschema.xml:36 src/ui/preferences/preferences.blp:139
+msgid "3-Pane Layout"
+msgstr "Diseño de 3 paneles"
+
+#: data/app.gschema.xml:37 src/ui/preferences/preferences.blp:140
+msgid "Expands the notebook list to include the notebook name"
+msgstr ""
+
+#: data/app.gschema.xml:41 src/ui/preferences/preferences.blp:207
+msgid "Notes Storage Location"
+msgstr "Ubicación para almacenar las notas"
+
+#: data/app.gschema.xml:42 src/ui/preferences/preferences.blp:208
+msgid "Where the notebooks are stored (requires app restart)"
+msgstr "Donde las notas se almacenan (requiere reiniciar la app)"
+
+#: data/app.gschema.xml:46 src/ui/preferences/preferences.blp:235
+msgid "Trash Storage Location"
+msgstr ""
+
+#: data/app.gschema.xml:47 src/ui/preferences/preferences.blp:236
+msgid "Where the trash folder is located (requires app restart)"
+msgstr ""
+
+#: data/app.gschema.xml:51 src/ui/preferences/preferences.blp:87
+msgid "Show line numbers"
+msgstr ""
+
+#: data/app.gschema.xml:52 src/ui/preferences/preferences.blp:88
+msgid "Displays line numbers at the left of the note"
+msgstr ""
+
+#: data/app.gschema.xml:56 src/ui/preferences/preferences.blp:98
+msgid "Show all notes"
+msgstr ""
+
+#: data/app.gschema.xml:57 src/ui/preferences/preferences.blp:99
+msgid "Displays the \"All Notes\" notebook at the top of the notebook list"
+msgstr ""
+
+#: data/app.gschema.xml:61 src/ui/preferences/preferences.blp:185
+msgid "Enable autosave"
+msgstr ""
+
+#: data/app.gschema.xml:62 src/ui/preferences/preferences.blp:186
+msgid ""
+"Automatically saves the current note every 30 seconds if the contents have "
+"changed (requires app restart)"
+msgstr ""
+
+#: data/app.gschema.xml:66 src/ui/preferences/preferences.blp:196
+msgid "Don't hide the Trash folder"
+msgstr ""
+
+#: data/app.gschema.xml:67
+msgid ""
+"The trash folder is set as a hidden folder by default, this option makes it "
+"visible"
+msgstr ""
+
+#: data/app.gschema.xml:71
+msgid "Note sort order"
+msgstr ""
+
+#: data/app.gschema.xml:72
+msgid "The sort order of the note list"
+msgstr ""
+
+#: data/app.gschema.xml:76
+msgid "Notebook sort order"
+msgstr ""
+
+#: data/app.gschema.xml:77
+msgid "The sort order of the notebook list"
+msgstr ""
+
+#: data/app.gschema.xml:81
+msgid "URL detection level"
+msgstr ""
+
+#: data/app.gschema.xml:82
+msgid "How agressive to look for URLs in markdown text"
+msgstr ""
+
+#: data/app.gschema.xml:86
+msgid "Line spacing"
+msgstr ""
+
+#: data/app.gschema.xml:87 src/ui/preferences/preferences.blp:74
+msgid "The line spacing for the note text"
+msgstr ""
 
 #: data/app.metainfo.xml.in:5
 msgid "Take notes in Markdown"
@@ -314,103 +225,116 @@ msgstr ""
 msgid "Trash can"
 msgstr "Papelera"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:23
-#: src/ui/edit_view/toolbar/toolbar.blp:131
+#: data/app.metainfo.xml.in:393
+msgid "Main Folio window in light mode"
+msgstr ""
+
+#: data/app.metainfo.xml.in:397
+msgid "Main Folio window in dark mode"
+msgstr ""
+
+#: data/app.metainfo.xml.in:401
+msgid "Folio on small/mobile screens"
+msgstr ""
+
+#: data/app.metainfo.xml.in:405
+msgid "Folio preferences screen"
+msgstr ""
+
+#: data/app.metainfo.xml.in:409
+msgid "Folio in three pane mode"
+msgstr ""
+
+#: src/ui/edit_view/toolbar/toolbar.blp:6
 #: src/ui/widgets/markdown/heading_popover.blp:48
 msgid "Plain Text"
 msgstr "Texto simple"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:24
-#: src/ui/edit_view/toolbar/toolbar.blp:132
+#: src/ui/edit_view/toolbar/toolbar.blp:7
 #: src/ui/widgets/markdown/heading_popover.blp:12
 msgid "Heading 1"
 msgstr "Encabezado 1"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:25
-#: src/ui/edit_view/toolbar/toolbar.blp:133
+#: src/ui/edit_view/toolbar/toolbar.blp:8
 #: src/ui/widgets/markdown/heading_popover.blp:18
 msgid "Heading 2"
 msgstr "Encabezado 2"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:26
-#: src/ui/edit_view/toolbar/toolbar.blp:134
+#: src/ui/edit_view/toolbar/toolbar.blp:9
 #: src/ui/widgets/markdown/heading_popover.blp:24
 msgid "Heading 3"
 msgstr "Encabezado 3"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:27
-#: src/ui/edit_view/toolbar/toolbar.blp:135
+#: src/ui/edit_view/toolbar/toolbar.blp:10
 #: src/ui/widgets/markdown/heading_popover.blp:30
 msgid "Heading 4"
 msgstr "Encabezado 4"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:28
-#: src/ui/edit_view/toolbar/toolbar.blp:136
+#: src/ui/edit_view/toolbar/toolbar.blp:11
 #: src/ui/widgets/markdown/heading_popover.blp:36
 msgid "Heading 5"
 msgstr "Encabezado 5"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:29
-#: src/ui/edit_view/toolbar/toolbar.blp:137
+#: src/ui/edit_view/toolbar/toolbar.blp:12
 #: src/ui/widgets/markdown/heading_popover.blp:42
 msgid "Heading 6"
 msgstr "Encabezado 6"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:39
-#: src/ui/edit_view/toolbar/toolbar.blp:104
-#: src/ui/edit_view/toolbar/toolbar.blp:148
-#: src/ui/edit_view/toolbar/toolbar.blp:201 src/ui/popup/shortcut_window.blp:72
+#: src/ui/edit_view/toolbar/toolbar.blp:41
+#: src/ui/edit_view/toolbar/toolbar.blp:107
+#: src/ui/edit_view/toolbar/toolbar.blp:142
+#: src/ui/edit_view/toolbar/toolbar.blp:195 src/ui/popup/shortcut_window.blp:72
 msgid "Bold"
 msgstr "Negrita"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:45
-#: src/ui/edit_view/toolbar/toolbar.blp:111
-#: src/ui/edit_view/toolbar/toolbar.blp:155
-#: src/ui/edit_view/toolbar/toolbar.blp:202 src/ui/popup/shortcut_window.blp:77
+#: src/ui/edit_view/toolbar/toolbar.blp:47
+#: src/ui/edit_view/toolbar/toolbar.blp:114
+#: src/ui/edit_view/toolbar/toolbar.blp:149
+#: src/ui/edit_view/toolbar/toolbar.blp:196 src/ui/popup/shortcut_window.blp:77
 msgid "Italic"
 msgstr "Cursiva"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:51
-#: src/ui/edit_view/toolbar/toolbar.blp:162
-#: src/ui/edit_view/toolbar/toolbar.blp:203 src/ui/popup/shortcut_window.blp:82
+#: src/ui/edit_view/toolbar/toolbar.blp:53
+#: src/ui/edit_view/toolbar/toolbar.blp:156
+#: src/ui/edit_view/toolbar/toolbar.blp:197 src/ui/popup/shortcut_window.blp:82
 msgid "Strikethrough"
 msgstr "Tachado"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:57
-#: src/ui/edit_view/toolbar/toolbar.blp:169
-#: src/ui/edit_view/toolbar/toolbar.blp:204 src/ui/popup/shortcut_window.blp:87
+#: src/ui/edit_view/toolbar/toolbar.blp:59
+#: src/ui/edit_view/toolbar/toolbar.blp:163
+#: src/ui/edit_view/toolbar/toolbar.blp:198 src/ui/popup/shortcut_window.blp:87
 msgid "Highlight"
 msgstr "Subrayado"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:67
-#: src/ui/edit_view/toolbar/toolbar.blp:193 src/ui/popup/shortcut_window.blp:92
+#: src/ui/edit_view/toolbar/toolbar.blp:69
+#: src/ui/edit_view/toolbar/toolbar.blp:187 src/ui/popup/shortcut_window.blp:92
 msgid "Insert Link"
 msgstr "Insertar enlace"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:73
-#: src/ui/edit_view/toolbar/toolbar.blp:194
+#: src/ui/edit_view/toolbar/toolbar.blp:75
+#: src/ui/edit_view/toolbar/toolbar.blp:188
 msgid "Insert Code"
 msgstr "Insertar código"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:79
-#: src/ui/edit_view/toolbar/toolbar.blp:195
+#: src/ui/edit_view/toolbar/toolbar.blp:81
+#: src/ui/edit_view/toolbar/toolbar.blp:189
 msgid "Insert Horizontal Rule"
 msgstr "Insertar separación horizontal"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:118
+#: src/ui/edit_view/toolbar/toolbar.blp:121
 msgid "Format"
 msgstr "Formato"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:181
+#: src/ui/edit_view/toolbar/toolbar.blp:175
 msgid "Insert"
 msgstr "Insertar"
 
-#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:34
+#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:18
 #: src/ui/strings.vala:44 src/ui/strings.vala:58
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:39
+#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:23
 msgid "Confirm"
 msgstr "Confirmar"
 
@@ -454,37 +378,85 @@ msgstr "Formato"
 msgid "Navigation"
 msgstr "Navegación"
 
-#: src/ui/popup/shortcut_window.blp:102 src/ui/window/window.blp:216
+#: src/ui/popup/shortcut_window.blp:102 src/ui/window/window.blp:268
 msgid "Toggle Sidebar"
 msgstr "Alternar barra lateral"
 
-#: src/ui/popup/shortcut_window.blp:107 src/ui/window/window.blp:63
+#: src/ui/popup/shortcut_window.blp:107 src/ui/window/window.blp:70
 msgid "Search Notes"
 msgstr "Buscar notas"
 
-#: data/app.gschema.xml:22 src/ui/preferences/preferences.blp:47
-msgid "Makes the dark theme pitch black"
-msgstr "Cambia el tema oscuro a color negro"
-
-#: data/app.gschema.xml:26 src/ui/preferences/preferences.blp:87
-msgid "Enable Toolbar"
-msgstr "Activar barra de herramientas"
-
-#: data/app.gschema.xml:31 src/ui/preferences/preferences.blp:98
-msgid "Enable Cheatsheet"
+#: src/ui/popup/shortcut_window.blp:114
+msgid "Display"
 msgstr ""
 
-#: data/app.gschema.xml:36 src/ui/preferences/preferences.blp:117
-msgid "3-Pane Layout"
-msgstr "Diseño de 3 paneles"
+#: src/ui/popup/shortcut_window.blp:117
+msgid "Full Screen"
+msgstr ""
 
-#: data/app.gschema.xml:41 src/ui/preferences/preferences.blp:185
-msgid "Notes Storage Location"
-msgstr "Ubicación para almacenar las notas"
+#: src/ui/popup/shortcut_window.blp:122
+msgid "Zoom In"
+msgstr ""
 
-#: data/app.gschema.xml:42 src/ui/preferences/preferences.blp:186
-msgid "Where the notebooks are stored (requires app restart)"
-msgstr "Donde las notas se almacenan (requiere reiniciar la app)"
+#: src/ui/popup/shortcut_window.blp:127
+msgid "Zoom Out"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:31
+#, fuzzy
+msgid "Markdown URL Detection"
+msgstr "Lista de funciones de Markdown"
+
+#: src/ui/preferences/preferences.blp:32
+msgid ""
+"Determines the level of detection of URLs in\n"
+"free form text is used:\n"
+" - Aggressive tries to find all URLs\n"
+" - Strict requires a protocol identifier (ie http://)\n"
+" - Disabled turns detection off."
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:39
+msgid "Fonts"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:73
+msgid "Line Spacing"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:81
+msgid "Tools"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:133
+msgid "Layout"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:161
+msgid "Fixed Width To Use For Notes"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:162
+msgid "Sets the fixed width size of a note in px"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:167
+msgid "Sort Order For Notebooks"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:172
+msgid "Sort Order For Notes"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:179
+msgid "Files"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:197
+msgid ""
+"The trash folder is set as a hidden folder by default, this option makes it "
+"visible (requires app restart)"
+msgstr ""
 
 #: src/ui/strings.vala:4 src/ui/window/notebooks_bar/notebooks_bar.blp:129
 #: src/ui/window/notebooks_bar/notebooks_bar.blp:171
@@ -492,6 +464,7 @@ msgid "Trash"
 msgstr "Papelera"
 
 #: src/ui/strings.vala:5
+#, c-format
 msgid "%d Notes"
 msgstr "%d notas"
 
@@ -499,7 +472,7 @@ msgstr "%d notas"
 msgid "Are you sure you want to delete everything in the trash?"
 msgstr "¿De verdad quiere borrar todo lo de la papelera?"
 
-#: src/ui/strings.vala:7 src/ui/window/window.blp:54
+#: src/ui/strings.vala:7 src/ui/window/window.blp:61
 msgid "Empty Trash"
 msgstr "Vaciar papelera"
 
@@ -536,10 +509,12 @@ msgid "Move"
 msgstr "Mover"
 
 #: src/ui/strings.vala:18
+#, c-format
 msgid "Note “%s” already exists in notebook “%s”"
 msgstr "La nota “%s” ya existe en libreta “%s”"
 
 #: src/ui/strings.vala:19
+#, c-format
 msgid "Are you sure you want to delete the note “%s”?"
 msgstr "¿De verdad quiere borrar la nota “%s”?"
 
@@ -548,6 +523,7 @@ msgid "Delete Note"
 msgstr "Borrar nota"
 
 #: src/ui/strings.vala:21
+#, c-format
 msgid "Are you sure you want to delete the notebook “%s”?"
 msgstr "¿De verdad quiere borrar la libreta “%s”?"
 
@@ -556,34 +532,42 @@ msgid "Delete Notebook"
 msgstr "Borrar libreta"
 
 #: src/ui/strings.vala:24
-msgid "Note name shouldn’t contain “.” or “/”"
+#, fuzzy
+msgid "Note names cannot contain a “/”"
 msgstr "Nombres de notas no deben contener “.” o “/”"
 
 #: src/ui/strings.vala:25
-msgid "Note name shouldn’t be blank"
+#, fuzzy
+msgid "Note names cannot be blank"
 msgstr "Nombres de notas no deben ser vacios"
 
 #: src/ui/strings.vala:26
+#, c-format
 msgid "Note “%s” already exists"
 msgstr "La nota “%s” ya existe"
 
 #: src/ui/strings.vala:27
-msgid "Couldn’t create note"
+#, fuzzy
+msgid "Could not create note"
 msgstr "No se pudo crear la nota"
 
 #: src/ui/strings.vala:28
-msgid "Couldn’t change note"
+#, fuzzy
+msgid "Could not change note"
 msgstr "No se pudo cambiar la nota"
 
 #: src/ui/strings.vala:29
-msgid "Couldn’t delete note"
+#, fuzzy
+msgid "Could not delete note"
 msgstr "No se pudo borrar la nota"
 
 #: src/ui/strings.vala:30
-msgid "Couldn’t restore note"
+#, fuzzy
+msgid "Could not restore note"
 msgstr "No se pudo recuperar la nota"
 
 #: src/ui/strings.vala:31
+#, c-format
 msgid "Saved “%s” to “%s”"
 msgstr "“%s” se guardó en “%s”"
 
@@ -592,27 +576,33 @@ msgid "Unknown error"
 msgstr "Error desconocido"
 
 #: src/ui/strings.vala:33
-msgid "Notebook name shouldn’t contain “.” or “/”"
+#, fuzzy
+msgid "Notebook names cannot contain a “/”"
 msgstr "Nombres de libretas no deben contener “.” o “/”"
 
 #: src/ui/strings.vala:34
-msgid "Notebook name shouldn’t be blank"
+#, fuzzy
+msgid "Notebook names cannot be blank"
 msgstr "Nombres de libretas no deben ser vacíos"
 
 #: src/ui/strings.vala:35
+#, c-format
 msgid "Notebook “%s” already exists"
 msgstr "La libreta “%s” ya existe"
 
 #: src/ui/strings.vala:36
-msgid "Couldn’t create notebook"
+#, fuzzy
+msgid "Could not create notebook"
 msgstr "No se pudo crear la libreta"
 
 #: src/ui/strings.vala:37
-msgid "Couldn’t change notebook"
+#, fuzzy
+msgid "Could not change notebook"
 msgstr "No se pudo cambiar la libreta"
 
 #: src/ui/strings.vala:38
-msgid "Couldn’t delete notebook"
+#, fuzzy
+msgid "Could not delete notebook"
 msgstr "No se pudo borrar la libreta"
 
 #: src/ui/strings.vala:40
@@ -624,7 +614,7 @@ msgid "Rename"
 msgstr "Renombrar"
 
 #: src/ui/strings.vala:42
-msgid "Couldn’t find an app to handle file URIs"
+msgid "Could not find an app to handle file URIs"
 msgstr ""
 
 #: src/ui/strings.vala:43
@@ -634,6 +624,10 @@ msgstr "Aplicar"
 #: src/ui/strings.vala:45
 msgid "Pick where the notebooks will be stored"
 msgstr "Escoja donde se almacenarán las notas"
+
+#: src/ui/strings.vala:46
+msgid "Pick where the trash can will be stored"
+msgstr ""
 
 #: src/ui/strings.vala:47 src/ui/window/notebooks_bar/notebooks_bar.blp:59
 #: src/ui/window/notebooks_bar/notebooks_bar.blp:101
@@ -646,6 +640,110 @@ msgstr ""
 
 #: src/ui/strings.vala:50
 msgid "Extension"
+msgstr ""
+
+#: src/ui/strings.vala:51
+msgid "Unable to recognize URI"
+msgstr ""
+
+#: src/ui/strings.vala:52
+msgid "Pick primary font for notes"
+msgstr ""
+
+#: src/ui/strings.vala:53
+msgid "Pick monospace font for code"
+msgstr ""
+
+#: src/ui/strings.vala:54
+msgid "File Changed On Disk"
+msgstr ""
+
+#: src/ui/strings.vala:55
+msgid ""
+"The file has changed on disk since it was last saved/loaded by Folio.\n"
+"\n"
+"You may do one of the following:\n"
+"\n"
+" • Reload the file (discarding any changes you have made in Folio)\n"
+" • Overwrite the file (discarding any changes made outside of Folio)\n"
+" • Cancel the operation and manually resolve the issue\n"
+"\n"
+"Note: Canceling the save if you have already moved to a new note/notebook "
+"will discard your changes."
+msgstr ""
+
+#: src/ui/strings.vala:56
+msgid "Reload"
+msgstr ""
+
+#: src/ui/strings.vala:57
+msgid "Overwrite"
+msgstr ""
+
+#: src/ui/strings.vala:59
+msgid ""
+"The file has changed on disk by another application.\n"
+"\n"
+"You may do one of the following:\n"
+"\n"
+" • Reload the file (discarding any changes you have made in Folio)\n"
+" • Overwrite the file (discarding any changes made outside of Folio)"
+msgstr ""
+
+#: src/ui/strings.vala:61
+#, c-format
+msgid "Note %i"
+msgstr ""
+
+#: src/ui/strings.vala:62
+msgid "Modified Time - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:63
+msgid "Modified Time - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:64
+msgid "Alphabetical - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:65
+msgid "Alphabetical - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:66
+msgid "Natural - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:67
+msgid "Natural - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:68
+#, c-format
+msgid "Unable to launch external application for file %s."
+msgstr ""
+
+#: src/ui/strings.vala:69
+msgid "Aggressive"
+msgstr ""
+
+#: src/ui/strings.vala:70
+msgid "Strict"
+msgstr ""
+
+#: src/ui/strings.vala:71
+msgid "Disabled"
+msgstr ""
+
+#: src/ui/strings.vala:72
+#, fuzzy, c-format
+msgid "“%s” moved to trash"
+msgstr "Mover a la papelera"
+
+#: src/ui/strings.vala:73
+#, c-format
+msgid "“%s” restored"
 msgstr ""
 
 #: src/ui/widgets/theme_selector/theme_selector.blp:15
@@ -677,40 +775,45 @@ msgid "_Keyboard Shortcuts"
 msgstr "_Atajos del teclado"
 
 #: src/ui/window/app_menu/app_menu.blp:43
-msgid "_About"
+#, fuzzy
+msgid "_About Folio"
 msgstr "_Acerca de Folio"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:54
-msgid "Notebook Name"
-msgstr "Nombre de la libreta"
-
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:66
-msgid "Duplicate notebook names are not allowed!"
-msgstr ""
-
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:82
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:6
 msgid "First Characters"
 msgstr "Primeros carácteres"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:83
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:7
 msgid "Initials"
 msgstr "Iniciales"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:84
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:8
 msgid "Initials: camelCase"
 msgstr "Iniciales: camelCase"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:85
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:9
 msgid "Initials: snake_case"
 msgstr "Iniciales: snake_case"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:86
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:10
 msgid "Icon"
 msgstr "Icono"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:116
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:11
+msgid "Custom"
+msgstr ""
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:16
 msgid "Notebook Color"
 msgstr "Color de la libreta"
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:58
+msgid "Notebook Name"
+msgstr "Nombre de la libreta"
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:70
+msgid "Duplicate notebook names are not allowed!"
+msgstr ""
 
 #: src/ui/window/notebooks_bar/notebook_create_popup.blp:126
 msgid "Create Notebook"
@@ -728,11 +831,11 @@ msgstr "Mover todo a la papelera"
 msgid "Notebooks"
 msgstr ""
 
-#: src/ui/window/sidebar/note_create_popup.blp:37
+#: src/ui/window/sidebar/note_create_popup.blp:25
 msgid "Note Name"
 msgstr "Nombre de la nota"
 
-#: src/ui/window/sidebar/note_create_popup.blp:45
+#: src/ui/window/sidebar/note_create_popup.blp:33
 msgid "Create Note"
 msgstr "Crear nota"
 
@@ -756,30 +859,37 @@ msgstr "Mover a la papelera"
 msgid "Open Containing Folder"
 msgstr "Ver en carpeta"
 
-#: src/ui/window/window.blp:118
+#: src/ui/window/window.blp:123
 msgid "Get started writing"
 msgstr "Empezar a escribir"
 
-#: src/ui/window/window.blp:143
+#: src/ui/window/window.blp:152
+msgid "Open file in external application"
+msgstr ""
+
+#: src/ui/window/window.blp:160
+msgid "Open file"
+msgstr ""
+
+#: src/ui/window/window.blp:181
 msgid "Create a notebook"
 msgstr "Crea una libreta"
 
-#: src/ui/window/window.blp:168
+#: src/ui/window/window.blp:210
 msgid "Trash is empty"
 msgstr "La papelera está vacía"
 
-#: src/ui/window/window.blp:224
-msgid "Back"
-msgstr "Atrás"
-
-#: src/ui/window/window.blp:239
+#: src/ui/window/window.blp:285
 msgid "Open in Notebook"
 msgstr "Abrir en la libreta"
 
-#: src/ui/window/window.blp:264
+#: src/ui/window/window.blp:312
 msgid "_Rename Note"
 msgstr "_Renombrar Nota"
 
-#: src/ui/window/window.blp:270
+#: src/ui/window/window.blp:319
 msgid "_Export Note"
 msgstr "_Exportar Nota"
+
+#~ msgid "Back"
+#~ msgstr "Atrás"

--- a/po/fa.po
+++ b/po/fa.po
@@ -2,229 +2,16 @@
 # This file is distributed under the same license as the Folio package.
 msgid ""
 msgstr ""
+"Project-Id-Version: Folio\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-10-12 16:53+0200\n"
 "PO-Revision-Date: 2024-03-02 17:14:42+0000\n"
+"Language: fa_ir\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: GlotPress/4.0.0\n"
-"Language: fa_ir\n"
-"Project-Id-Version: Folio\n"
-
-#: data/app.gschema.xml:76
-msgid "Notebook sort order"
-msgstr ""
-
-#: data/app.gschema.xml:77
-msgid "The sort order of the notebook list"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:145
-msgid "Sort Order For Notebooks"
-msgstr ""
-
-#: data/app.gschema.xml:71
-msgid "Note sort order"
-msgstr ""
-
-#: data/app.gschema.xml:72
-msgid "The sort order of the note list"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:150
-msgid "Sort Order For Notes"
-msgstr ""
-
-#: src/ui/strings.vala:62
-msgid "Modified Time - Ascending"
-msgstr ""
-
-#: src/ui/strings.vala:63
-msgid "Modified Time - Descending"
-msgstr ""
-
-#: src/ui/strings.vala:64
-msgid "Alphabetical - Ascending"
-msgstr ""
-
-#: src/ui/strings.vala:65
-msgid "Alphabetical - Descending"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:114
-msgid "Display"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:117
-msgid "Full Screen"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:122
-msgid "Zoom In"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:127
-msgid "Zoom Out"
-msgstr ""
-
-#: src/ui/strings.vala:52
-msgid "Pick primary font for notes"
-msgstr ""
-
-#: src/ui/strings.vala:53
-msgid "Pick monospace font for code"
-msgstr ""
-
-#: src/ui/strings.vala:54
-msgid "File Changed On Disk"
-msgstr ""
-
-#: src/ui/strings.vala:55
-msgid ""
-"The file has changed on disk since it was last saved/loaded by Folio.\n"
-"\n"
-"You may do one of the following:\n"
-"\n"
-" • Reload the file (discarding any changes you have made in Folio)\n"
-" • Overwrite the file (discarding any changes made outside of Folio)\n"
-" • Cancel the operation and manually resolve the issue\n"
-"\n"
-"Note: Canceling the save if you have already moved to a new note/notebook will discard your changes."
-msgstr ""
-
-#: src/ui/strings.vala:56
-msgid "Reload"
-msgstr ""
-
-#: src/ui/strings.vala:57
-msgid "Overwrite"
-msgstr ""
-
-#: src/ui/strings.vala:59
-msgid ""
-"The file has changed on disk by another application.\n"
-"\n"
-"You may do one of the following:\n"
-"\n"
-" • Reload the file (discarding any changes you have made in Folio)\n"
-" • Overwrite the file (discarding any changes made outside of Folio)"
-msgstr ""
-
-#: src/ui/strings.vala:61
-msgid "Note %i"
-msgstr ""
-
-#: data/app.gschema.xml:46 src/ui/preferences/preferences.blp:213
-msgid "Trash Storage Location"
-msgstr ""
-
-#: data/app.gschema.xml:47 src/ui/preferences/preferences.blp:214
-msgid "Where the trash folder is located (requires app restart)"
-msgstr ""
-
-#: src/ui/strings.vala:46
-msgid "Pick where the trash can will be stored"
-msgstr ""
-
-#: data/app.gschema.xml:16 src/ui/preferences/preferences.blp:128
-msgid "Use Fixed Width For Notes"
-msgstr ""
-
-#: data/app.gschema.xml:17 src/ui/preferences/preferences.blp:129
-msgid "Use a fixed width for the text area of a note"
-msgstr ""
-
-#: data/app.gschema.xml:37 src/ui/preferences/preferences.blp:118
-msgid "Expands the notebook list to include the notebook name"
-msgstr ""
-
-#: data/app.gschema.xml:51 src/ui/preferences/preferences.blp:65
-msgid "Show line numbers"
-msgstr ""
-
-#: data/app.gschema.xml:52 src/ui/preferences/preferences.blp:66
-msgid "Displays line numbers at the left of the note"
-msgstr ""
-
-#: data/app.gschema.xml:56 src/ui/preferences/preferences.blp:76
-msgid "Show all notes"
-msgstr ""
-
-#: data/app.gschema.xml:57 src/ui/preferences/preferences.blp:77
-msgid "Displays the \"All Notes\" notebook at the top of the notebook list"
-msgstr ""
-
-#: data/app.gschema.xml:61 src/ui/preferences/preferences.blp:163
-msgid "Enable autosave"
-msgstr ""
-
-#: data/app.gschema.xml:62 src/ui/preferences/preferences.blp:164
-msgid "Automatically saves the current note every 30 seconds if the contents have changed (requires app restart)"
-msgstr ""
-
-#: data/app.gschema.xml:66 src/ui/preferences/preferences.blp:174
-msgid "Don't hide the Trash folder"
-msgstr ""
-
-#: data/app.gschema.xml:67
-msgid "The trash folder is set as a hidden folder by default, this option makes it visible"
-msgstr ""
-
-#: data/app.metainfo.xml.in:367
-msgid "Main Folio window in light mode"
-msgstr ""
-
-#: data/app.metainfo.xml.in:371
-msgid "Main Folio window in dark mode"
-msgstr ""
-
-#: data/app.metainfo.xml.in:375
-msgid "Folio on small/mobile screens"
-msgstr ""
-
-#: data/app.metainfo.xml.in:379
-msgid "Folio preferences screen"
-msgstr ""
-
-#: data/app.metainfo.xml.in:383
-msgid "Folio in three pane mode"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:59
-msgid "Tools"
-msgstr ""
-
-#: data/app.gschema.xml:27 src/ui/preferences/preferences.blp:88
-msgid "Displays the formatting toolbar at the bottom of the note"
-msgstr ""
-
-#: data/app.gschema.xml:32 src/ui/preferences/preferences.blp:99
-msgid "Adds a button to the markdown reference sheet on the right of the formatting toolbar"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:111
-msgid "Layout"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:139
-msgid "Fixed Width To Use For Notes"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:140
-msgid "Sets the fixed width size of a note in px"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:157
-msgid "Files"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:175
-msgid "The trash folder is set as a hidden folder by default, this option makes it visible (requires app restart)"
-msgstr ""
-
-#: src/ui/strings.vala:51
-msgid "Unable to recognize URI"
-msgstr ""
 
 #: data/app.desktop.in:9 src/ui/strings.vala:3
 msgid "Folio"
@@ -240,21 +27,23 @@ msgstr "یادداشت‌برداری"
 
 #: data/app.desktop.in:13
 msgid "Notebook;Note;Notes;Text;Markdown;Notepad;Write;School;Post-it;Sticky;"
-msgstr "Notebook;Note;Notes;Text;Markdown;Notepad;Write;School;Post-it;Sticky;دفترچهٔ یادداشت;یادداشت‌ها;مارک‌داون;مارک‌دون;مارک‌دان;نوشتن;مدرسه;فرستادن;"
+msgstr ""
+"Notebook;Note;Notes;Text;Markdown;Notepad;Write;School;Post-it;Sticky;دفترچهٔ "
+"یادداشت;یادداشت‌ها;مارک‌داون;مارک‌دون;مارک‌دان;نوشتن;مدرسه;فرستادن;"
 
 #: data/app.desktop.in:22 src/ui/popup/shortcut_window.blp:17
-#: src/ui/strings.vala:8 src/ui/window/window.blp:47
-#: src/ui/window/window.blp:124
+#: src/ui/strings.vala:8 src/ui/window/window.blp:54
+#: src/ui/window/window.blp:131
 msgid "New Note"
 msgstr "یادداشت جدید"
 
 #: data/app.desktop.in:26 src/ui/popup/shortcut_window.blp:37
-#: src/ui/strings.vala:14 src/ui/window/window.blp:149
+#: src/ui/strings.vala:14 src/ui/window/window.blp:189
 msgid "New Notebook"
 msgstr "دفترچهٔ جدید"
 
-#: data/app.desktop.in:30 src/ui/edit_view/toolbar/toolbar.blp:90
-#: src/ui/strings.vala:39 src/ui/window/window.blp:245
+#: data/app.desktop.in:30 src/ui/edit_view/toolbar/toolbar.blp:92
+#: src/ui/strings.vala:39 src/ui/window/window.blp:291
 msgid "Markdown Cheatsheet"
 msgstr "برگهٔ تقلب مارک‌دون"
 
@@ -262,25 +51,147 @@ msgstr "برگهٔ تقلب مارک‌دون"
 msgid "Preferences"
 msgstr "ترجیحات"
 
-#: data/app.gschema.xml:6 src/ui/preferences/preferences.blp:18
+#: data/app.gschema.xml:6 src/ui/preferences/preferences.blp:45
 msgid "Note Font"
 msgstr "قلم یادداشت"
 
-#: data/app.gschema.xml:7 src/ui/preferences/preferences.blp:19
+#: data/app.gschema.xml:7 src/ui/preferences/preferences.blp:46
 msgid "The font notes will be displayed in"
 msgstr "قلمی که یادداشت‌ها با آن نمایش داده می‌شوند"
 
-#: data/app.gschema.xml:11 src/ui/preferences/preferences.blp:31
+#: data/app.gschema.xml:11 src/ui/preferences/preferences.blp:58
 msgid "Monospace Font"
 msgstr "قلم تک‌عرض"
 
-#: data/app.gschema.xml:12 src/ui/preferences/preferences.blp:32
+#: data/app.gschema.xml:12 src/ui/preferences/preferences.blp:59
 msgid "The font code will be displayed in"
 msgstr "قلمی که کدها با آن نمایش داده می‌شوند"
 
-#: data/app.gschema.xml:21 src/ui/preferences/preferences.blp:46
+#: data/app.gschema.xml:16 src/ui/preferences/preferences.blp:150
+msgid "Use Fixed Width For Notes"
+msgstr ""
+
+#: data/app.gschema.xml:17 src/ui/preferences/preferences.blp:151
+msgid "Use a fixed width for the text area of a note"
+msgstr ""
+
+#: data/app.gschema.xml:21 src/ui/preferences/preferences.blp:18
 msgid "OLED Mode"
 msgstr "حالت اُلِد"
+
+#: data/app.gschema.xml:22 src/ui/preferences/preferences.blp:19
+msgid "Makes the dark theme pitch black"
+msgstr "سیاه مطلق کردن حالت تاریک"
+
+#: data/app.gschema.xml:26 src/ui/preferences/preferences.blp:109
+msgid "Enable Toolbar"
+msgstr "به کار انداختن جعبه‌ابزار"
+
+#: data/app.gschema.xml:27 src/ui/preferences/preferences.blp:110
+msgid "Displays the formatting toolbar at the bottom of the note"
+msgstr ""
+
+#: data/app.gschema.xml:31 src/ui/preferences/preferences.blp:120
+msgid "Enable Cheatsheet"
+msgstr ""
+
+#: data/app.gschema.xml:32 src/ui/preferences/preferences.blp:121
+msgid ""
+"Adds a button to the markdown reference sheet on the right of the formatting "
+"toolbar"
+msgstr ""
+
+#: data/app.gschema.xml:36 src/ui/preferences/preferences.blp:139
+msgid "3-Pane Layout"
+msgstr "چیدمان سه‌ستونه"
+
+#: data/app.gschema.xml:37 src/ui/preferences/preferences.blp:140
+msgid "Expands the notebook list to include the notebook name"
+msgstr ""
+
+#: data/app.gschema.xml:41 src/ui/preferences/preferences.blp:207
+msgid "Notes Storage Location"
+msgstr "مکان ذخیره‌سازی یادداشت‌ها"
+
+#: data/app.gschema.xml:42 src/ui/preferences/preferences.blp:208
+msgid "Where the notebooks are stored (requires app restart)"
+msgstr "جایی که یادداشت‌ها ذخیره می‌شوند (نیازمند راه‌اندازی دوبارهٔ کاره)"
+
+#: data/app.gschema.xml:46 src/ui/preferences/preferences.blp:235
+msgid "Trash Storage Location"
+msgstr ""
+
+#: data/app.gschema.xml:47 src/ui/preferences/preferences.blp:236
+msgid "Where the trash folder is located (requires app restart)"
+msgstr ""
+
+#: data/app.gschema.xml:51 src/ui/preferences/preferences.blp:87
+msgid "Show line numbers"
+msgstr ""
+
+#: data/app.gschema.xml:52 src/ui/preferences/preferences.blp:88
+msgid "Displays line numbers at the left of the note"
+msgstr ""
+
+#: data/app.gschema.xml:56 src/ui/preferences/preferences.blp:98
+msgid "Show all notes"
+msgstr ""
+
+#: data/app.gschema.xml:57 src/ui/preferences/preferences.blp:99
+msgid "Displays the \"All Notes\" notebook at the top of the notebook list"
+msgstr ""
+
+#: data/app.gschema.xml:61 src/ui/preferences/preferences.blp:185
+msgid "Enable autosave"
+msgstr ""
+
+#: data/app.gschema.xml:62 src/ui/preferences/preferences.blp:186
+msgid ""
+"Automatically saves the current note every 30 seconds if the contents have "
+"changed (requires app restart)"
+msgstr ""
+
+#: data/app.gschema.xml:66 src/ui/preferences/preferences.blp:196
+msgid "Don't hide the Trash folder"
+msgstr ""
+
+#: data/app.gschema.xml:67
+msgid ""
+"The trash folder is set as a hidden folder by default, this option makes it "
+"visible"
+msgstr ""
+
+#: data/app.gschema.xml:71
+msgid "Note sort order"
+msgstr ""
+
+#: data/app.gschema.xml:72
+msgid "The sort order of the note list"
+msgstr ""
+
+#: data/app.gschema.xml:76
+msgid "Notebook sort order"
+msgstr ""
+
+#: data/app.gschema.xml:77
+msgid "The sort order of the notebook list"
+msgstr ""
+
+#: data/app.gschema.xml:81
+msgid "URL detection level"
+msgstr ""
+
+#: data/app.gschema.xml:82
+msgid "How agressive to look for URLs in markdown text"
+msgstr ""
+
+#: data/app.gschema.xml:86
+msgid "Line spacing"
+msgstr ""
+
+#: data/app.gschema.xml:87 src/ui/preferences/preferences.blp:74
+msgid "The line spacing for the note text"
+msgstr ""
 
 #: data/app.metainfo.xml.in:5
 msgid "Take notes in Markdown"
@@ -314,103 +225,116 @@ msgstr ""
 msgid "Trash can"
 msgstr "زباله‌دان"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:23
-#: src/ui/edit_view/toolbar/toolbar.blp:131
+#: data/app.metainfo.xml.in:393
+msgid "Main Folio window in light mode"
+msgstr ""
+
+#: data/app.metainfo.xml.in:397
+msgid "Main Folio window in dark mode"
+msgstr ""
+
+#: data/app.metainfo.xml.in:401
+msgid "Folio on small/mobile screens"
+msgstr ""
+
+#: data/app.metainfo.xml.in:405
+msgid "Folio preferences screen"
+msgstr ""
+
+#: data/app.metainfo.xml.in:409
+msgid "Folio in three pane mode"
+msgstr ""
+
+#: src/ui/edit_view/toolbar/toolbar.blp:6
 #: src/ui/widgets/markdown/heading_popover.blp:48
 msgid "Plain Text"
 msgstr "متن ساده"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:24
-#: src/ui/edit_view/toolbar/toolbar.blp:132
+#: src/ui/edit_view/toolbar/toolbar.blp:7
 #: src/ui/widgets/markdown/heading_popover.blp:12
 msgid "Heading 1"
 msgstr "سرایند ۱"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:25
-#: src/ui/edit_view/toolbar/toolbar.blp:133
+#: src/ui/edit_view/toolbar/toolbar.blp:8
 #: src/ui/widgets/markdown/heading_popover.blp:18
 msgid "Heading 2"
 msgstr "سرایند ۲"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:26
-#: src/ui/edit_view/toolbar/toolbar.blp:134
+#: src/ui/edit_view/toolbar/toolbar.blp:9
 #: src/ui/widgets/markdown/heading_popover.blp:24
 msgid "Heading 3"
 msgstr "سرایند ۳"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:27
-#: src/ui/edit_view/toolbar/toolbar.blp:135
+#: src/ui/edit_view/toolbar/toolbar.blp:10
 #: src/ui/widgets/markdown/heading_popover.blp:30
 msgid "Heading 4"
 msgstr "سرایند ۴"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:28
-#: src/ui/edit_view/toolbar/toolbar.blp:136
+#: src/ui/edit_view/toolbar/toolbar.blp:11
 #: src/ui/widgets/markdown/heading_popover.blp:36
 msgid "Heading 5"
 msgstr "سرایند ۵"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:29
-#: src/ui/edit_view/toolbar/toolbar.blp:137
+#: src/ui/edit_view/toolbar/toolbar.blp:12
 #: src/ui/widgets/markdown/heading_popover.blp:42
 msgid "Heading 6"
 msgstr "سرایند ۶"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:39
-#: src/ui/edit_view/toolbar/toolbar.blp:104
-#: src/ui/edit_view/toolbar/toolbar.blp:148
-#: src/ui/edit_view/toolbar/toolbar.blp:201 src/ui/popup/shortcut_window.blp:72
+#: src/ui/edit_view/toolbar/toolbar.blp:41
+#: src/ui/edit_view/toolbar/toolbar.blp:107
+#: src/ui/edit_view/toolbar/toolbar.blp:142
+#: src/ui/edit_view/toolbar/toolbar.blp:195 src/ui/popup/shortcut_window.blp:72
 msgid "Bold"
 msgstr "توپُر"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:45
-#: src/ui/edit_view/toolbar/toolbar.blp:111
-#: src/ui/edit_view/toolbar/toolbar.blp:155
-#: src/ui/edit_view/toolbar/toolbar.blp:202 src/ui/popup/shortcut_window.blp:77
+#: src/ui/edit_view/toolbar/toolbar.blp:47
+#: src/ui/edit_view/toolbar/toolbar.blp:114
+#: src/ui/edit_view/toolbar/toolbar.blp:149
+#: src/ui/edit_view/toolbar/toolbar.blp:196 src/ui/popup/shortcut_window.blp:77
 msgid "Italic"
 msgstr "کج"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:51
-#: src/ui/edit_view/toolbar/toolbar.blp:162
-#: src/ui/edit_view/toolbar/toolbar.blp:203 src/ui/popup/shortcut_window.blp:82
+#: src/ui/edit_view/toolbar/toolbar.blp:53
+#: src/ui/edit_view/toolbar/toolbar.blp:156
+#: src/ui/edit_view/toolbar/toolbar.blp:197 src/ui/popup/shortcut_window.blp:82
 msgid "Strikethrough"
 msgstr "خط‌خورده"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:57
-#: src/ui/edit_view/toolbar/toolbar.blp:169
-#: src/ui/edit_view/toolbar/toolbar.blp:204 src/ui/popup/shortcut_window.blp:87
+#: src/ui/edit_view/toolbar/toolbar.blp:59
+#: src/ui/edit_view/toolbar/toolbar.blp:163
+#: src/ui/edit_view/toolbar/toolbar.blp:198 src/ui/popup/shortcut_window.blp:87
 msgid "Highlight"
 msgstr "برجسته"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:67
-#: src/ui/edit_view/toolbar/toolbar.blp:193 src/ui/popup/shortcut_window.blp:92
+#: src/ui/edit_view/toolbar/toolbar.blp:69
+#: src/ui/edit_view/toolbar/toolbar.blp:187 src/ui/popup/shortcut_window.blp:92
 msgid "Insert Link"
 msgstr "درج پیوند"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:73
-#: src/ui/edit_view/toolbar/toolbar.blp:194
+#: src/ui/edit_view/toolbar/toolbar.blp:75
+#: src/ui/edit_view/toolbar/toolbar.blp:188
 msgid "Insert Code"
 msgstr "درج کد"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:79
-#: src/ui/edit_view/toolbar/toolbar.blp:195
+#: src/ui/edit_view/toolbar/toolbar.blp:81
+#: src/ui/edit_view/toolbar/toolbar.blp:189
 msgid "Insert Horizontal Rule"
 msgstr "درج خط افقی"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:118
+#: src/ui/edit_view/toolbar/toolbar.blp:121
 msgid "Format"
 msgstr "قالب"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:181
+#: src/ui/edit_view/toolbar/toolbar.blp:175
 msgid "Insert"
 msgstr "درج"
 
-#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:34
+#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:18
 #: src/ui/strings.vala:44 src/ui/strings.vala:58
 msgid "Cancel"
 msgstr "لغو"
 
-#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:39
+#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:23
 msgid "Confirm"
 msgstr "تأیید"
 
@@ -454,37 +378,85 @@ msgstr "قالب‌بندی"
 msgid "Navigation"
 msgstr "ناوبری"
 
-#: src/ui/popup/shortcut_window.blp:102 src/ui/window/window.blp:216
+#: src/ui/popup/shortcut_window.blp:102 src/ui/window/window.blp:268
 msgid "Toggle Sidebar"
 msgstr "تعویض حالت نوار کناری"
 
-#: src/ui/popup/shortcut_window.blp:107 src/ui/window/window.blp:63
+#: src/ui/popup/shortcut_window.blp:107 src/ui/window/window.blp:70
 msgid "Search Notes"
 msgstr "جست‌وجوی یادداشت‌ها"
 
-#: data/app.gschema.xml:22 src/ui/preferences/preferences.blp:47
-msgid "Makes the dark theme pitch black"
-msgstr "سیاه مطلق کردن حالت تاریک"
-
-#: data/app.gschema.xml:26 src/ui/preferences/preferences.blp:87
-msgid "Enable Toolbar"
-msgstr "به کار انداختن جعبه‌ابزار"
-
-#: data/app.gschema.xml:31 src/ui/preferences/preferences.blp:98
-msgid "Enable Cheatsheet"
+#: src/ui/popup/shortcut_window.blp:114
+msgid "Display"
 msgstr ""
 
-#: data/app.gschema.xml:36 src/ui/preferences/preferences.blp:117
-msgid "3-Pane Layout"
-msgstr "چیدمان سه‌ستونه"
+#: src/ui/popup/shortcut_window.blp:117
+msgid "Full Screen"
+msgstr ""
 
-#: data/app.gschema.xml:41 src/ui/preferences/preferences.blp:185
-msgid "Notes Storage Location"
-msgstr "مکان ذخیره‌سازی یادداشت‌ها"
+#: src/ui/popup/shortcut_window.blp:122
+msgid "Zoom In"
+msgstr ""
 
-#: data/app.gschema.xml:42 src/ui/preferences/preferences.blp:186
-msgid "Where the notebooks are stored (requires app restart)"
-msgstr "جایی که یادداشت‌ها ذخیره می‌شوند (نیازمند راه‌اندازی دوبارهٔ کاره)"
+#: src/ui/popup/shortcut_window.blp:127
+msgid "Zoom Out"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:31
+#, fuzzy
+msgid "Markdown URL Detection"
+msgstr "برگهٔ تقلب مارک‌دون"
+
+#: src/ui/preferences/preferences.blp:32
+msgid ""
+"Determines the level of detection of URLs in\n"
+"free form text is used:\n"
+" - Aggressive tries to find all URLs\n"
+" - Strict requires a protocol identifier (ie http://)\n"
+" - Disabled turns detection off."
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:39
+msgid "Fonts"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:73
+msgid "Line Spacing"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:81
+msgid "Tools"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:133
+msgid "Layout"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:161
+msgid "Fixed Width To Use For Notes"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:162
+msgid "Sets the fixed width size of a note in px"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:167
+msgid "Sort Order For Notebooks"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:172
+msgid "Sort Order For Notes"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:179
+msgid "Files"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:197
+msgid ""
+"The trash folder is set as a hidden folder by default, this option makes it "
+"visible (requires app restart)"
+msgstr ""
 
 #: src/ui/strings.vala:4 src/ui/window/notebooks_bar/notebooks_bar.blp:129
 #: src/ui/window/notebooks_bar/notebooks_bar.blp:171
@@ -492,6 +464,7 @@ msgid "Trash"
 msgstr "زباله‌دان"
 
 #: src/ui/strings.vala:5
+#, c-format
 msgid "%d Notes"
 msgstr "%d یادداشت"
 
@@ -499,7 +472,7 @@ msgstr "%d یادداشت"
 msgid "Are you sure you want to delete everything in the trash?"
 msgstr "آیا مطمئنید که می‌خواهید تمامی موارد داخل زباله‌دان را حذف کنید؟"
 
-#: src/ui/strings.vala:7 src/ui/window/window.blp:54
+#: src/ui/strings.vala:7 src/ui/window/window.blp:61
 msgid "Empty Trash"
 msgstr "تخلیهٔ زباله‌دان"
 
@@ -536,10 +509,12 @@ msgid "Move"
 msgstr "انتقال"
 
 #: src/ui/strings.vala:18
+#, c-format
 msgid "Note “%s” already exists in notebook “%s”"
 msgstr "یادداشت «%s» هم‌اکنون در دفترچهٔ «%s» وجود دارد"
 
 #: src/ui/strings.vala:19
+#, c-format
 msgid "Are you sure you want to delete the note “%s”?"
 msgstr "آیا مطمئنید که می‌خواهید یادداشت «%s» را حذف کنید؟"
 
@@ -548,6 +523,7 @@ msgid "Delete Note"
 msgstr "حذف یادداشت"
 
 #: src/ui/strings.vala:21
+#, c-format
 msgid "Are you sure you want to delete the notebook “%s”?"
 msgstr "آیا مطمئنید که می‌خواهید دفترچهٔ «%s» را حذف کنید؟"
 
@@ -556,34 +532,42 @@ msgid "Delete Notebook"
 msgstr "حذف دفترچه"
 
 #: src/ui/strings.vala:24
-msgid "Note name shouldn’t contain “.” or “/”"
+#, fuzzy
+msgid "Note names cannot contain a “/”"
 msgstr "نام یادداشت نباید حاوی «.» یا «/» باشد"
 
 #: src/ui/strings.vala:25
-msgid "Note name shouldn’t be blank"
+#, fuzzy
+msgid "Note names cannot be blank"
 msgstr "نام یادداشت نمی‌تواند خالی باشد"
 
 #: src/ui/strings.vala:26
+#, c-format
 msgid "Note “%s” already exists"
 msgstr "یادداشت «%s» هم‌اکنون وجود دارد"
 
 #: src/ui/strings.vala:27
-msgid "Couldn’t create note"
+#, fuzzy
+msgid "Could not create note"
 msgstr "نمی‌توان یادداشت را ایجاد کرد"
 
 #: src/ui/strings.vala:28
-msgid "Couldn’t change note"
+#, fuzzy
+msgid "Could not change note"
 msgstr "نمی‌توان یادداشت را تغییر داد"
 
 #: src/ui/strings.vala:29
-msgid "Couldn’t delete note"
+#, fuzzy
+msgid "Could not delete note"
 msgstr "نمی‌توان یادداشت را حذف کرد"
 
 #: src/ui/strings.vala:30
-msgid "Couldn’t restore note"
+#, fuzzy
+msgid "Could not restore note"
 msgstr "نمی‌توان یادداشت را بازیابی کرد"
 
 #: src/ui/strings.vala:31
+#, c-format
 msgid "Saved “%s” to “%s”"
 msgstr "«%s» در «%s» ذخیره شد"
 
@@ -592,27 +576,33 @@ msgid "Unknown error"
 msgstr "خطای ناشناخته"
 
 #: src/ui/strings.vala:33
-msgid "Notebook name shouldn’t contain “.” or “/”"
+#, fuzzy
+msgid "Notebook names cannot contain a “/”"
 msgstr "نام دفترچه نباید حاوی «.» یا «/» باشد"
 
 #: src/ui/strings.vala:34
-msgid "Notebook name shouldn’t be blank"
+#, fuzzy
+msgid "Notebook names cannot be blank"
 msgstr "نام دفترچه نمی‌تواند خالی باشد"
 
 #: src/ui/strings.vala:35
+#, c-format
 msgid "Notebook “%s” already exists"
 msgstr "دفترچهٔ «%s» هم‌اکنون وجود دارد"
 
 #: src/ui/strings.vala:36
-msgid "Couldn’t create notebook"
+#, fuzzy
+msgid "Could not create notebook"
 msgstr "نمی‌توان دفترچه را ایجاد کرد"
 
 #: src/ui/strings.vala:37
-msgid "Couldn’t change notebook"
+#, fuzzy
+msgid "Could not change notebook"
 msgstr "نمی‌توان دفترچه را تغییر داد"
 
 #: src/ui/strings.vala:38
-msgid "Couldn’t delete notebook"
+#, fuzzy
+msgid "Could not delete notebook"
 msgstr "نمی‌توان دفترچه را حذف کرد"
 
 #: src/ui/strings.vala:40
@@ -624,7 +614,7 @@ msgid "Rename"
 msgstr "تغییر نام"
 
 #: src/ui/strings.vala:42
-msgid "Couldn’t find an app to handle file URIs"
+msgid "Could not find an app to handle file URIs"
 msgstr ""
 
 #: src/ui/strings.vala:43
@@ -634,6 +624,10 @@ msgstr "اِعمال"
 #: src/ui/strings.vala:45
 msgid "Pick where the notebooks will be stored"
 msgstr "جایی که دفترچه‌ها ذخیره می‌شوند را انتخاب کنید"
+
+#: src/ui/strings.vala:46
+msgid "Pick where the trash can will be stored"
+msgstr ""
 
 #: src/ui/strings.vala:47 src/ui/window/notebooks_bar/notebooks_bar.blp:59
 #: src/ui/window/notebooks_bar/notebooks_bar.blp:101
@@ -646,6 +640,110 @@ msgstr ""
 
 #: src/ui/strings.vala:50
 msgid "Extension"
+msgstr ""
+
+#: src/ui/strings.vala:51
+msgid "Unable to recognize URI"
+msgstr ""
+
+#: src/ui/strings.vala:52
+msgid "Pick primary font for notes"
+msgstr ""
+
+#: src/ui/strings.vala:53
+msgid "Pick monospace font for code"
+msgstr ""
+
+#: src/ui/strings.vala:54
+msgid "File Changed On Disk"
+msgstr ""
+
+#: src/ui/strings.vala:55
+msgid ""
+"The file has changed on disk since it was last saved/loaded by Folio.\n"
+"\n"
+"You may do one of the following:\n"
+"\n"
+" • Reload the file (discarding any changes you have made in Folio)\n"
+" • Overwrite the file (discarding any changes made outside of Folio)\n"
+" • Cancel the operation and manually resolve the issue\n"
+"\n"
+"Note: Canceling the save if you have already moved to a new note/notebook "
+"will discard your changes."
+msgstr ""
+
+#: src/ui/strings.vala:56
+msgid "Reload"
+msgstr ""
+
+#: src/ui/strings.vala:57
+msgid "Overwrite"
+msgstr ""
+
+#: src/ui/strings.vala:59
+msgid ""
+"The file has changed on disk by another application.\n"
+"\n"
+"You may do one of the following:\n"
+"\n"
+" • Reload the file (discarding any changes you have made in Folio)\n"
+" • Overwrite the file (discarding any changes made outside of Folio)"
+msgstr ""
+
+#: src/ui/strings.vala:61
+#, c-format
+msgid "Note %i"
+msgstr ""
+
+#: src/ui/strings.vala:62
+msgid "Modified Time - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:63
+msgid "Modified Time - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:64
+msgid "Alphabetical - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:65
+msgid "Alphabetical - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:66
+msgid "Natural - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:67
+msgid "Natural - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:68
+#, c-format
+msgid "Unable to launch external application for file %s."
+msgstr ""
+
+#: src/ui/strings.vala:69
+msgid "Aggressive"
+msgstr ""
+
+#: src/ui/strings.vala:70
+msgid "Strict"
+msgstr ""
+
+#: src/ui/strings.vala:71
+msgid "Disabled"
+msgstr ""
+
+#: src/ui/strings.vala:72
+#, fuzzy, c-format
+msgid "“%s” moved to trash"
+msgstr "انتقال به زباله‌دان"
+
+#: src/ui/strings.vala:73
+#, c-format
+msgid "“%s” restored"
 msgstr ""
 
 #: src/ui/widgets/theme_selector/theme_selector.blp:15
@@ -677,40 +775,45 @@ msgid "_Keyboard Shortcuts"
 msgstr "_میان‌برهای صفحه‌کلید"
 
 #: src/ui/window/app_menu/app_menu.blp:43
-msgid "_About"
+#, fuzzy
+msgid "_About Folio"
 msgstr "_درباره"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:54
-msgid "Notebook Name"
-msgstr "نام دفترچه"
-
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:66
-msgid "Duplicate notebook names are not allowed!"
-msgstr ""
-
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:82
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:6
 msgid "First Characters"
 msgstr "نویسه‌های نخست"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:83
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:7
 msgid "Initials"
 msgstr "حروف اول"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:84
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:8
 msgid "Initials: camelCase"
 msgstr "حروف اول: CamelCase"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:85
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:9
 msgid "Initials: snake_case"
 msgstr "حروف اول: snake_case"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:86
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:10
 msgid "Icon"
 msgstr "نقشک"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:116
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:11
+msgid "Custom"
+msgstr ""
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:16
 msgid "Notebook Color"
 msgstr "رنگ دفترچه"
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:58
+msgid "Notebook Name"
+msgstr "نام دفترچه"
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:70
+msgid "Duplicate notebook names are not allowed!"
+msgstr ""
 
 #: src/ui/window/notebooks_bar/notebook_create_popup.blp:126
 msgid "Create Notebook"
@@ -728,11 +831,11 @@ msgstr "انتقال همه به زباله‌دان"
 msgid "Notebooks"
 msgstr ""
 
-#: src/ui/window/sidebar/note_create_popup.blp:37
+#: src/ui/window/sidebar/note_create_popup.blp:25
 msgid "Note Name"
 msgstr "نام یادداشت"
 
-#: src/ui/window/sidebar/note_create_popup.blp:45
+#: src/ui/window/sidebar/note_create_popup.blp:33
 msgid "Create Note"
 msgstr "ایجاد یادداشت"
 
@@ -756,30 +859,37 @@ msgstr "انتقال به زباله‌دان"
 msgid "Open Containing Folder"
 msgstr "گشودن شاخهٔ محتوی"
 
-#: src/ui/window/window.blp:118
+#: src/ui/window/window.blp:123
 msgid "Get started writing"
 msgstr "شروع نوشتن"
 
-#: src/ui/window/window.blp:143
+#: src/ui/window/window.blp:152
+msgid "Open file in external application"
+msgstr ""
+
+#: src/ui/window/window.blp:160
+msgid "Open file"
+msgstr ""
+
+#: src/ui/window/window.blp:181
 msgid "Create a notebook"
 msgstr "ایجاد یک دفترچه"
 
-#: src/ui/window/window.blp:168
+#: src/ui/window/window.blp:210
 msgid "Trash is empty"
 msgstr "زباله‌دان خالی است"
 
-#: src/ui/window/window.blp:224
-msgid "Back"
-msgstr "بازگشت"
-
-#: src/ui/window/window.blp:239
+#: src/ui/window/window.blp:285
 msgid "Open in Notebook"
 msgstr "گشودن در دفترچه"
 
-#: src/ui/window/window.blp:264
+#: src/ui/window/window.blp:312
 msgid "_Rename Note"
 msgstr "_تغییر نام یادداشت"
 
-#: src/ui/window/window.blp:270
+#: src/ui/window/window.blp:319
 msgid "_Export Note"
 msgstr "_برون‌ریزی یادداشت"
+
+#~ msgid "Back"
+#~ msgstr "بازگشت"

--- a/po/fi.po
+++ b/po/fi.po
@@ -2,229 +2,16 @@
 # This file is distributed under the same license as the Folio package.
 msgid ""
 msgstr ""
+"Project-Id-Version: Folio\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-10-12 16:53+0200\n"
 "PO-Revision-Date: 2024-03-02 16:56:39+0000\n"
+"Language: fi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: GlotPress/4.0.0\n"
-"Language: fi\n"
-"Project-Id-Version: Folio\n"
-
-#: data/app.gschema.xml:76
-msgid "Notebook sort order"
-msgstr ""
-
-#: data/app.gschema.xml:77
-msgid "The sort order of the notebook list"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:145
-msgid "Sort Order For Notebooks"
-msgstr ""
-
-#: data/app.gschema.xml:71
-msgid "Note sort order"
-msgstr ""
-
-#: data/app.gschema.xml:72
-msgid "The sort order of the note list"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:150
-msgid "Sort Order For Notes"
-msgstr ""
-
-#: src/ui/strings.vala:62
-msgid "Modified Time - Ascending"
-msgstr ""
-
-#: src/ui/strings.vala:63
-msgid "Modified Time - Descending"
-msgstr ""
-
-#: src/ui/strings.vala:64
-msgid "Alphabetical - Ascending"
-msgstr ""
-
-#: src/ui/strings.vala:65
-msgid "Alphabetical - Descending"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:114
-msgid "Display"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:117
-msgid "Full Screen"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:122
-msgid "Zoom In"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:127
-msgid "Zoom Out"
-msgstr ""
-
-#: src/ui/strings.vala:52
-msgid "Pick primary font for notes"
-msgstr ""
-
-#: src/ui/strings.vala:53
-msgid "Pick monospace font for code"
-msgstr ""
-
-#: src/ui/strings.vala:54
-msgid "File Changed On Disk"
-msgstr ""
-
-#: src/ui/strings.vala:55
-msgid ""
-"The file has changed on disk since it was last saved/loaded by Folio.\n"
-"\n"
-"You may do one of the following:\n"
-"\n"
-" • Reload the file (discarding any changes you have made in Folio)\n"
-" • Overwrite the file (discarding any changes made outside of Folio)\n"
-" • Cancel the operation and manually resolve the issue\n"
-"\n"
-"Note: Canceling the save if you have already moved to a new note/notebook will discard your changes."
-msgstr ""
-
-#: src/ui/strings.vala:56
-msgid "Reload"
-msgstr ""
-
-#: src/ui/strings.vala:57
-msgid "Overwrite"
-msgstr ""
-
-#: src/ui/strings.vala:59
-msgid ""
-"The file has changed on disk by another application.\n"
-"\n"
-"You may do one of the following:\n"
-"\n"
-" • Reload the file (discarding any changes you have made in Folio)\n"
-" • Overwrite the file (discarding any changes made outside of Folio)"
-msgstr ""
-
-#: src/ui/strings.vala:61
-msgid "Note %i"
-msgstr ""
-
-#: data/app.gschema.xml:46 src/ui/preferences/preferences.blp:213
-msgid "Trash Storage Location"
-msgstr ""
-
-#: data/app.gschema.xml:47 src/ui/preferences/preferences.blp:214
-msgid "Where the trash folder is located (requires app restart)"
-msgstr ""
-
-#: src/ui/strings.vala:46
-msgid "Pick where the trash can will be stored"
-msgstr ""
-
-#: data/app.gschema.xml:16 src/ui/preferences/preferences.blp:128
-msgid "Use Fixed Width For Notes"
-msgstr ""
-
-#: data/app.gschema.xml:17 src/ui/preferences/preferences.blp:129
-msgid "Use a fixed width for the text area of a note"
-msgstr ""
-
-#: data/app.gschema.xml:37 src/ui/preferences/preferences.blp:118
-msgid "Expands the notebook list to include the notebook name"
-msgstr ""
-
-#: data/app.gschema.xml:51 src/ui/preferences/preferences.blp:65
-msgid "Show line numbers"
-msgstr ""
-
-#: data/app.gschema.xml:52 src/ui/preferences/preferences.blp:66
-msgid "Displays line numbers at the left of the note"
-msgstr ""
-
-#: data/app.gschema.xml:56 src/ui/preferences/preferences.blp:76
-msgid "Show all notes"
-msgstr ""
-
-#: data/app.gschema.xml:57 src/ui/preferences/preferences.blp:77
-msgid "Displays the \"All Notes\" notebook at the top of the notebook list"
-msgstr ""
-
-#: data/app.gschema.xml:61 src/ui/preferences/preferences.blp:163
-msgid "Enable autosave"
-msgstr ""
-
-#: data/app.gschema.xml:62 src/ui/preferences/preferences.blp:164
-msgid "Automatically saves the current note every 30 seconds if the contents have changed (requires app restart)"
-msgstr ""
-
-#: data/app.gschema.xml:66 src/ui/preferences/preferences.blp:174
-msgid "Don't hide the Trash folder"
-msgstr ""
-
-#: data/app.gschema.xml:67
-msgid "The trash folder is set as a hidden folder by default, this option makes it visible"
-msgstr ""
-
-#: data/app.metainfo.xml.in:367
-msgid "Main Folio window in light mode"
-msgstr ""
-
-#: data/app.metainfo.xml.in:371
-msgid "Main Folio window in dark mode"
-msgstr ""
-
-#: data/app.metainfo.xml.in:375
-msgid "Folio on small/mobile screens"
-msgstr ""
-
-#: data/app.metainfo.xml.in:379
-msgid "Folio preferences screen"
-msgstr ""
-
-#: data/app.metainfo.xml.in:383
-msgid "Folio in three pane mode"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:59
-msgid "Tools"
-msgstr ""
-
-#: data/app.gschema.xml:27 src/ui/preferences/preferences.blp:88
-msgid "Displays the formatting toolbar at the bottom of the note"
-msgstr ""
-
-#: data/app.gschema.xml:32 src/ui/preferences/preferences.blp:99
-msgid "Adds a button to the markdown reference sheet on the right of the formatting toolbar"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:111
-msgid "Layout"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:139
-msgid "Fixed Width To Use For Notes"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:140
-msgid "Sets the fixed width size of a note in px"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:157
-msgid "Files"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:175
-msgid "The trash folder is set as a hidden folder by default, this option makes it visible (requires app restart)"
-msgstr ""
-
-#: src/ui/strings.vala:51
-msgid "Unable to recognize URI"
-msgstr ""
 
 #: data/app.desktop.in:9 src/ui/strings.vala:3
 msgid "Folio"
@@ -243,18 +30,18 @@ msgid "Notebook;Note;Notes;Text;Markdown;Notepad;Write;School;Post-it;Sticky;"
 msgstr "Notebook;Note;Notes;Text;Markdown;Notepad;Write;School;Post-it;Sticky;"
 
 #: data/app.desktop.in:22 src/ui/popup/shortcut_window.blp:17
-#: src/ui/strings.vala:8 src/ui/window/window.blp:47
-#: src/ui/window/window.blp:124
+#: src/ui/strings.vala:8 src/ui/window/window.blp:54
+#: src/ui/window/window.blp:131
 msgid "New Note"
 msgstr "Uusi muistiinpano"
 
 #: data/app.desktop.in:26 src/ui/popup/shortcut_window.blp:37
-#: src/ui/strings.vala:14 src/ui/window/window.blp:149
+#: src/ui/strings.vala:14 src/ui/window/window.blp:189
 msgid "New Notebook"
 msgstr "Uusi muistikirja"
 
-#: data/app.desktop.in:30 src/ui/edit_view/toolbar/toolbar.blp:90
-#: src/ui/strings.vala:39 src/ui/window/window.blp:245
+#: data/app.desktop.in:30 src/ui/edit_view/toolbar/toolbar.blp:92
+#: src/ui/strings.vala:39 src/ui/window/window.blp:291
 msgid "Markdown Cheatsheet"
 msgstr "Markdown-ohje"
 
@@ -262,25 +49,149 @@ msgstr "Markdown-ohje"
 msgid "Preferences"
 msgstr "Asetukset"
 
-#: data/app.gschema.xml:6 src/ui/preferences/preferences.blp:18
+#: data/app.gschema.xml:6 src/ui/preferences/preferences.blp:45
 msgid "Note Font"
 msgstr "Muistiinpanon fontti"
 
-#: data/app.gschema.xml:7 src/ui/preferences/preferences.blp:19
+#: data/app.gschema.xml:7 src/ui/preferences/preferences.blp:46
 msgid "The font notes will be displayed in"
 msgstr "Muistiinpanojen fontti"
 
-#: data/app.gschema.xml:11 src/ui/preferences/preferences.blp:31
+#: data/app.gschema.xml:11 src/ui/preferences/preferences.blp:58
 msgid "Monospace Font"
 msgstr ""
 
-#: data/app.gschema.xml:12 src/ui/preferences/preferences.blp:32
+#: data/app.gschema.xml:12 src/ui/preferences/preferences.blp:59
 msgid "The font code will be displayed in"
 msgstr ""
 
-#: data/app.gschema.xml:21 src/ui/preferences/preferences.blp:46
+#: data/app.gschema.xml:16 src/ui/preferences/preferences.blp:150
+msgid "Use Fixed Width For Notes"
+msgstr ""
+
+#: data/app.gschema.xml:17 src/ui/preferences/preferences.blp:151
+msgid "Use a fixed width for the text area of a note"
+msgstr ""
+
+#: data/app.gschema.xml:21 src/ui/preferences/preferences.blp:18
 msgid "OLED Mode"
 msgstr "OLED-tila"
+
+#: data/app.gschema.xml:22 src/ui/preferences/preferences.blp:19
+msgid "Makes the dark theme pitch black"
+msgstr "Tekee tummasta teemasta täysin mustan"
+
+#: data/app.gschema.xml:26 src/ui/preferences/preferences.blp:109
+msgid "Enable Toolbar"
+msgstr ""
+
+#: data/app.gschema.xml:27 src/ui/preferences/preferences.blp:110
+msgid "Displays the formatting toolbar at the bottom of the note"
+msgstr ""
+
+#: data/app.gschema.xml:31 src/ui/preferences/preferences.blp:120
+msgid "Enable Cheatsheet"
+msgstr ""
+
+#: data/app.gschema.xml:32 src/ui/preferences/preferences.blp:121
+msgid ""
+"Adds a button to the markdown reference sheet on the right of the formatting "
+"toolbar"
+msgstr ""
+
+#: data/app.gschema.xml:36 src/ui/preferences/preferences.blp:139
+msgid "3-Pane Layout"
+msgstr ""
+
+#: data/app.gschema.xml:37 src/ui/preferences/preferences.blp:140
+msgid "Expands the notebook list to include the notebook name"
+msgstr ""
+
+#: data/app.gschema.xml:41 src/ui/preferences/preferences.blp:207
+msgid "Notes Storage Location"
+msgstr "Muistiinpanojen tallennuskansio"
+
+#: data/app.gschema.xml:42 src/ui/preferences/preferences.blp:208
+msgid "Where the notebooks are stored (requires app restart)"
+msgstr ""
+"Kansio, johon muistikirjat tallennetaan (vaatii sovelluksen "
+"uudelleenkäynnistyksen)"
+
+#: data/app.gschema.xml:46 src/ui/preferences/preferences.blp:235
+msgid "Trash Storage Location"
+msgstr ""
+
+#: data/app.gschema.xml:47 src/ui/preferences/preferences.blp:236
+msgid "Where the trash folder is located (requires app restart)"
+msgstr ""
+
+#: data/app.gschema.xml:51 src/ui/preferences/preferences.blp:87
+msgid "Show line numbers"
+msgstr ""
+
+#: data/app.gschema.xml:52 src/ui/preferences/preferences.blp:88
+msgid "Displays line numbers at the left of the note"
+msgstr ""
+
+#: data/app.gschema.xml:56 src/ui/preferences/preferences.blp:98
+msgid "Show all notes"
+msgstr ""
+
+#: data/app.gschema.xml:57 src/ui/preferences/preferences.blp:99
+msgid "Displays the \"All Notes\" notebook at the top of the notebook list"
+msgstr ""
+
+#: data/app.gschema.xml:61 src/ui/preferences/preferences.blp:185
+msgid "Enable autosave"
+msgstr ""
+
+#: data/app.gschema.xml:62 src/ui/preferences/preferences.blp:186
+msgid ""
+"Automatically saves the current note every 30 seconds if the contents have "
+"changed (requires app restart)"
+msgstr ""
+
+#: data/app.gschema.xml:66 src/ui/preferences/preferences.blp:196
+msgid "Don't hide the Trash folder"
+msgstr ""
+
+#: data/app.gschema.xml:67
+msgid ""
+"The trash folder is set as a hidden folder by default, this option makes it "
+"visible"
+msgstr ""
+
+#: data/app.gschema.xml:71
+msgid "Note sort order"
+msgstr ""
+
+#: data/app.gschema.xml:72
+msgid "The sort order of the note list"
+msgstr ""
+
+#: data/app.gschema.xml:76
+msgid "Notebook sort order"
+msgstr ""
+
+#: data/app.gschema.xml:77
+msgid "The sort order of the notebook list"
+msgstr ""
+
+#: data/app.gschema.xml:81
+msgid "URL detection level"
+msgstr ""
+
+#: data/app.gschema.xml:82
+msgid "How agressive to look for URLs in markdown text"
+msgstr ""
+
+#: data/app.gschema.xml:86
+msgid "Line spacing"
+msgstr ""
+
+#: data/app.gschema.xml:87 src/ui/preferences/preferences.blp:74
+msgid "The line spacing for the note text"
+msgstr ""
 
 #: data/app.metainfo.xml.in:5
 msgid "Take notes in Markdown"
@@ -314,103 +225,116 @@ msgstr ""
 msgid "Trash can"
 msgstr "Roskakori"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:23
-#: src/ui/edit_view/toolbar/toolbar.blp:131
+#: data/app.metainfo.xml.in:393
+msgid "Main Folio window in light mode"
+msgstr ""
+
+#: data/app.metainfo.xml.in:397
+msgid "Main Folio window in dark mode"
+msgstr ""
+
+#: data/app.metainfo.xml.in:401
+msgid "Folio on small/mobile screens"
+msgstr ""
+
+#: data/app.metainfo.xml.in:405
+msgid "Folio preferences screen"
+msgstr ""
+
+#: data/app.metainfo.xml.in:409
+msgid "Folio in three pane mode"
+msgstr ""
+
+#: src/ui/edit_view/toolbar/toolbar.blp:6
 #: src/ui/widgets/markdown/heading_popover.blp:48
 msgid "Plain Text"
 msgstr "Leipäteksti"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:24
-#: src/ui/edit_view/toolbar/toolbar.blp:132
+#: src/ui/edit_view/toolbar/toolbar.blp:7
 #: src/ui/widgets/markdown/heading_popover.blp:12
 msgid "Heading 1"
 msgstr "Otsikko 1"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:25
-#: src/ui/edit_view/toolbar/toolbar.blp:133
+#: src/ui/edit_view/toolbar/toolbar.blp:8
 #: src/ui/widgets/markdown/heading_popover.blp:18
 msgid "Heading 2"
 msgstr "Otsikko 2"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:26
-#: src/ui/edit_view/toolbar/toolbar.blp:134
+#: src/ui/edit_view/toolbar/toolbar.blp:9
 #: src/ui/widgets/markdown/heading_popover.blp:24
 msgid "Heading 3"
 msgstr "Otsikko 3"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:27
-#: src/ui/edit_view/toolbar/toolbar.blp:135
+#: src/ui/edit_view/toolbar/toolbar.blp:10
 #: src/ui/widgets/markdown/heading_popover.blp:30
 msgid "Heading 4"
 msgstr "Otsikko 4"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:28
-#: src/ui/edit_view/toolbar/toolbar.blp:136
+#: src/ui/edit_view/toolbar/toolbar.blp:11
 #: src/ui/widgets/markdown/heading_popover.blp:36
 msgid "Heading 5"
 msgstr "Otsikko 5"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:29
-#: src/ui/edit_view/toolbar/toolbar.blp:137
+#: src/ui/edit_view/toolbar/toolbar.blp:12
 #: src/ui/widgets/markdown/heading_popover.blp:42
 msgid "Heading 6"
 msgstr "Otsikko 6"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:39
-#: src/ui/edit_view/toolbar/toolbar.blp:104
-#: src/ui/edit_view/toolbar/toolbar.blp:148
-#: src/ui/edit_view/toolbar/toolbar.blp:201 src/ui/popup/shortcut_window.blp:72
+#: src/ui/edit_view/toolbar/toolbar.blp:41
+#: src/ui/edit_view/toolbar/toolbar.blp:107
+#: src/ui/edit_view/toolbar/toolbar.blp:142
+#: src/ui/edit_view/toolbar/toolbar.blp:195 src/ui/popup/shortcut_window.blp:72
 msgid "Bold"
 msgstr "Lihavointi"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:45
-#: src/ui/edit_view/toolbar/toolbar.blp:111
-#: src/ui/edit_view/toolbar/toolbar.blp:155
-#: src/ui/edit_view/toolbar/toolbar.blp:202 src/ui/popup/shortcut_window.blp:77
+#: src/ui/edit_view/toolbar/toolbar.blp:47
+#: src/ui/edit_view/toolbar/toolbar.blp:114
+#: src/ui/edit_view/toolbar/toolbar.blp:149
+#: src/ui/edit_view/toolbar/toolbar.blp:196 src/ui/popup/shortcut_window.blp:77
 msgid "Italic"
 msgstr "Kursiivi"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:51
-#: src/ui/edit_view/toolbar/toolbar.blp:162
-#: src/ui/edit_view/toolbar/toolbar.blp:203 src/ui/popup/shortcut_window.blp:82
+#: src/ui/edit_view/toolbar/toolbar.blp:53
+#: src/ui/edit_view/toolbar/toolbar.blp:156
+#: src/ui/edit_view/toolbar/toolbar.blp:197 src/ui/popup/shortcut_window.blp:82
 msgid "Strikethrough"
 msgstr "Yliviivaus"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:57
-#: src/ui/edit_view/toolbar/toolbar.blp:169
-#: src/ui/edit_view/toolbar/toolbar.blp:204 src/ui/popup/shortcut_window.blp:87
+#: src/ui/edit_view/toolbar/toolbar.blp:59
+#: src/ui/edit_view/toolbar/toolbar.blp:163
+#: src/ui/edit_view/toolbar/toolbar.blp:198 src/ui/popup/shortcut_window.blp:87
 msgid "Highlight"
 msgstr "Korostus"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:67
-#: src/ui/edit_view/toolbar/toolbar.blp:193 src/ui/popup/shortcut_window.blp:92
+#: src/ui/edit_view/toolbar/toolbar.blp:69
+#: src/ui/edit_view/toolbar/toolbar.blp:187 src/ui/popup/shortcut_window.blp:92
 msgid "Insert Link"
 msgstr "Lisää linkki"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:73
-#: src/ui/edit_view/toolbar/toolbar.blp:194
+#: src/ui/edit_view/toolbar/toolbar.blp:75
+#: src/ui/edit_view/toolbar/toolbar.blp:188
 msgid "Insert Code"
 msgstr "Lisää ohjelmakoodi"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:79
-#: src/ui/edit_view/toolbar/toolbar.blp:195
+#: src/ui/edit_view/toolbar/toolbar.blp:81
+#: src/ui/edit_view/toolbar/toolbar.blp:189
 msgid "Insert Horizontal Rule"
 msgstr ""
 
-#: src/ui/edit_view/toolbar/toolbar.blp:118
+#: src/ui/edit_view/toolbar/toolbar.blp:121
 msgid "Format"
 msgstr ""
 
-#: src/ui/edit_view/toolbar/toolbar.blp:181
+#: src/ui/edit_view/toolbar/toolbar.blp:175
 msgid "Insert"
 msgstr ""
 
-#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:34
+#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:18
 #: src/ui/strings.vala:44 src/ui/strings.vala:58
 msgid "Cancel"
 msgstr "Peruuta"
 
-#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:39
+#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:23
 msgid "Confirm"
 msgstr "Vahvista"
 
@@ -454,37 +378,85 @@ msgstr "Muotoilu"
 msgid "Navigation"
 msgstr "Navigaatio"
 
-#: src/ui/popup/shortcut_window.blp:102 src/ui/window/window.blp:216
+#: src/ui/popup/shortcut_window.blp:102 src/ui/window/window.blp:268
 msgid "Toggle Sidebar"
 msgstr "Avaa/sulje sivupalkki"
 
-#: src/ui/popup/shortcut_window.blp:107 src/ui/window/window.blp:63
+#: src/ui/popup/shortcut_window.blp:107 src/ui/window/window.blp:70
 msgid "Search Notes"
 msgstr "Etsi muistiinpanoista"
 
-#: data/app.gschema.xml:22 src/ui/preferences/preferences.blp:47
-msgid "Makes the dark theme pitch black"
-msgstr "Tekee tummasta teemasta täysin mustan"
-
-#: data/app.gschema.xml:26 src/ui/preferences/preferences.blp:87
-msgid "Enable Toolbar"
+#: src/ui/popup/shortcut_window.blp:114
+msgid "Display"
 msgstr ""
 
-#: data/app.gschema.xml:31 src/ui/preferences/preferences.blp:98
-msgid "Enable Cheatsheet"
+#: src/ui/popup/shortcut_window.blp:117
+msgid "Full Screen"
 msgstr ""
 
-#: data/app.gschema.xml:36 src/ui/preferences/preferences.blp:117
-msgid "3-Pane Layout"
+#: src/ui/popup/shortcut_window.blp:122
+msgid "Zoom In"
 msgstr ""
 
-#: data/app.gschema.xml:41 src/ui/preferences/preferences.blp:185
-msgid "Notes Storage Location"
-msgstr "Muistiinpanojen tallennuskansio"
+#: src/ui/popup/shortcut_window.blp:127
+msgid "Zoom Out"
+msgstr ""
 
-#: data/app.gschema.xml:42 src/ui/preferences/preferences.blp:186
-msgid "Where the notebooks are stored (requires app restart)"
-msgstr "Kansio, johon muistikirjat tallennetaan (vaatii sovelluksen uudelleenkäynnistyksen)"
+#: src/ui/preferences/preferences.blp:31
+#, fuzzy
+msgid "Markdown URL Detection"
+msgstr "Markdown-ohje"
+
+#: src/ui/preferences/preferences.blp:32
+msgid ""
+"Determines the level of detection of URLs in\n"
+"free form text is used:\n"
+" - Aggressive tries to find all URLs\n"
+" - Strict requires a protocol identifier (ie http://)\n"
+" - Disabled turns detection off."
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:39
+msgid "Fonts"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:73
+msgid "Line Spacing"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:81
+msgid "Tools"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:133
+msgid "Layout"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:161
+msgid "Fixed Width To Use For Notes"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:162
+msgid "Sets the fixed width size of a note in px"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:167
+msgid "Sort Order For Notebooks"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:172
+msgid "Sort Order For Notes"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:179
+msgid "Files"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:197
+msgid ""
+"The trash folder is set as a hidden folder by default, this option makes it "
+"visible (requires app restart)"
+msgstr ""
 
 #: src/ui/strings.vala:4 src/ui/window/notebooks_bar/notebooks_bar.blp:129
 #: src/ui/window/notebooks_bar/notebooks_bar.blp:171
@@ -492,6 +464,7 @@ msgid "Trash"
 msgstr "Roskat"
 
 #: src/ui/strings.vala:5
+#, c-format
 msgid "%d Notes"
 msgstr "%d muistiinpanoa"
 
@@ -499,7 +472,7 @@ msgstr "%d muistiinpanoa"
 msgid "Are you sure you want to delete everything in the trash?"
 msgstr "Haluatko varmasti tuhota kaiken roskakorissa?"
 
-#: src/ui/strings.vala:7 src/ui/window/window.blp:54
+#: src/ui/strings.vala:7 src/ui/window/window.blp:61
 msgid "Empty Trash"
 msgstr "Tyhjennä roskakori"
 
@@ -536,10 +509,12 @@ msgid "Move"
 msgstr "Siirrä"
 
 #: src/ui/strings.vala:18
+#, c-format
 msgid "Note “%s” already exists in notebook “%s”"
 msgstr "Muistiinpano ”%s” löytyy jo muistikirjasta ”%s”"
 
 #: src/ui/strings.vala:19
+#, c-format
 msgid "Are you sure you want to delete the note “%s”?"
 msgstr "Haluatko varmasti poistaa muistiinpanon ”%s”?"
 
@@ -548,6 +523,7 @@ msgid "Delete Note"
 msgstr "Poista muistiinpano"
 
 #: src/ui/strings.vala:21
+#, c-format
 msgid "Are you sure you want to delete the notebook “%s”?"
 msgstr "Haluatko varmasti poistaa muistikirjan ”%s”?"
 
@@ -556,34 +532,42 @@ msgid "Delete Notebook"
 msgstr "Poista muistikirja"
 
 #: src/ui/strings.vala:24
-msgid "Note name shouldn’t contain “.” or “/”"
+#, fuzzy
+msgid "Note names cannot contain a “/”"
 msgstr "Muistiinpanon nimi ei saa sisältää merkkejä ”.” tai ”/”"
 
 #: src/ui/strings.vala:25
-msgid "Note name shouldn’t be blank"
+#, fuzzy
+msgid "Note names cannot be blank"
 msgstr "Muistiinpanon nimi ei saa olla tyhjä"
 
 #: src/ui/strings.vala:26
+#, c-format
 msgid "Note “%s” already exists"
 msgstr "Muistiinpano ”%s” on jo olemassa"
 
 #: src/ui/strings.vala:27
-msgid "Couldn’t create note"
+#, fuzzy
+msgid "Could not create note"
 msgstr "Muistiinpanon luominen ei onnistunut"
 
 #: src/ui/strings.vala:28
-msgid "Couldn’t change note"
+#, fuzzy
+msgid "Could not change note"
 msgstr "Muistiinpanon muuttaminen ei onnistunut"
 
 #: src/ui/strings.vala:29
-msgid "Couldn’t delete note"
+#, fuzzy
+msgid "Could not delete note"
 msgstr "Muistiinpanon poistaminen ei onnistunut"
 
 #: src/ui/strings.vala:30
-msgid "Couldn’t restore note"
+#, fuzzy
+msgid "Could not restore note"
 msgstr "Muistiinpanon palauttaminen ei onnistunut"
 
 #: src/ui/strings.vala:31
+#, c-format
 msgid "Saved “%s” to “%s”"
 msgstr "Tallennettu ”%s” kohteeseen ”%s”"
 
@@ -592,27 +576,33 @@ msgid "Unknown error"
 msgstr "Tuntematon virhe"
 
 #: src/ui/strings.vala:33
-msgid "Notebook name shouldn’t contain “.” or “/”"
+#, fuzzy
+msgid "Notebook names cannot contain a “/”"
 msgstr "Muistikirjan nimi ei saa sisältää merkkejä ”.” ja ”/”"
 
 #: src/ui/strings.vala:34
-msgid "Notebook name shouldn’t be blank"
+#, fuzzy
+msgid "Notebook names cannot be blank"
 msgstr "Muistikirjan nimi ei saa olla tyhjä"
 
 #: src/ui/strings.vala:35
+#, c-format
 msgid "Notebook “%s” already exists"
 msgstr "Muistikirja ”%s” on jo olemassa"
 
 #: src/ui/strings.vala:36
-msgid "Couldn’t create notebook"
+#, fuzzy
+msgid "Could not create notebook"
 msgstr "Muistikirjan luominen ei onnistunut"
 
 #: src/ui/strings.vala:37
-msgid "Couldn’t change notebook"
+#, fuzzy
+msgid "Could not change notebook"
 msgstr "Muistikirjan muuttaminen ei onnistunut"
 
 #: src/ui/strings.vala:38
-msgid "Couldn’t delete notebook"
+#, fuzzy
+msgid "Could not delete notebook"
 msgstr "Muistikirjan poistaminen ei onnistunut"
 
 #: src/ui/strings.vala:40
@@ -624,7 +614,7 @@ msgid "Rename"
 msgstr "Nimeä uudelleen"
 
 #: src/ui/strings.vala:42
-msgid "Couldn’t find an app to handle file URIs"
+msgid "Could not find an app to handle file URIs"
 msgstr ""
 
 #: src/ui/strings.vala:43
@@ -634,6 +624,10 @@ msgstr "Käytä"
 #: src/ui/strings.vala:45
 msgid "Pick where the notebooks will be stored"
 msgstr "Valitse muistikirjojen tallennuskansio"
+
+#: src/ui/strings.vala:46
+msgid "Pick where the trash can will be stored"
+msgstr ""
 
 #: src/ui/strings.vala:47 src/ui/window/notebooks_bar/notebooks_bar.blp:59
 #: src/ui/window/notebooks_bar/notebooks_bar.blp:101
@@ -646,6 +640,110 @@ msgstr ""
 
 #: src/ui/strings.vala:50
 msgid "Extension"
+msgstr ""
+
+#: src/ui/strings.vala:51
+msgid "Unable to recognize URI"
+msgstr ""
+
+#: src/ui/strings.vala:52
+msgid "Pick primary font for notes"
+msgstr ""
+
+#: src/ui/strings.vala:53
+msgid "Pick monospace font for code"
+msgstr ""
+
+#: src/ui/strings.vala:54
+msgid "File Changed On Disk"
+msgstr ""
+
+#: src/ui/strings.vala:55
+msgid ""
+"The file has changed on disk since it was last saved/loaded by Folio.\n"
+"\n"
+"You may do one of the following:\n"
+"\n"
+" • Reload the file (discarding any changes you have made in Folio)\n"
+" • Overwrite the file (discarding any changes made outside of Folio)\n"
+" • Cancel the operation and manually resolve the issue\n"
+"\n"
+"Note: Canceling the save if you have already moved to a new note/notebook "
+"will discard your changes."
+msgstr ""
+
+#: src/ui/strings.vala:56
+msgid "Reload"
+msgstr ""
+
+#: src/ui/strings.vala:57
+msgid "Overwrite"
+msgstr ""
+
+#: src/ui/strings.vala:59
+msgid ""
+"The file has changed on disk by another application.\n"
+"\n"
+"You may do one of the following:\n"
+"\n"
+" • Reload the file (discarding any changes you have made in Folio)\n"
+" • Overwrite the file (discarding any changes made outside of Folio)"
+msgstr ""
+
+#: src/ui/strings.vala:61
+#, c-format
+msgid "Note %i"
+msgstr ""
+
+#: src/ui/strings.vala:62
+msgid "Modified Time - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:63
+msgid "Modified Time - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:64
+msgid "Alphabetical - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:65
+msgid "Alphabetical - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:66
+msgid "Natural - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:67
+msgid "Natural - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:68
+#, c-format
+msgid "Unable to launch external application for file %s."
+msgstr ""
+
+#: src/ui/strings.vala:69
+msgid "Aggressive"
+msgstr ""
+
+#: src/ui/strings.vala:70
+msgid "Strict"
+msgstr ""
+
+#: src/ui/strings.vala:71
+msgid "Disabled"
+msgstr ""
+
+#: src/ui/strings.vala:72
+#, fuzzy, c-format
+msgid "“%s” moved to trash"
+msgstr "Siirrä roskakoriin"
+
+#: src/ui/strings.vala:73
+#, c-format
+msgid "“%s” restored"
 msgstr ""
 
 #: src/ui/widgets/theme_selector/theme_selector.blp:15
@@ -677,40 +775,45 @@ msgid "_Keyboard Shortcuts"
 msgstr "_Näppäinoikotiet"
 
 #: src/ui/window/app_menu/app_menu.blp:43
-msgid "_About"
+#, fuzzy
+msgid "_About Folio"
 msgstr "_Tietoa"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:54
-msgid "Notebook Name"
-msgstr "Muistikirjan nimi"
-
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:66
-msgid "Duplicate notebook names are not allowed!"
-msgstr ""
-
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:82
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:6
 msgid "First Characters"
 msgstr "Ensimmäiset merkit"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:83
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:7
 msgid "Initials"
 msgstr "Alkukirjaimet"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:84
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:8
 msgid "Initials: camelCase"
 msgstr "Alkukirjaimet: camelCase"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:85
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:9
 msgid "Initials: snake_case"
 msgstr "Alkukirjaimet: snake_case"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:86
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:10
 msgid "Icon"
 msgstr "Kuvake"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:116
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:11
+msgid "Custom"
+msgstr ""
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:16
 msgid "Notebook Color"
 msgstr "Muistikirjan väri"
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:58
+msgid "Notebook Name"
+msgstr "Muistikirjan nimi"
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:70
+msgid "Duplicate notebook names are not allowed!"
+msgstr ""
 
 #: src/ui/window/notebooks_bar/notebook_create_popup.blp:126
 msgid "Create Notebook"
@@ -728,11 +831,11 @@ msgstr "Siirrä kaikki roskakoriin"
 msgid "Notebooks"
 msgstr ""
 
-#: src/ui/window/sidebar/note_create_popup.blp:37
+#: src/ui/window/sidebar/note_create_popup.blp:25
 msgid "Note Name"
 msgstr "Muistiinpanon nimi"
 
-#: src/ui/window/sidebar/note_create_popup.blp:45
+#: src/ui/window/sidebar/note_create_popup.blp:33
 msgid "Create Note"
 msgstr "Luo muistiinpano"
 
@@ -756,30 +859,37 @@ msgstr "Siirrä roskakoriin"
 msgid "Open Containing Folder"
 msgstr "Avaa sisältävä kansio"
 
-#: src/ui/window/window.blp:118
+#: src/ui/window/window.blp:123
 msgid "Get started writing"
 msgstr "Aloita kirjoittaminen"
 
-#: src/ui/window/window.blp:143
+#: src/ui/window/window.blp:152
+msgid "Open file in external application"
+msgstr ""
+
+#: src/ui/window/window.blp:160
+msgid "Open file"
+msgstr ""
+
+#: src/ui/window/window.blp:181
 msgid "Create a notebook"
 msgstr "Luo muistikirja"
 
-#: src/ui/window/window.blp:168
+#: src/ui/window/window.blp:210
 msgid "Trash is empty"
 msgstr "Roskakori on tyhjä"
 
-#: src/ui/window/window.blp:224
-msgid "Back"
-msgstr "Takaisin"
-
-#: src/ui/window/window.blp:239
+#: src/ui/window/window.blp:285
 msgid "Open in Notebook"
 msgstr "Avaa muistikirjassa"
 
-#: src/ui/window/window.blp:264
+#: src/ui/window/window.blp:312
 msgid "_Rename Note"
 msgstr "_Uudelleennimeä muistiinpano"
 
-#: src/ui/window/window.blp:270
+#: src/ui/window/window.blp:319
 msgid "_Export Note"
 msgstr "_Vie muistiinpano"
+
+#~ msgid "Back"
+#~ msgstr "Takaisin"

--- a/po/fr.po
+++ b/po/fr.po
@@ -2,244 +2,16 @@
 # This file is distributed under the same license as the Folio package.
 msgid ""
 msgstr ""
+"Project-Id-Version: Folio\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-10-12 16:53+0200\n"
 "PO-Revision-Date: 2024-03-25 03:28:18+0000\n"
+"Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: GlotPress/4.0.0\n"
-"Language: fr\n"
-"Project-Id-Version: Folio\n"
-
-#: data/app.gschema.xml:76
-msgid "Notebook sort order"
-msgstr "Ordre de tri des carnets de notes"
-
-#: data/app.gschema.xml:77
-msgid "The sort order of the notebook list"
-msgstr "L’ordre de tri de la liste des carnets de notes"
-
-#: src/ui/preferences/preferences.blp:145
-msgid "Sort Order For Notebooks"
-msgstr "Ordre de tri des carnets de notes"
-
-#: data/app.gschema.xml:71
-msgid "Note sort order"
-msgstr "Ordre de tri des notes"
-
-#: data/app.gschema.xml:72
-msgid "The sort order of the note list"
-msgstr "L’ordre de tri de la liste des notes"
-
-#: src/ui/preferences/preferences.blp:150
-msgid "Sort Order For Notes"
-msgstr "Ordre de tri des notes"
-
-#: src/ui/strings.vala:62
-msgid "Modified Time - Ascending"
-msgstr "Date de modification - Croissant"
-
-#: src/ui/strings.vala:63
-msgid "Modified Time - Descending"
-msgstr "Date de modification - Décroissant"
-
-#: src/ui/strings.vala:64
-msgid "Alphabetical - Ascending"
-msgstr "Alphabétique - Croissant"
-
-#: src/ui/strings.vala:65
-msgid "Alphabetical - Descending"
-msgstr "Alphabétique - Décroissant"
-
-#: src/ui/popup/shortcut_window.blp:114
-msgid "Display"
-msgstr "Affichage"
-
-#: src/ui/popup/shortcut_window.blp:117
-msgid "Full Screen"
-msgstr "Plein écran"
-
-#: src/ui/popup/shortcut_window.blp:122
-msgid "Zoom In"
-msgstr "Agrandir"
-
-#: src/ui/popup/shortcut_window.blp:127
-msgid "Zoom Out"
-msgstr "Réduire"
-
-#: src/ui/strings.vala:52
-msgid "Pick primary font for notes"
-msgstr "Choisir une police primaire pour les notes"
-
-#: src/ui/strings.vala:53
-msgid "Pick monospace font for code"
-msgstr "Choisir une police monospace pour le code"
-
-#: src/ui/strings.vala:54
-msgid "File Changed On Disk"
-msgstr "Fichier modifié sur le disque"
-
-#: src/ui/strings.vala:55
-msgid ""
-"The file has changed on disk since it was last saved/loaded by Folio.\n"
-"\n"
-"You may do one of the following:\n"
-"\n"
-" • Reload the file (discarding any changes you have made in Folio)\n"
-" • Overwrite the file (discarding any changes made outside of Folio)\n"
-" • Cancel the operation and manually resolve the issue\n"
-"\n"
-"Note: Canceling the save if you have already moved to a new note/notebook will discard your changes."
-msgstr ""
-"Le fichier a changé sur le disque depuis son dernier enregistrement/chargement par Folio.↵\n"
-"↵\n"
-"Vous pouvez effectuer l'une des opérations suivantes :↵\n"
-"↵\n"
-"  • Rechargez le fichier (en annulant toutes les modifications que vous avez apportées dans Folio)↵\n"
-"  • Écraser le fichier (en annulant toutes les modifications apportées en dehors de Folio)↵\n"
-"  • Annulez l'opération et résolvez manuellement le problème↵\n"
-"↵\n"
-"Remarque : L'annulation de l'enregistrement si vous êtes déjà passé à une nouvelle note/un nouveau carnet annulera vos modifications."
-
-#: src/ui/strings.vala:56
-msgid "Reload"
-msgstr "Recharger"
-
-#: src/ui/strings.vala:57
-msgid "Overwrite"
-msgstr "Remplacer"
-
-#: src/ui/strings.vala:59
-msgid ""
-"The file has changed on disk by another application.\n"
-"\n"
-"You may do one of the following:\n"
-"\n"
-" • Reload the file (discarding any changes you have made in Folio)\n"
-" • Overwrite the file (discarding any changes made outside of Folio)"
-msgstr ""
-"Le fichier a été modifié sur le disque par une autre application.\n"
-"\n"
-"Vous pouvez essayer l’une des actions suivantes : \n"
-"\n"
-" • Recharger le fichier (abandonnera toute modification faite dans Folio)↵\n"
-" • Remplacer le fichier (abandonnera toute modification faite en dehors de Folio)"
-
-#: src/ui/strings.vala:61
-msgid "Note %i"
-msgstr "Note %i"
-
-#: data/app.gschema.xml:46 src/ui/preferences/preferences.blp:213
-msgid "Trash Storage Location"
-msgstr "Emplacement de stockage de la corbeille"
-
-#: data/app.gschema.xml:47 src/ui/preferences/preferences.blp:214
-msgid "Where the trash folder is located (requires app restart)"
-msgstr "Où le dossier de la corbeille est stocké (requiert un redémarrage de l’appli)"
-
-#: src/ui/strings.vala:46
-msgid "Pick where the trash can will be stored"
-msgstr "Choisissez l’emplacement de stockage de la corbeille"
-
-#: data/app.gschema.xml:16 src/ui/preferences/preferences.blp:128
-msgid "Use Fixed Width For Notes"
-msgstr "Utiliser une largeur fixe pour les notes"
-
-#: data/app.gschema.xml:17 src/ui/preferences/preferences.blp:129
-msgid "Use a fixed width for the text area of a note"
-msgstr "Utiliser une largeur maximale pour la zone de texte d’une note"
-
-#: data/app.gschema.xml:37 src/ui/preferences/preferences.blp:118
-msgid "Expands the notebook list to include the notebook name"
-msgstr "Étend la liste de carnet pour inclure le nom du carnet"
-
-#: data/app.gschema.xml:51 src/ui/preferences/preferences.blp:65
-msgid "Show line numbers"
-msgstr "Afficher les numéros de ligne"
-
-#: data/app.gschema.xml:52 src/ui/preferences/preferences.blp:66
-msgid "Displays line numbers at the left of the note"
-msgstr "Affiche les numéros de ligne sur la gauche de la note"
-
-#: data/app.gschema.xml:56 src/ui/preferences/preferences.blp:76
-msgid "Show all notes"
-msgstr "Afficher toutes les notes"
-
-#: data/app.gschema.xml:57 src/ui/preferences/preferences.blp:77
-msgid "Displays the \"All Notes\" notebook at the top of the notebook list"
-msgstr "Affiche le carne « Toutes les notes » en haut de la liste des carnets"
-
-#: data/app.gschema.xml:61 src/ui/preferences/preferences.blp:163
-msgid "Enable autosave"
-msgstr "Activer l’enregistrement automatique"
-
-#: data/app.gschema.xml:62 src/ui/preferences/preferences.blp:164
-msgid "Automatically saves the current note every 30 seconds if the contents have changed (requires app restart)"
-msgstr "Enregistre automatiquement la note actuelle toutes les 30 secondes si le contenu est modifié (nécessite un redémarrage de l’application)"
-
-#: data/app.gschema.xml:66 src/ui/preferences/preferences.blp:174
-msgid "Don't hide the Trash folder"
-msgstr "Ne pas masquer la corbeille"
-
-#: data/app.gschema.xml:67
-msgid "The trash folder is set as a hidden folder by default, this option makes it visible"
-msgstr "Le dossier de la corbeille est masqué par défaut, cette option le rend visible"
-
-#: data/app.metainfo.xml.in:367
-msgid "Main Folio window in light mode"
-msgstr "Fenêtre principale de Folio en mode clair"
-
-#: data/app.metainfo.xml.in:371
-msgid "Main Folio window in dark mode"
-msgstr "Fenêtre principale de Folio en mode sombre"
-
-#: data/app.metainfo.xml.in:375
-msgid "Folio on small/mobile screens"
-msgstr "Folio sur écran format mobile"
-
-#: data/app.metainfo.xml.in:379
-msgid "Folio preferences screen"
-msgstr "Écran des préférences de Folio"
-
-#: data/app.metainfo.xml.in:383
-msgid "Folio in three pane mode"
-msgstr "Folio en mode 3 panneaux"
-
-#: src/ui/preferences/preferences.blp:59
-msgid "Tools"
-msgstr "Outils"
-
-#: data/app.gschema.xml:27 src/ui/preferences/preferences.blp:88
-msgid "Displays the formatting toolbar at the bottom of the note"
-msgstr "Affiche la barre d’outils de formatage en bas de la note"
-
-#: data/app.gschema.xml:32 src/ui/preferences/preferences.blp:99
-msgid "Adds a button to the markdown reference sheet on the right of the formatting toolbar"
-msgstr "Ajoute un bouton vers la feuille de référence Markdown sur la droite de la barre d’outils de formatage"
-
-#: src/ui/preferences/preferences.blp:111
-msgid "Layout"
-msgstr "Affichage"
-
-#: src/ui/preferences/preferences.blp:139
-msgid "Fixed Width To Use For Notes"
-msgstr "Largeur fixe à utiliser pour les notes"
-
-#: src/ui/preferences/preferences.blp:140
-msgid "Sets the fixed width size of a note in px"
-msgstr "Largeur d’une note en px"
-
-#: src/ui/preferences/preferences.blp:157
-msgid "Files"
-msgstr "Fichiers"
-
-#: src/ui/preferences/preferences.blp:175
-msgid "The trash folder is set as a hidden folder by default, this option makes it visible (requires app restart)"
-msgstr "Le dossier de la corbeille est masqué par défaut, cette option le rend visible (nécessite un redémarrage de l’application)"
-
-#: src/ui/strings.vala:51
-msgid "Unable to recognize URI"
-msgstr "Impossible de reconnaître l’URI"
 
 #: data/app.desktop.in:9 src/ui/strings.vala:3
 msgid "Folio"
@@ -258,18 +30,18 @@ msgid "Notebook;Note;Notes;Text;Markdown;Notepad;Write;School;Post-it;Sticky;"
 msgstr "Notebook;Note;Notes;Text;Markdown;Notepad;Write;School;Post-it;Sticky;"
 
 #: data/app.desktop.in:22 src/ui/popup/shortcut_window.blp:17
-#: src/ui/strings.vala:8 src/ui/window/window.blp:47
-#: src/ui/window/window.blp:124
+#: src/ui/strings.vala:8 src/ui/window/window.blp:54
+#: src/ui/window/window.blp:131
 msgid "New Note"
 msgstr "Nouvelle note"
 
 #: data/app.desktop.in:26 src/ui/popup/shortcut_window.blp:37
-#: src/ui/strings.vala:14 src/ui/window/window.blp:149
+#: src/ui/strings.vala:14 src/ui/window/window.blp:189
 msgid "New Notebook"
 msgstr "Nouveau carnet de note"
 
-#: data/app.desktop.in:30 src/ui/edit_view/toolbar/toolbar.blp:90
-#: src/ui/strings.vala:39 src/ui/window/window.blp:245
+#: data/app.desktop.in:30 src/ui/edit_view/toolbar/toolbar.blp:92
+#: src/ui/strings.vala:39 src/ui/window/window.blp:291
 msgid "Markdown Cheatsheet"
 msgstr "Feuille technique Markdown"
 
@@ -277,25 +49,155 @@ msgstr "Feuille technique Markdown"
 msgid "Preferences"
 msgstr "Préférences"
 
-#: data/app.gschema.xml:6 src/ui/preferences/preferences.blp:18
+#: data/app.gschema.xml:6 src/ui/preferences/preferences.blp:45
 msgid "Note Font"
 msgstr "Police de note"
 
-#: data/app.gschema.xml:7 src/ui/preferences/preferences.blp:19
+#: data/app.gschema.xml:7 src/ui/preferences/preferences.blp:46
 msgid "The font notes will be displayed in"
 msgstr "Les notes seront affichées en police"
 
-#: data/app.gschema.xml:11 src/ui/preferences/preferences.blp:31
+#: data/app.gschema.xml:11 src/ui/preferences/preferences.blp:58
 msgid "Monospace Font"
 msgstr "Police monospace"
 
-#: data/app.gschema.xml:12 src/ui/preferences/preferences.blp:32
+#: data/app.gschema.xml:12 src/ui/preferences/preferences.blp:59
 msgid "The font code will be displayed in"
 msgstr "Le code de la police sera affiché en"
 
-#: data/app.gschema.xml:21 src/ui/preferences/preferences.blp:46
+#: data/app.gschema.xml:16 src/ui/preferences/preferences.blp:150
+msgid "Use Fixed Width For Notes"
+msgstr "Utiliser une largeur fixe pour les notes"
+
+#: data/app.gschema.xml:17 src/ui/preferences/preferences.blp:151
+msgid "Use a fixed width for the text area of a note"
+msgstr "Utiliser une largeur maximale pour la zone de texte d’une note"
+
+#: data/app.gschema.xml:21 src/ui/preferences/preferences.blp:18
 msgid "OLED Mode"
 msgstr "Mode OLED"
+
+#: data/app.gschema.xml:22 src/ui/preferences/preferences.blp:19
+msgid "Makes the dark theme pitch black"
+msgstr "Rend le thème sombre noir"
+
+#: data/app.gschema.xml:26 src/ui/preferences/preferences.blp:109
+msgid "Enable Toolbar"
+msgstr "Activer la barre d’outils"
+
+#: data/app.gschema.xml:27 src/ui/preferences/preferences.blp:110
+msgid "Displays the formatting toolbar at the bottom of the note"
+msgstr "Affiche la barre d’outils de formatage en bas de la note"
+
+#: data/app.gschema.xml:31 src/ui/preferences/preferences.blp:120
+msgid "Enable Cheatsheet"
+msgstr "Activer la fiche technique"
+
+#: data/app.gschema.xml:32 src/ui/preferences/preferences.blp:121
+msgid ""
+"Adds a button to the markdown reference sheet on the right of the formatting "
+"toolbar"
+msgstr ""
+"Ajoute un bouton vers la feuille de référence Markdown sur la droite de la "
+"barre d’outils de formatage"
+
+#: data/app.gschema.xml:36 src/ui/preferences/preferences.blp:139
+msgid "3-Pane Layout"
+msgstr "Disposition en 3 volets"
+
+#: data/app.gschema.xml:37 src/ui/preferences/preferences.blp:140
+msgid "Expands the notebook list to include the notebook name"
+msgstr "Étend la liste de carnet pour inclure le nom du carnet"
+
+#: data/app.gschema.xml:41 src/ui/preferences/preferences.blp:207
+msgid "Notes Storage Location"
+msgstr "Emplacement de stockage des notes"
+
+#: data/app.gschema.xml:42 src/ui/preferences/preferences.blp:208
+msgid "Where the notebooks are stored (requires app restart)"
+msgstr ""
+"Où les carnets de notes sont stockés (requiert un redémarrage de l’appli)"
+
+#: data/app.gschema.xml:46 src/ui/preferences/preferences.blp:235
+msgid "Trash Storage Location"
+msgstr "Emplacement de stockage de la corbeille"
+
+#: data/app.gschema.xml:47 src/ui/preferences/preferences.blp:236
+msgid "Where the trash folder is located (requires app restart)"
+msgstr ""
+"Où le dossier de la corbeille est stocké (requiert un redémarrage de l’appli)"
+
+#: data/app.gschema.xml:51 src/ui/preferences/preferences.blp:87
+msgid "Show line numbers"
+msgstr "Afficher les numéros de ligne"
+
+#: data/app.gschema.xml:52 src/ui/preferences/preferences.blp:88
+msgid "Displays line numbers at the left of the note"
+msgstr "Affiche les numéros de ligne sur la gauche de la note"
+
+#: data/app.gschema.xml:56 src/ui/preferences/preferences.blp:98
+msgid "Show all notes"
+msgstr "Afficher toutes les notes"
+
+#: data/app.gschema.xml:57 src/ui/preferences/preferences.blp:99
+msgid "Displays the \"All Notes\" notebook at the top of the notebook list"
+msgstr "Affiche le carne « Toutes les notes » en haut de la liste des carnets"
+
+#: data/app.gschema.xml:61 src/ui/preferences/preferences.blp:185
+msgid "Enable autosave"
+msgstr "Activer l’enregistrement automatique"
+
+#: data/app.gschema.xml:62 src/ui/preferences/preferences.blp:186
+msgid ""
+"Automatically saves the current note every 30 seconds if the contents have "
+"changed (requires app restart)"
+msgstr ""
+"Enregistre automatiquement la note actuelle toutes les 30 secondes si le "
+"contenu est modifié (nécessite un redémarrage de l’application)"
+
+#: data/app.gschema.xml:66 src/ui/preferences/preferences.blp:196
+msgid "Don't hide the Trash folder"
+msgstr "Ne pas masquer la corbeille"
+
+#: data/app.gschema.xml:67
+msgid ""
+"The trash folder is set as a hidden folder by default, this option makes it "
+"visible"
+msgstr ""
+"Le dossier de la corbeille est masqué par défaut, cette option le rend "
+"visible"
+
+#: data/app.gschema.xml:71
+msgid "Note sort order"
+msgstr "Ordre de tri des notes"
+
+#: data/app.gschema.xml:72
+msgid "The sort order of the note list"
+msgstr "L’ordre de tri de la liste des notes"
+
+#: data/app.gschema.xml:76
+msgid "Notebook sort order"
+msgstr "Ordre de tri des carnets de notes"
+
+#: data/app.gschema.xml:77
+msgid "The sort order of the notebook list"
+msgstr "L’ordre de tri de la liste des carnets de notes"
+
+#: data/app.gschema.xml:81
+msgid "URL detection level"
+msgstr ""
+
+#: data/app.gschema.xml:82
+msgid "How agressive to look for URLs in markdown text"
+msgstr ""
+
+#: data/app.gschema.xml:86
+msgid "Line spacing"
+msgstr ""
+
+#: data/app.gschema.xml:87 src/ui/preferences/preferences.blp:74
+msgid "The line spacing for the note text"
+msgstr ""
 
 #: data/app.metainfo.xml.in:5
 msgid "Take notes in Markdown"
@@ -329,103 +231,116 @@ msgstr "Coloration de l’application selon la couleur du carnet de notes"
 msgid "Trash can"
 msgstr "Corbeille"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:23
-#: src/ui/edit_view/toolbar/toolbar.blp:131
+#: data/app.metainfo.xml.in:393
+msgid "Main Folio window in light mode"
+msgstr "Fenêtre principale de Folio en mode clair"
+
+#: data/app.metainfo.xml.in:397
+msgid "Main Folio window in dark mode"
+msgstr "Fenêtre principale de Folio en mode sombre"
+
+#: data/app.metainfo.xml.in:401
+msgid "Folio on small/mobile screens"
+msgstr "Folio sur écran format mobile"
+
+#: data/app.metainfo.xml.in:405
+msgid "Folio preferences screen"
+msgstr "Écran des préférences de Folio"
+
+#: data/app.metainfo.xml.in:409
+msgid "Folio in three pane mode"
+msgstr "Folio en mode 3 panneaux"
+
+#: src/ui/edit_view/toolbar/toolbar.blp:6
 #: src/ui/widgets/markdown/heading_popover.blp:48
 msgid "Plain Text"
 msgstr "Texte simple"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:24
-#: src/ui/edit_view/toolbar/toolbar.blp:132
+#: src/ui/edit_view/toolbar/toolbar.blp:7
 #: src/ui/widgets/markdown/heading_popover.blp:12
 msgid "Heading 1"
 msgstr "Titre 1"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:25
-#: src/ui/edit_view/toolbar/toolbar.blp:133
+#: src/ui/edit_view/toolbar/toolbar.blp:8
 #: src/ui/widgets/markdown/heading_popover.blp:18
 msgid "Heading 2"
 msgstr "Titre 2"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:26
-#: src/ui/edit_view/toolbar/toolbar.blp:134
+#: src/ui/edit_view/toolbar/toolbar.blp:9
 #: src/ui/widgets/markdown/heading_popover.blp:24
 msgid "Heading 3"
 msgstr "Titre 3"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:27
-#: src/ui/edit_view/toolbar/toolbar.blp:135
+#: src/ui/edit_view/toolbar/toolbar.blp:10
 #: src/ui/widgets/markdown/heading_popover.blp:30
 msgid "Heading 4"
 msgstr "Titre 4"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:28
-#: src/ui/edit_view/toolbar/toolbar.blp:136
+#: src/ui/edit_view/toolbar/toolbar.blp:11
 #: src/ui/widgets/markdown/heading_popover.blp:36
 msgid "Heading 5"
 msgstr "Titre 5"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:29
-#: src/ui/edit_view/toolbar/toolbar.blp:137
+#: src/ui/edit_view/toolbar/toolbar.blp:12
 #: src/ui/widgets/markdown/heading_popover.blp:42
 msgid "Heading 6"
 msgstr "Titre 6"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:39
-#: src/ui/edit_view/toolbar/toolbar.blp:104
-#: src/ui/edit_view/toolbar/toolbar.blp:148
-#: src/ui/edit_view/toolbar/toolbar.blp:201 src/ui/popup/shortcut_window.blp:72
+#: src/ui/edit_view/toolbar/toolbar.blp:41
+#: src/ui/edit_view/toolbar/toolbar.blp:107
+#: src/ui/edit_view/toolbar/toolbar.blp:142
+#: src/ui/edit_view/toolbar/toolbar.blp:195 src/ui/popup/shortcut_window.blp:72
 msgid "Bold"
 msgstr "Gras"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:45
-#: src/ui/edit_view/toolbar/toolbar.blp:111
-#: src/ui/edit_view/toolbar/toolbar.blp:155
-#: src/ui/edit_view/toolbar/toolbar.blp:202 src/ui/popup/shortcut_window.blp:77
+#: src/ui/edit_view/toolbar/toolbar.blp:47
+#: src/ui/edit_view/toolbar/toolbar.blp:114
+#: src/ui/edit_view/toolbar/toolbar.blp:149
+#: src/ui/edit_view/toolbar/toolbar.blp:196 src/ui/popup/shortcut_window.blp:77
 msgid "Italic"
 msgstr "Italique"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:51
-#: src/ui/edit_view/toolbar/toolbar.blp:162
-#: src/ui/edit_view/toolbar/toolbar.blp:203 src/ui/popup/shortcut_window.blp:82
+#: src/ui/edit_view/toolbar/toolbar.blp:53
+#: src/ui/edit_view/toolbar/toolbar.blp:156
+#: src/ui/edit_view/toolbar/toolbar.blp:197 src/ui/popup/shortcut_window.blp:82
 msgid "Strikethrough"
 msgstr "Barré"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:57
-#: src/ui/edit_view/toolbar/toolbar.blp:169
-#: src/ui/edit_view/toolbar/toolbar.blp:204 src/ui/popup/shortcut_window.blp:87
+#: src/ui/edit_view/toolbar/toolbar.blp:59
+#: src/ui/edit_view/toolbar/toolbar.blp:163
+#: src/ui/edit_view/toolbar/toolbar.blp:198 src/ui/popup/shortcut_window.blp:87
 msgid "Highlight"
 msgstr "Surligné"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:67
-#: src/ui/edit_view/toolbar/toolbar.blp:193 src/ui/popup/shortcut_window.blp:92
+#: src/ui/edit_view/toolbar/toolbar.blp:69
+#: src/ui/edit_view/toolbar/toolbar.blp:187 src/ui/popup/shortcut_window.blp:92
 msgid "Insert Link"
 msgstr "Insérer un lien"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:73
-#: src/ui/edit_view/toolbar/toolbar.blp:194
+#: src/ui/edit_view/toolbar/toolbar.blp:75
+#: src/ui/edit_view/toolbar/toolbar.blp:188
 msgid "Insert Code"
 msgstr "Insérer du code"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:79
-#: src/ui/edit_view/toolbar/toolbar.blp:195
+#: src/ui/edit_view/toolbar/toolbar.blp:81
+#: src/ui/edit_view/toolbar/toolbar.blp:189
 msgid "Insert Horizontal Rule"
 msgstr "Insérer une règle horizontale"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:118
+#: src/ui/edit_view/toolbar/toolbar.blp:121
 msgid "Format"
 msgstr "Format"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:181
+#: src/ui/edit_view/toolbar/toolbar.blp:175
 msgid "Insert"
 msgstr "Insérer"
 
-#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:34
+#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:18
 #: src/ui/strings.vala:44 src/ui/strings.vala:58
 msgid "Cancel"
 msgstr "Annuler"
 
-#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:39
+#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:23
 msgid "Confirm"
 msgstr "Confirmer"
 
@@ -469,37 +384,87 @@ msgstr "Formatage"
 msgid "Navigation"
 msgstr "Navigation"
 
-#: src/ui/popup/shortcut_window.blp:102 src/ui/window/window.blp:216
+#: src/ui/popup/shortcut_window.blp:102 src/ui/window/window.blp:268
 msgid "Toggle Sidebar"
 msgstr "Basculer la barre latérale"
 
-#: src/ui/popup/shortcut_window.blp:107 src/ui/window/window.blp:63
+#: src/ui/popup/shortcut_window.blp:107 src/ui/window/window.blp:70
 msgid "Search Notes"
 msgstr "Rechercher des notes"
 
-#: data/app.gschema.xml:22 src/ui/preferences/preferences.blp:47
-msgid "Makes the dark theme pitch black"
-msgstr "Rend le thème sombre noir"
+#: src/ui/popup/shortcut_window.blp:114
+msgid "Display"
+msgstr "Affichage"
 
-#: data/app.gschema.xml:26 src/ui/preferences/preferences.blp:87
-msgid "Enable Toolbar"
-msgstr "Activer la barre d’outils"
+#: src/ui/popup/shortcut_window.blp:117
+msgid "Full Screen"
+msgstr "Plein écran"
 
-#: data/app.gschema.xml:31 src/ui/preferences/preferences.blp:98
-msgid "Enable Cheatsheet"
-msgstr "Activer la fiche technique"
+#: src/ui/popup/shortcut_window.blp:122
+msgid "Zoom In"
+msgstr "Agrandir"
 
-#: data/app.gschema.xml:36 src/ui/preferences/preferences.blp:117
-msgid "3-Pane Layout"
-msgstr "Disposition en 3 volets"
+#: src/ui/popup/shortcut_window.blp:127
+msgid "Zoom Out"
+msgstr "Réduire"
 
-#: data/app.gschema.xml:41 src/ui/preferences/preferences.blp:185
-msgid "Notes Storage Location"
-msgstr "Emplacement de stockage des notes"
+#: src/ui/preferences/preferences.blp:31
+#, fuzzy
+msgid "Markdown URL Detection"
+msgstr "Feuille technique Markdown"
 
-#: data/app.gschema.xml:42 src/ui/preferences/preferences.blp:186
-msgid "Where the notebooks are stored (requires app restart)"
-msgstr "Où les carnets de notes sont stockés (requiert un redémarrage de l’appli)"
+#: src/ui/preferences/preferences.blp:32
+msgid ""
+"Determines the level of detection of URLs in\n"
+"free form text is used:\n"
+" - Aggressive tries to find all URLs\n"
+" - Strict requires a protocol identifier (ie http://)\n"
+" - Disabled turns detection off."
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:39
+msgid "Fonts"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:73
+msgid "Line Spacing"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:81
+msgid "Tools"
+msgstr "Outils"
+
+#: src/ui/preferences/preferences.blp:133
+msgid "Layout"
+msgstr "Affichage"
+
+#: src/ui/preferences/preferences.blp:161
+msgid "Fixed Width To Use For Notes"
+msgstr "Largeur fixe à utiliser pour les notes"
+
+#: src/ui/preferences/preferences.blp:162
+msgid "Sets the fixed width size of a note in px"
+msgstr "Largeur d’une note en px"
+
+#: src/ui/preferences/preferences.blp:167
+msgid "Sort Order For Notebooks"
+msgstr "Ordre de tri des carnets de notes"
+
+#: src/ui/preferences/preferences.blp:172
+msgid "Sort Order For Notes"
+msgstr "Ordre de tri des notes"
+
+#: src/ui/preferences/preferences.blp:179
+msgid "Files"
+msgstr "Fichiers"
+
+#: src/ui/preferences/preferences.blp:197
+msgid ""
+"The trash folder is set as a hidden folder by default, this option makes it "
+"visible (requires app restart)"
+msgstr ""
+"Le dossier de la corbeille est masqué par défaut, cette option le rend "
+"visible (nécessite un redémarrage de l’application)"
 
 #: src/ui/strings.vala:4 src/ui/window/notebooks_bar/notebooks_bar.blp:129
 #: src/ui/window/notebooks_bar/notebooks_bar.blp:171
@@ -507,6 +472,7 @@ msgid "Trash"
 msgstr "Mettre à la corbeille"
 
 #: src/ui/strings.vala:5
+#, c-format
 msgid "%d Notes"
 msgstr "%d notes"
 
@@ -514,7 +480,7 @@ msgstr "%d notes"
 msgid "Are you sure you want to delete everything in the trash?"
 msgstr "Êtes-vous sûr de vouloir vider la corbeille ?"
 
-#: src/ui/strings.vala:7 src/ui/window/window.blp:54
+#: src/ui/strings.vala:7 src/ui/window/window.blp:61
 msgid "Empty Trash"
 msgstr "Vider la corbeille"
 
@@ -551,10 +517,12 @@ msgid "Move"
 msgstr "Déplacer"
 
 #: src/ui/strings.vala:18
+#, c-format
 msgid "Note “%s” already exists in notebook “%s”"
 msgstr "La note « %s » existe déjà dans le carnet de notes « %s »"
 
 #: src/ui/strings.vala:19
+#, c-format
 msgid "Are you sure you want to delete the note “%s”?"
 msgstr "Êtes-vous sûr de vouloir supprimer la note « %s » ?"
 
@@ -563,6 +531,7 @@ msgid "Delete Note"
 msgstr "Supprimer la note"
 
 #: src/ui/strings.vala:21
+#, c-format
 msgid "Are you sure you want to delete the notebook “%s”?"
 msgstr "Êtes-vous sûr de vouloir supprimer le carnet de notes « %s » ?"
 
@@ -571,34 +540,42 @@ msgid "Delete Notebook"
 msgstr "Supprimer le carnet de notes"
 
 #: src/ui/strings.vala:24
-msgid "Note name shouldn’t contain “.” or “/”"
+#, fuzzy
+msgid "Note names cannot contain a “/”"
 msgstr "Le nom d’une note ne doit pas contenir « . » ou « / »"
 
 #: src/ui/strings.vala:25
-msgid "Note name shouldn’t be blank"
+#, fuzzy
+msgid "Note names cannot be blank"
 msgstr "Le nom de la note ne devrait pas être vide"
 
 #: src/ui/strings.vala:26
+#, c-format
 msgid "Note “%s” already exists"
 msgstr "La note « %s » existe déjà"
 
 #: src/ui/strings.vala:27
-msgid "Couldn’t create note"
+#, fuzzy
+msgid "Could not create note"
 msgstr "Impossible de créer la note"
 
 #: src/ui/strings.vala:28
-msgid "Couldn’t change note"
+#, fuzzy
+msgid "Could not change note"
 msgstr "Impossible de changer la note"
 
 #: src/ui/strings.vala:29
-msgid "Couldn’t delete note"
+#, fuzzy
+msgid "Could not delete note"
 msgstr "Impossible de supprimer la note"
 
 #: src/ui/strings.vala:30
-msgid "Couldn’t restore note"
+#, fuzzy
+msgid "Could not restore note"
 msgstr "Impossible de restaurer la note"
 
 #: src/ui/strings.vala:31
+#, c-format
 msgid "Saved “%s” to “%s”"
 msgstr "« %s » enregistré dans « %s »"
 
@@ -607,27 +584,33 @@ msgid "Unknown error"
 msgstr "Erreur inconnue"
 
 #: src/ui/strings.vala:33
-msgid "Notebook name shouldn’t contain “.” or “/”"
+#, fuzzy
+msgid "Notebook names cannot contain a “/”"
 msgstr "Le nom d’un carnet de notes ne doit pas contenir « . » ou « / »"
 
 #: src/ui/strings.vala:34
-msgid "Notebook name shouldn’t be blank"
+#, fuzzy
+msgid "Notebook names cannot be blank"
 msgstr "Le nom du carnet de notes ne devrait pas être vide"
 
 #: src/ui/strings.vala:35
+#, c-format
 msgid "Notebook “%s” already exists"
 msgstr "Le carnet de notes « %s » existe déjà"
 
 #: src/ui/strings.vala:36
-msgid "Couldn’t create notebook"
+#, fuzzy
+msgid "Could not create notebook"
 msgstr "Impossible de créer le carnet de notes"
 
 #: src/ui/strings.vala:37
-msgid "Couldn’t change notebook"
+#, fuzzy
+msgid "Could not change notebook"
 msgstr "Impossible de changer le carnet de notes"
 
 #: src/ui/strings.vala:38
-msgid "Couldn’t delete notebook"
+#, fuzzy
+msgid "Could not delete notebook"
 msgstr "Impossible de supprimer le carnet de notes"
 
 #: src/ui/strings.vala:40
@@ -639,7 +622,8 @@ msgid "Rename"
 msgstr "Renommer"
 
 #: src/ui/strings.vala:42
-msgid "Couldn’t find an app to handle file URIs"
+#, fuzzy
+msgid "Could not find an app to handle file URIs"
 msgstr "Impossible de trouver une application pour gérer les URI des fichiers"
 
 #: src/ui/strings.vala:43
@@ -649,6 +633,10 @@ msgstr "Appliquer"
 #: src/ui/strings.vala:45
 msgid "Pick where the notebooks will be stored"
 msgstr "Choisir où les carnets de note seront stockés"
+
+#: src/ui/strings.vala:46
+msgid "Pick where the trash can will be stored"
+msgstr "Choisissez l’emplacement de stockage de la corbeille"
 
 #: src/ui/strings.vala:47 src/ui/window/notebooks_bar/notebooks_bar.blp:59
 #: src/ui/window/notebooks_bar/notebooks_bar.blp:101
@@ -662,6 +650,132 @@ msgstr "Dernière modification"
 #: src/ui/strings.vala:50
 msgid "Extension"
 msgstr "Extension"
+
+#: src/ui/strings.vala:51
+msgid "Unable to recognize URI"
+msgstr "Impossible de reconnaître l’URI"
+
+#: src/ui/strings.vala:52
+msgid "Pick primary font for notes"
+msgstr "Choisir une police primaire pour les notes"
+
+#: src/ui/strings.vala:53
+msgid "Pick monospace font for code"
+msgstr "Choisir une police monospace pour le code"
+
+#: src/ui/strings.vala:54
+msgid "File Changed On Disk"
+msgstr "Fichier modifié sur le disque"
+
+#: src/ui/strings.vala:55
+msgid ""
+"The file has changed on disk since it was last saved/loaded by Folio.\n"
+"\n"
+"You may do one of the following:\n"
+"\n"
+" • Reload the file (discarding any changes you have made in Folio)\n"
+" • Overwrite the file (discarding any changes made outside of Folio)\n"
+" • Cancel the operation and manually resolve the issue\n"
+"\n"
+"Note: Canceling the save if you have already moved to a new note/notebook "
+"will discard your changes."
+msgstr ""
+"Le fichier a changé sur le disque depuis son dernier enregistrement/"
+"chargement par Folio.↵\n"
+"↵\n"
+"Vous pouvez effectuer l'une des opérations suivantes :↵\n"
+"↵\n"
+"  • Rechargez le fichier (en annulant toutes les modifications que vous avez "
+"apportées dans Folio)↵\n"
+"  • Écraser le fichier (en annulant toutes les modifications apportées en "
+"dehors de Folio)↵\n"
+"  • Annulez l'opération et résolvez manuellement le problème↵\n"
+"↵\n"
+"Remarque : L'annulation de l'enregistrement si vous êtes déjà passé à une "
+"nouvelle note/un nouveau carnet annulera vos modifications."
+
+#: src/ui/strings.vala:56
+msgid "Reload"
+msgstr "Recharger"
+
+#: src/ui/strings.vala:57
+msgid "Overwrite"
+msgstr "Remplacer"
+
+#: src/ui/strings.vala:59
+msgid ""
+"The file has changed on disk by another application.\n"
+"\n"
+"You may do one of the following:\n"
+"\n"
+" • Reload the file (discarding any changes you have made in Folio)\n"
+" • Overwrite the file (discarding any changes made outside of Folio)"
+msgstr ""
+"Le fichier a été modifié sur le disque par une autre application.\n"
+"\n"
+"Vous pouvez essayer l’une des actions suivantes : \n"
+"\n"
+" • Recharger le fichier (abandonnera toute modification faite dans Folio)↵\n"
+" • Remplacer le fichier (abandonnera toute modification faite en dehors de "
+"Folio)"
+
+#: src/ui/strings.vala:61
+#, c-format
+msgid "Note %i"
+msgstr "Note %i"
+
+#: src/ui/strings.vala:62
+msgid "Modified Time - Ascending"
+msgstr "Date de modification - Croissant"
+
+#: src/ui/strings.vala:63
+msgid "Modified Time - Descending"
+msgstr "Date de modification - Décroissant"
+
+#: src/ui/strings.vala:64
+msgid "Alphabetical - Ascending"
+msgstr "Alphabétique - Croissant"
+
+#: src/ui/strings.vala:65
+msgid "Alphabetical - Descending"
+msgstr "Alphabétique - Décroissant"
+
+#: src/ui/strings.vala:66
+#, fuzzy
+msgid "Natural - Ascending"
+msgstr "Alphabétique - Croissant"
+
+#: src/ui/strings.vala:67
+#, fuzzy
+msgid "Natural - Descending"
+msgstr "Alphabétique - Décroissant"
+
+#: src/ui/strings.vala:68
+#, c-format
+msgid "Unable to launch external application for file %s."
+msgstr ""
+
+#: src/ui/strings.vala:69
+msgid "Aggressive"
+msgstr ""
+
+#: src/ui/strings.vala:70
+msgid "Strict"
+msgstr ""
+
+#: src/ui/strings.vala:71
+msgid "Disabled"
+msgstr ""
+
+#: src/ui/strings.vala:72
+#, fuzzy, c-format
+msgid "“%s” moved to trash"
+msgstr "Déplacer vers la corbeille"
+
+#: src/ui/strings.vala:73
+#, c-format
+msgid "“%s” restored"
+msgstr ""
 
 #: src/ui/widgets/theme_selector/theme_selector.blp:15
 msgid "Follow system style"
@@ -692,40 +806,45 @@ msgid "_Keyboard Shortcuts"
 msgstr "_Raccourcis clavier"
 
 #: src/ui/window/app_menu/app_menu.blp:43
-msgid "_About"
+#, fuzzy
+msgid "_About Folio"
 msgstr "À _propos"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:54
-msgid "Notebook Name"
-msgstr "Nom du carnet de notes"
-
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:66
-msgid "Duplicate notebook names are not allowed!"
-msgstr "Deux carnets de notes ne peuvent avoir le même nom !"
-
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:82
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:6
 msgid "First Characters"
 msgstr "Premiers caractères"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:83
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:7
 msgid "Initials"
 msgstr "Initiales"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:84
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:8
 msgid "Initials: camelCase"
 msgstr "Initiales : camelCase"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:85
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:9
 msgid "Initials: snake_case"
 msgstr "Initiales : snake_case"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:86
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:10
 msgid "Icon"
 msgstr "Icône"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:116
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:11
+msgid "Custom"
+msgstr ""
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:16
 msgid "Notebook Color"
 msgstr "Couleur du carnet de notes"
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:58
+msgid "Notebook Name"
+msgstr "Nom du carnet de notes"
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:70
+msgid "Duplicate notebook names are not allowed!"
+msgstr "Deux carnets de notes ne peuvent avoir le même nom !"
 
 #: src/ui/window/notebooks_bar/notebook_create_popup.blp:126
 msgid "Create Notebook"
@@ -743,11 +862,11 @@ msgstr "Déplacer tout vers la corbeille"
 msgid "Notebooks"
 msgstr "Carnets de notes"
 
-#: src/ui/window/sidebar/note_create_popup.blp:37
+#: src/ui/window/sidebar/note_create_popup.blp:25
 msgid "Note Name"
 msgstr "Nom de la note"
 
-#: src/ui/window/sidebar/note_create_popup.blp:45
+#: src/ui/window/sidebar/note_create_popup.blp:33
 msgid "Create Note"
 msgstr "Créer la note"
 
@@ -771,30 +890,37 @@ msgstr "Déplacer vers la corbeille"
 msgid "Open Containing Folder"
 msgstr "Ouvrir le dossier contenant"
 
-#: src/ui/window/window.blp:118
+#: src/ui/window/window.blp:123
 msgid "Get started writing"
 msgstr "Commencez à écrire"
 
-#: src/ui/window/window.blp:143
+#: src/ui/window/window.blp:152
+msgid "Open file in external application"
+msgstr ""
+
+#: src/ui/window/window.blp:160
+msgid "Open file"
+msgstr ""
+
+#: src/ui/window/window.blp:181
 msgid "Create a notebook"
 msgstr "Créer un carnet de notes"
 
-#: src/ui/window/window.blp:168
+#: src/ui/window/window.blp:210
 msgid "Trash is empty"
 msgstr "Corbeille vide"
 
-#: src/ui/window/window.blp:224
-msgid "Back"
-msgstr "Retour"
-
-#: src/ui/window/window.blp:239
+#: src/ui/window/window.blp:285
 msgid "Open in Notebook"
 msgstr "Ouvrir dans le carnet de notes"
 
-#: src/ui/window/window.blp:264
+#: src/ui/window/window.blp:312
 msgid "_Rename Note"
 msgstr "_Renommer la note"
 
-#: src/ui/window/window.blp:270
+#: src/ui/window/window.blp:319
 msgid "_Export Note"
 msgstr "_Exporter la note"
+
+#~ msgid "Back"
+#~ msgstr "Retour"

--- a/po/gl.po
+++ b/po/gl.po
@@ -2,229 +2,16 @@
 # This file is distributed under the same license as the Folio package.
 msgid ""
 msgstr ""
+"Project-Id-Version: Folio\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-10-12 16:53+0200\n"
 "PO-Revision-Date: 2024-03-02 16:57:06+0000\n"
+"Language: gl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: GlotPress/4.0.0\n"
-"Language: gl\n"
-"Project-Id-Version: Folio\n"
-
-#: data/app.gschema.xml:76
-msgid "Notebook sort order"
-msgstr ""
-
-#: data/app.gschema.xml:77
-msgid "The sort order of the notebook list"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:145
-msgid "Sort Order For Notebooks"
-msgstr ""
-
-#: data/app.gschema.xml:71
-msgid "Note sort order"
-msgstr ""
-
-#: data/app.gschema.xml:72
-msgid "The sort order of the note list"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:150
-msgid "Sort Order For Notes"
-msgstr ""
-
-#: src/ui/strings.vala:62
-msgid "Modified Time - Ascending"
-msgstr ""
-
-#: src/ui/strings.vala:63
-msgid "Modified Time - Descending"
-msgstr ""
-
-#: src/ui/strings.vala:64
-msgid "Alphabetical - Ascending"
-msgstr ""
-
-#: src/ui/strings.vala:65
-msgid "Alphabetical - Descending"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:114
-msgid "Display"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:117
-msgid "Full Screen"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:122
-msgid "Zoom In"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:127
-msgid "Zoom Out"
-msgstr ""
-
-#: src/ui/strings.vala:52
-msgid "Pick primary font for notes"
-msgstr ""
-
-#: src/ui/strings.vala:53
-msgid "Pick monospace font for code"
-msgstr ""
-
-#: src/ui/strings.vala:54
-msgid "File Changed On Disk"
-msgstr ""
-
-#: src/ui/strings.vala:55
-msgid ""
-"The file has changed on disk since it was last saved/loaded by Folio.\n"
-"\n"
-"You may do one of the following:\n"
-"\n"
-" • Reload the file (discarding any changes you have made in Folio)\n"
-" • Overwrite the file (discarding any changes made outside of Folio)\n"
-" • Cancel the operation and manually resolve the issue\n"
-"\n"
-"Note: Canceling the save if you have already moved to a new note/notebook will discard your changes."
-msgstr ""
-
-#: src/ui/strings.vala:56
-msgid "Reload"
-msgstr ""
-
-#: src/ui/strings.vala:57
-msgid "Overwrite"
-msgstr ""
-
-#: src/ui/strings.vala:59
-msgid ""
-"The file has changed on disk by another application.\n"
-"\n"
-"You may do one of the following:\n"
-"\n"
-" • Reload the file (discarding any changes you have made in Folio)\n"
-" • Overwrite the file (discarding any changes made outside of Folio)"
-msgstr ""
-
-#: src/ui/strings.vala:61
-msgid "Note %i"
-msgstr ""
-
-#: data/app.gschema.xml:46 src/ui/preferences/preferences.blp:213
-msgid "Trash Storage Location"
-msgstr ""
-
-#: data/app.gschema.xml:47 src/ui/preferences/preferences.blp:214
-msgid "Where the trash folder is located (requires app restart)"
-msgstr ""
-
-#: src/ui/strings.vala:46
-msgid "Pick where the trash can will be stored"
-msgstr ""
-
-#: data/app.gschema.xml:16 src/ui/preferences/preferences.blp:128
-msgid "Use Fixed Width For Notes"
-msgstr ""
-
-#: data/app.gschema.xml:17 src/ui/preferences/preferences.blp:129
-msgid "Use a fixed width for the text area of a note"
-msgstr ""
-
-#: data/app.gschema.xml:37 src/ui/preferences/preferences.blp:118
-msgid "Expands the notebook list to include the notebook name"
-msgstr ""
-
-#: data/app.gschema.xml:51 src/ui/preferences/preferences.blp:65
-msgid "Show line numbers"
-msgstr ""
-
-#: data/app.gschema.xml:52 src/ui/preferences/preferences.blp:66
-msgid "Displays line numbers at the left of the note"
-msgstr ""
-
-#: data/app.gschema.xml:56 src/ui/preferences/preferences.blp:76
-msgid "Show all notes"
-msgstr ""
-
-#: data/app.gschema.xml:57 src/ui/preferences/preferences.blp:77
-msgid "Displays the \"All Notes\" notebook at the top of the notebook list"
-msgstr ""
-
-#: data/app.gschema.xml:61 src/ui/preferences/preferences.blp:163
-msgid "Enable autosave"
-msgstr ""
-
-#: data/app.gschema.xml:62 src/ui/preferences/preferences.blp:164
-msgid "Automatically saves the current note every 30 seconds if the contents have changed (requires app restart)"
-msgstr ""
-
-#: data/app.gschema.xml:66 src/ui/preferences/preferences.blp:174
-msgid "Don't hide the Trash folder"
-msgstr ""
-
-#: data/app.gschema.xml:67
-msgid "The trash folder is set as a hidden folder by default, this option makes it visible"
-msgstr ""
-
-#: data/app.metainfo.xml.in:367
-msgid "Main Folio window in light mode"
-msgstr ""
-
-#: data/app.metainfo.xml.in:371
-msgid "Main Folio window in dark mode"
-msgstr ""
-
-#: data/app.metainfo.xml.in:375
-msgid "Folio on small/mobile screens"
-msgstr ""
-
-#: data/app.metainfo.xml.in:379
-msgid "Folio preferences screen"
-msgstr ""
-
-#: data/app.metainfo.xml.in:383
-msgid "Folio in three pane mode"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:59
-msgid "Tools"
-msgstr ""
-
-#: data/app.gschema.xml:27 src/ui/preferences/preferences.blp:88
-msgid "Displays the formatting toolbar at the bottom of the note"
-msgstr ""
-
-#: data/app.gschema.xml:32 src/ui/preferences/preferences.blp:99
-msgid "Adds a button to the markdown reference sheet on the right of the formatting toolbar"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:111
-msgid "Layout"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:139
-msgid "Fixed Width To Use For Notes"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:140
-msgid "Sets the fixed width size of a note in px"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:157
-msgid "Files"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:175
-msgid "The trash folder is set as a hidden folder by default, this option makes it visible (requires app restart)"
-msgstr ""
-
-#: src/ui/strings.vala:51
-msgid "Unable to recognize URI"
-msgstr ""
 
 #: data/app.desktop.in:9 src/ui/strings.vala:3
 msgid "Folio"
@@ -240,21 +27,22 @@ msgstr "Tomar notas"
 
 #: data/app.desktop.in:13
 msgid "Notebook;Note;Notes;Text;Markdown;Notepad;Write;School;Post-it;Sticky;"
-msgstr "Caderno;Nota;Notas;Texto;Markdown;Notepad;Escribir;Escola;Post-it;Pegañento;"
+msgstr ""
+"Caderno;Nota;Notas;Texto;Markdown;Notepad;Escribir;Escola;Post-it;Pegañento;"
 
 #: data/app.desktop.in:22 src/ui/popup/shortcut_window.blp:17
-#: src/ui/strings.vala:8 src/ui/window/window.blp:47
-#: src/ui/window/window.blp:124
+#: src/ui/strings.vala:8 src/ui/window/window.blp:54
+#: src/ui/window/window.blp:131
 msgid "New Note"
 msgstr "Nova nota"
 
 #: data/app.desktop.in:26 src/ui/popup/shortcut_window.blp:37
-#: src/ui/strings.vala:14 src/ui/window/window.blp:149
+#: src/ui/strings.vala:14 src/ui/window/window.blp:189
 msgid "New Notebook"
 msgstr "Novo caderno"
 
-#: data/app.desktop.in:30 src/ui/edit_view/toolbar/toolbar.blp:90
-#: src/ui/strings.vala:39 src/ui/window/window.blp:245
+#: data/app.desktop.in:30 src/ui/edit_view/toolbar/toolbar.blp:92
+#: src/ui/strings.vala:39 src/ui/window/window.blp:291
 msgid "Markdown Cheatsheet"
 msgstr "Guía de Markdown"
 
@@ -262,25 +50,147 @@ msgstr "Guía de Markdown"
 msgid "Preferences"
 msgstr "Preferencias"
 
-#: data/app.gschema.xml:6 src/ui/preferences/preferences.blp:18
+#: data/app.gschema.xml:6 src/ui/preferences/preferences.blp:45
 msgid "Note Font"
 msgstr "Tipo de letra da nota"
 
-#: data/app.gschema.xml:7 src/ui/preferences/preferences.blp:19
+#: data/app.gschema.xml:7 src/ui/preferences/preferences.blp:46
 msgid "The font notes will be displayed in"
 msgstr "O tipo de letra no que se mostran as notas"
 
-#: data/app.gschema.xml:11 src/ui/preferences/preferences.blp:31
+#: data/app.gschema.xml:11 src/ui/preferences/preferences.blp:58
 msgid "Monospace Font"
 msgstr "Tipo de letra monoespaciado"
 
-#: data/app.gschema.xml:12 src/ui/preferences/preferences.blp:32
+#: data/app.gschema.xml:12 src/ui/preferences/preferences.blp:59
 msgid "The font code will be displayed in"
 msgstr "O tipo de letra no que se mostra o código"
 
-#: data/app.gschema.xml:21 src/ui/preferences/preferences.blp:46
+#: data/app.gschema.xml:16 src/ui/preferences/preferences.blp:150
+msgid "Use Fixed Width For Notes"
+msgstr ""
+
+#: data/app.gschema.xml:17 src/ui/preferences/preferences.blp:151
+msgid "Use a fixed width for the text area of a note"
+msgstr ""
+
+#: data/app.gschema.xml:21 src/ui/preferences/preferences.blp:18
 msgid "OLED Mode"
 msgstr "Modo OLED"
+
+#: data/app.gschema.xml:22 src/ui/preferences/preferences.blp:19
+msgid "Makes the dark theme pitch black"
+msgstr "Fai o tema escuro máis negro"
+
+#: data/app.gschema.xml:26 src/ui/preferences/preferences.blp:109
+msgid "Enable Toolbar"
+msgstr "Activar a barra lateral"
+
+#: data/app.gschema.xml:27 src/ui/preferences/preferences.blp:110
+msgid "Displays the formatting toolbar at the bottom of the note"
+msgstr ""
+
+#: data/app.gschema.xml:31 src/ui/preferences/preferences.blp:120
+msgid "Enable Cheatsheet"
+msgstr ""
+
+#: data/app.gschema.xml:32 src/ui/preferences/preferences.blp:121
+msgid ""
+"Adds a button to the markdown reference sheet on the right of the formatting "
+"toolbar"
+msgstr ""
+
+#: data/app.gschema.xml:36 src/ui/preferences/preferences.blp:139
+msgid "3-Pane Layout"
+msgstr "Disposición de 3 paneis"
+
+#: data/app.gschema.xml:37 src/ui/preferences/preferences.blp:140
+msgid "Expands the notebook list to include the notebook name"
+msgstr ""
+
+#: data/app.gschema.xml:41 src/ui/preferences/preferences.blp:207
+msgid "Notes Storage Location"
+msgstr "Localización do almacenamento das notas"
+
+#: data/app.gschema.xml:42 src/ui/preferences/preferences.blp:208
+msgid "Where the notebooks are stored (requires app restart)"
+msgstr "Onde se almacenan os cadernos (require reiniciar a aplicación)"
+
+#: data/app.gschema.xml:46 src/ui/preferences/preferences.blp:235
+msgid "Trash Storage Location"
+msgstr ""
+
+#: data/app.gschema.xml:47 src/ui/preferences/preferences.blp:236
+msgid "Where the trash folder is located (requires app restart)"
+msgstr ""
+
+#: data/app.gschema.xml:51 src/ui/preferences/preferences.blp:87
+msgid "Show line numbers"
+msgstr ""
+
+#: data/app.gschema.xml:52 src/ui/preferences/preferences.blp:88
+msgid "Displays line numbers at the left of the note"
+msgstr ""
+
+#: data/app.gschema.xml:56 src/ui/preferences/preferences.blp:98
+msgid "Show all notes"
+msgstr ""
+
+#: data/app.gschema.xml:57 src/ui/preferences/preferences.blp:99
+msgid "Displays the \"All Notes\" notebook at the top of the notebook list"
+msgstr ""
+
+#: data/app.gschema.xml:61 src/ui/preferences/preferences.blp:185
+msgid "Enable autosave"
+msgstr ""
+
+#: data/app.gschema.xml:62 src/ui/preferences/preferences.blp:186
+msgid ""
+"Automatically saves the current note every 30 seconds if the contents have "
+"changed (requires app restart)"
+msgstr ""
+
+#: data/app.gschema.xml:66 src/ui/preferences/preferences.blp:196
+msgid "Don't hide the Trash folder"
+msgstr ""
+
+#: data/app.gschema.xml:67
+msgid ""
+"The trash folder is set as a hidden folder by default, this option makes it "
+"visible"
+msgstr ""
+
+#: data/app.gschema.xml:71
+msgid "Note sort order"
+msgstr ""
+
+#: data/app.gschema.xml:72
+msgid "The sort order of the note list"
+msgstr ""
+
+#: data/app.gschema.xml:76
+msgid "Notebook sort order"
+msgstr ""
+
+#: data/app.gschema.xml:77
+msgid "The sort order of the notebook list"
+msgstr ""
+
+#: data/app.gschema.xml:81
+msgid "URL detection level"
+msgstr ""
+
+#: data/app.gschema.xml:82
+msgid "How agressive to look for URLs in markdown text"
+msgstr ""
+
+#: data/app.gschema.xml:86
+msgid "Line spacing"
+msgstr ""
+
+#: data/app.gschema.xml:87 src/ui/preferences/preferences.blp:74
+msgid "The line spacing for the note text"
+msgstr ""
 
 #: data/app.metainfo.xml.in:5
 msgid "Take notes in Markdown"
@@ -314,103 +224,116 @@ msgstr ""
 msgid "Trash can"
 msgstr "Lixo"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:23
-#: src/ui/edit_view/toolbar/toolbar.blp:131
+#: data/app.metainfo.xml.in:393
+msgid "Main Folio window in light mode"
+msgstr ""
+
+#: data/app.metainfo.xml.in:397
+msgid "Main Folio window in dark mode"
+msgstr ""
+
+#: data/app.metainfo.xml.in:401
+msgid "Folio on small/mobile screens"
+msgstr ""
+
+#: data/app.metainfo.xml.in:405
+msgid "Folio preferences screen"
+msgstr ""
+
+#: data/app.metainfo.xml.in:409
+msgid "Folio in three pane mode"
+msgstr ""
+
+#: src/ui/edit_view/toolbar/toolbar.blp:6
 #: src/ui/widgets/markdown/heading_popover.blp:48
 msgid "Plain Text"
 msgstr "Texto plano"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:24
-#: src/ui/edit_view/toolbar/toolbar.blp:132
+#: src/ui/edit_view/toolbar/toolbar.blp:7
 #: src/ui/widgets/markdown/heading_popover.blp:12
 msgid "Heading 1"
 msgstr "Cabeceira 1"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:25
-#: src/ui/edit_view/toolbar/toolbar.blp:133
+#: src/ui/edit_view/toolbar/toolbar.blp:8
 #: src/ui/widgets/markdown/heading_popover.blp:18
 msgid "Heading 2"
 msgstr "Cabeceira 2"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:26
-#: src/ui/edit_view/toolbar/toolbar.blp:134
+#: src/ui/edit_view/toolbar/toolbar.blp:9
 #: src/ui/widgets/markdown/heading_popover.blp:24
 msgid "Heading 3"
 msgstr "Cabeceira 3"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:27
-#: src/ui/edit_view/toolbar/toolbar.blp:135
+#: src/ui/edit_view/toolbar/toolbar.blp:10
 #: src/ui/widgets/markdown/heading_popover.blp:30
 msgid "Heading 4"
 msgstr "Cabeceira 4"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:28
-#: src/ui/edit_view/toolbar/toolbar.blp:136
+#: src/ui/edit_view/toolbar/toolbar.blp:11
 #: src/ui/widgets/markdown/heading_popover.blp:36
 msgid "Heading 5"
 msgstr "Cabeceira 5"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:29
-#: src/ui/edit_view/toolbar/toolbar.blp:137
+#: src/ui/edit_view/toolbar/toolbar.blp:12
 #: src/ui/widgets/markdown/heading_popover.blp:42
 msgid "Heading 6"
 msgstr "Cabeceira 6"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:39
-#: src/ui/edit_view/toolbar/toolbar.blp:104
-#: src/ui/edit_view/toolbar/toolbar.blp:148
-#: src/ui/edit_view/toolbar/toolbar.blp:201 src/ui/popup/shortcut_window.blp:72
+#: src/ui/edit_view/toolbar/toolbar.blp:41
+#: src/ui/edit_view/toolbar/toolbar.blp:107
+#: src/ui/edit_view/toolbar/toolbar.blp:142
+#: src/ui/edit_view/toolbar/toolbar.blp:195 src/ui/popup/shortcut_window.blp:72
 msgid "Bold"
 msgstr "Negriña"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:45
-#: src/ui/edit_view/toolbar/toolbar.blp:111
-#: src/ui/edit_view/toolbar/toolbar.blp:155
-#: src/ui/edit_view/toolbar/toolbar.blp:202 src/ui/popup/shortcut_window.blp:77
+#: src/ui/edit_view/toolbar/toolbar.blp:47
+#: src/ui/edit_view/toolbar/toolbar.blp:114
+#: src/ui/edit_view/toolbar/toolbar.blp:149
+#: src/ui/edit_view/toolbar/toolbar.blp:196 src/ui/popup/shortcut_window.blp:77
 msgid "Italic"
 msgstr "Cursiva"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:51
-#: src/ui/edit_view/toolbar/toolbar.blp:162
-#: src/ui/edit_view/toolbar/toolbar.blp:203 src/ui/popup/shortcut_window.blp:82
+#: src/ui/edit_view/toolbar/toolbar.blp:53
+#: src/ui/edit_view/toolbar/toolbar.blp:156
+#: src/ui/edit_view/toolbar/toolbar.blp:197 src/ui/popup/shortcut_window.blp:82
 msgid "Strikethrough"
 msgstr "Riscado"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:57
-#: src/ui/edit_view/toolbar/toolbar.blp:169
-#: src/ui/edit_view/toolbar/toolbar.blp:204 src/ui/popup/shortcut_window.blp:87
+#: src/ui/edit_view/toolbar/toolbar.blp:59
+#: src/ui/edit_view/toolbar/toolbar.blp:163
+#: src/ui/edit_view/toolbar/toolbar.blp:198 src/ui/popup/shortcut_window.blp:87
 msgid "Highlight"
 msgstr "Realzado"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:67
-#: src/ui/edit_view/toolbar/toolbar.blp:193 src/ui/popup/shortcut_window.blp:92
+#: src/ui/edit_view/toolbar/toolbar.blp:69
+#: src/ui/edit_view/toolbar/toolbar.blp:187 src/ui/popup/shortcut_window.blp:92
 msgid "Insert Link"
 msgstr "Inserir ligazón"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:73
-#: src/ui/edit_view/toolbar/toolbar.blp:194
+#: src/ui/edit_view/toolbar/toolbar.blp:75
+#: src/ui/edit_view/toolbar/toolbar.blp:188
 msgid "Insert Code"
 msgstr "Inserir código"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:79
-#: src/ui/edit_view/toolbar/toolbar.blp:195
+#: src/ui/edit_view/toolbar/toolbar.blp:81
+#: src/ui/edit_view/toolbar/toolbar.blp:189
 msgid "Insert Horizontal Rule"
 msgstr "Inserir regra horizontal"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:118
+#: src/ui/edit_view/toolbar/toolbar.blp:121
 msgid "Format"
 msgstr "Formatado"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:181
+#: src/ui/edit_view/toolbar/toolbar.blp:175
 msgid "Insert"
 msgstr "Inserir"
 
-#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:34
+#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:18
 #: src/ui/strings.vala:44 src/ui/strings.vala:58
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:39
+#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:23
 msgid "Confirm"
 msgstr "Confirmar"
 
@@ -454,37 +377,85 @@ msgstr "Formatado"
 msgid "Navigation"
 msgstr "Navegación"
 
-#: src/ui/popup/shortcut_window.blp:102 src/ui/window/window.blp:216
+#: src/ui/popup/shortcut_window.blp:102 src/ui/window/window.blp:268
 msgid "Toggle Sidebar"
 msgstr "Trocar barra lateral"
 
-#: src/ui/popup/shortcut_window.blp:107 src/ui/window/window.blp:63
+#: src/ui/popup/shortcut_window.blp:107 src/ui/window/window.blp:70
 msgid "Search Notes"
 msgstr "Buscar notas"
 
-#: data/app.gschema.xml:22 src/ui/preferences/preferences.blp:47
-msgid "Makes the dark theme pitch black"
-msgstr "Fai o tema escuro máis negro"
-
-#: data/app.gschema.xml:26 src/ui/preferences/preferences.blp:87
-msgid "Enable Toolbar"
-msgstr "Activar a barra lateral"
-
-#: data/app.gschema.xml:31 src/ui/preferences/preferences.blp:98
-msgid "Enable Cheatsheet"
+#: src/ui/popup/shortcut_window.blp:114
+msgid "Display"
 msgstr ""
 
-#: data/app.gschema.xml:36 src/ui/preferences/preferences.blp:117
-msgid "3-Pane Layout"
-msgstr "Disposición de 3 paneis"
+#: src/ui/popup/shortcut_window.blp:117
+msgid "Full Screen"
+msgstr ""
 
-#: data/app.gschema.xml:41 src/ui/preferences/preferences.blp:185
-msgid "Notes Storage Location"
-msgstr "Localización do almacenamento das notas"
+#: src/ui/popup/shortcut_window.blp:122
+msgid "Zoom In"
+msgstr ""
 
-#: data/app.gschema.xml:42 src/ui/preferences/preferences.blp:186
-msgid "Where the notebooks are stored (requires app restart)"
-msgstr "Onde se almacenan os cadernos (require reiniciar a aplicación)"
+#: src/ui/popup/shortcut_window.blp:127
+msgid "Zoom Out"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:31
+#, fuzzy
+msgid "Markdown URL Detection"
+msgstr "Guía de Markdown"
+
+#: src/ui/preferences/preferences.blp:32
+msgid ""
+"Determines the level of detection of URLs in\n"
+"free form text is used:\n"
+" - Aggressive tries to find all URLs\n"
+" - Strict requires a protocol identifier (ie http://)\n"
+" - Disabled turns detection off."
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:39
+msgid "Fonts"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:73
+msgid "Line Spacing"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:81
+msgid "Tools"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:133
+msgid "Layout"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:161
+msgid "Fixed Width To Use For Notes"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:162
+msgid "Sets the fixed width size of a note in px"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:167
+msgid "Sort Order For Notebooks"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:172
+msgid "Sort Order For Notes"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:179
+msgid "Files"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:197
+msgid ""
+"The trash folder is set as a hidden folder by default, this option makes it "
+"visible (requires app restart)"
+msgstr ""
 
 #: src/ui/strings.vala:4 src/ui/window/notebooks_bar/notebooks_bar.blp:129
 #: src/ui/window/notebooks_bar/notebooks_bar.blp:171
@@ -492,6 +463,7 @@ msgid "Trash"
 msgstr "Lixo"
 
 #: src/ui/strings.vala:5
+#, c-format
 msgid "%d Notes"
 msgstr "%d notas"
 
@@ -499,7 +471,7 @@ msgstr "%d notas"
 msgid "Are you sure you want to delete everything in the trash?"
 msgstr "Are you sure you want to delete everything in the trash?"
 
-#: src/ui/strings.vala:7 src/ui/window/window.blp:54
+#: src/ui/strings.vala:7 src/ui/window/window.blp:61
 msgid "Empty Trash"
 msgstr "Baleirar lixo"
 
@@ -536,10 +508,12 @@ msgid "Move"
 msgstr "Mover"
 
 #: src/ui/strings.vala:18
+#, c-format
 msgid "Note “%s” already exists in notebook “%s”"
 msgstr "A nota «%s» xa existe no caderno «%s»"
 
 #: src/ui/strings.vala:19
+#, c-format
 msgid "Are you sure you want to delete the note “%s”?"
 msgstr "Ten certeza que quere eliminar a nota «%s»?"
 
@@ -548,6 +522,7 @@ msgid "Delete Note"
 msgstr "Eliminar nota"
 
 #: src/ui/strings.vala:21
+#, c-format
 msgid "Are you sure you want to delete the notebook “%s”?"
 msgstr "Ten certeza que quere eliminar o caderno «%s»?"
 
@@ -556,34 +531,42 @@ msgid "Delete Notebook"
 msgstr "Eliminar caderno"
 
 #: src/ui/strings.vala:24
-msgid "Note name shouldn’t contain “.” or “/”"
+#, fuzzy
+msgid "Note names cannot contain a “/”"
 msgstr "O nome da nota non debe conter «.» ou «/»"
 
 #: src/ui/strings.vala:25
-msgid "Note name shouldn’t be blank"
+#, fuzzy
+msgid "Note names cannot be blank"
 msgstr "O nome da nota non debe estar baleiro"
 
 #: src/ui/strings.vala:26
+#, c-format
 msgid "Note “%s” already exists"
 msgstr "Xa existe a nota «%s»"
 
 #: src/ui/strings.vala:27
-msgid "Couldn’t create note"
+#, fuzzy
+msgid "Could not create note"
 msgstr "Non foi posíbel crear unha nota"
 
 #: src/ui/strings.vala:28
-msgid "Couldn’t change note"
+#, fuzzy
+msgid "Could not change note"
 msgstr "Non foi posíbel cambiar a nota"
 
 #: src/ui/strings.vala:29
-msgid "Couldn’t delete note"
+#, fuzzy
+msgid "Could not delete note"
 msgstr "Non foi posíbel eliminar a nota"
 
 #: src/ui/strings.vala:30
-msgid "Couldn’t restore note"
+#, fuzzy
+msgid "Could not restore note"
 msgstr "Non foi posíbel restaurar a nota"
 
 #: src/ui/strings.vala:31
+#, c-format
 msgid "Saved “%s” to “%s”"
 msgstr "Gardar «%s» en «%s»"
 
@@ -592,27 +575,33 @@ msgid "Unknown error"
 msgstr "Erro descoñecido"
 
 #: src/ui/strings.vala:33
-msgid "Notebook name shouldn’t contain “.” or “/”"
+#, fuzzy
+msgid "Notebook names cannot contain a “/”"
 msgstr "O nome do caderno non debe conter «.» ou «/»"
 
 #: src/ui/strings.vala:34
-msgid "Notebook name shouldn’t be blank"
+#, fuzzy
+msgid "Notebook names cannot be blank"
 msgstr "O nome do caderno non debería estar baleiro"
 
 #: src/ui/strings.vala:35
+#, c-format
 msgid "Notebook “%s” already exists"
 msgstr "Xa existe o caderno «%s»"
 
 #: src/ui/strings.vala:36
-msgid "Couldn’t create notebook"
+#, fuzzy
+msgid "Could not create notebook"
 msgstr "Non foi posíbel crear un caderno"
 
 #: src/ui/strings.vala:37
-msgid "Couldn’t change notebook"
+#, fuzzy
+msgid "Could not change notebook"
 msgstr "Non foi posíbel cambiar o caderno"
 
 #: src/ui/strings.vala:38
-msgid "Couldn’t delete notebook"
+#, fuzzy
+msgid "Could not delete notebook"
 msgstr "Non foi posíbel eliminar o caderno"
 
 #: src/ui/strings.vala:40
@@ -624,7 +613,7 @@ msgid "Rename"
 msgstr "Renomear"
 
 #: src/ui/strings.vala:42
-msgid "Couldn’t find an app to handle file URIs"
+msgid "Could not find an app to handle file URIs"
 msgstr ""
 
 #: src/ui/strings.vala:43
@@ -634,6 +623,10 @@ msgstr "Aplicar"
 #: src/ui/strings.vala:45
 msgid "Pick where the notebooks will be stored"
 msgstr "Escoller onde se almacenan os cadernos"
+
+#: src/ui/strings.vala:46
+msgid "Pick where the trash can will be stored"
+msgstr ""
 
 #: src/ui/strings.vala:47 src/ui/window/notebooks_bar/notebooks_bar.blp:59
 #: src/ui/window/notebooks_bar/notebooks_bar.blp:101
@@ -646,6 +639,110 @@ msgstr ""
 
 #: src/ui/strings.vala:50
 msgid "Extension"
+msgstr ""
+
+#: src/ui/strings.vala:51
+msgid "Unable to recognize URI"
+msgstr ""
+
+#: src/ui/strings.vala:52
+msgid "Pick primary font for notes"
+msgstr ""
+
+#: src/ui/strings.vala:53
+msgid "Pick monospace font for code"
+msgstr ""
+
+#: src/ui/strings.vala:54
+msgid "File Changed On Disk"
+msgstr ""
+
+#: src/ui/strings.vala:55
+msgid ""
+"The file has changed on disk since it was last saved/loaded by Folio.\n"
+"\n"
+"You may do one of the following:\n"
+"\n"
+" • Reload the file (discarding any changes you have made in Folio)\n"
+" • Overwrite the file (discarding any changes made outside of Folio)\n"
+" • Cancel the operation and manually resolve the issue\n"
+"\n"
+"Note: Canceling the save if you have already moved to a new note/notebook "
+"will discard your changes."
+msgstr ""
+
+#: src/ui/strings.vala:56
+msgid "Reload"
+msgstr ""
+
+#: src/ui/strings.vala:57
+msgid "Overwrite"
+msgstr ""
+
+#: src/ui/strings.vala:59
+msgid ""
+"The file has changed on disk by another application.\n"
+"\n"
+"You may do one of the following:\n"
+"\n"
+" • Reload the file (discarding any changes you have made in Folio)\n"
+" • Overwrite the file (discarding any changes made outside of Folio)"
+msgstr ""
+
+#: src/ui/strings.vala:61
+#, c-format
+msgid "Note %i"
+msgstr ""
+
+#: src/ui/strings.vala:62
+msgid "Modified Time - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:63
+msgid "Modified Time - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:64
+msgid "Alphabetical - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:65
+msgid "Alphabetical - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:66
+msgid "Natural - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:67
+msgid "Natural - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:68
+#, c-format
+msgid "Unable to launch external application for file %s."
+msgstr ""
+
+#: src/ui/strings.vala:69
+msgid "Aggressive"
+msgstr ""
+
+#: src/ui/strings.vala:70
+msgid "Strict"
+msgstr ""
+
+#: src/ui/strings.vala:71
+msgid "Disabled"
+msgstr ""
+
+#: src/ui/strings.vala:72
+#, fuzzy, c-format
+msgid "“%s” moved to trash"
+msgstr "Mover ao lixo"
+
+#: src/ui/strings.vala:73
+#, c-format
+msgid "“%s” restored"
 msgstr ""
 
 #: src/ui/widgets/theme_selector/theme_selector.blp:15
@@ -677,40 +774,45 @@ msgid "_Keyboard Shortcuts"
 msgstr "Atallos de _teclado"
 
 #: src/ui/window/app_menu/app_menu.blp:43
-msgid "_About"
+#, fuzzy
+msgid "_About Folio"
 msgstr "So_bre"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:54
-msgid "Notebook Name"
-msgstr "Nome do caderno"
-
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:66
-msgid "Duplicate notebook names are not allowed!"
-msgstr ""
-
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:82
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:6
 msgid "First Characters"
 msgstr "Primeiros caracters"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:83
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:7
 msgid "Initials"
 msgstr "Iniciais"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:84
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:8
 msgid "Initials: camelCase"
 msgstr "Iniciais: camelCase"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:85
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:9
 msgid "Initials: snake_case"
 msgstr "Iniciais: snake_case"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:86
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:10
 msgid "Icon"
 msgstr "Icona"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:116
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:11
+msgid "Custom"
+msgstr ""
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:16
 msgid "Notebook Color"
 msgstr "Cor do caderno"
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:58
+msgid "Notebook Name"
+msgstr "Nome do caderno"
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:70
+msgid "Duplicate notebook names are not allowed!"
+msgstr ""
 
 #: src/ui/window/notebooks_bar/notebook_create_popup.blp:126
 msgid "Create Notebook"
@@ -728,11 +830,11 @@ msgstr "Mover todo ao lixo"
 msgid "Notebooks"
 msgstr ""
 
-#: src/ui/window/sidebar/note_create_popup.blp:37
+#: src/ui/window/sidebar/note_create_popup.blp:25
 msgid "Note Name"
 msgstr "Nome da nota"
 
-#: src/ui/window/sidebar/note_create_popup.blp:45
+#: src/ui/window/sidebar/note_create_popup.blp:33
 msgid "Create Note"
 msgstr "Crear nota"
 
@@ -756,30 +858,37 @@ msgstr "Mover ao lixo"
 msgid "Open Containing Folder"
 msgstr "Abrir o cartafol contedor"
 
-#: src/ui/window/window.blp:118
+#: src/ui/window/window.blp:123
 msgid "Get started writing"
 msgstr "Comece a escribir"
 
-#: src/ui/window/window.blp:143
+#: src/ui/window/window.blp:152
+msgid "Open file in external application"
+msgstr ""
+
+#: src/ui/window/window.blp:160
+msgid "Open file"
+msgstr ""
+
+#: src/ui/window/window.blp:181
 msgid "Create a notebook"
 msgstr "Crear un caderno"
 
-#: src/ui/window/window.blp:168
+#: src/ui/window/window.blp:210
 msgid "Trash is empty"
 msgstr "O lixo está baleiro"
 
-#: src/ui/window/window.blp:224
-msgid "Back"
-msgstr "Atrás"
-
-#: src/ui/window/window.blp:239
+#: src/ui/window/window.blp:285
 msgid "Open in Notebook"
 msgstr "Abrir no caderno"
 
-#: src/ui/window/window.blp:264
+#: src/ui/window/window.blp:312
 msgid "_Rename Note"
 msgstr "_Renamear nota"
 
-#: src/ui/window/window.blp:270
+#: src/ui/window/window.blp:319
 msgid "_Export Note"
 msgstr "_Exportar nota"
+
+#~ msgid "Back"
+#~ msgstr "Atrás"

--- a/po/hi.po
+++ b/po/hi.po
@@ -2,244 +2,16 @@
 # This file is distributed under the same license as the Folio package.
 msgid ""
 msgstr ""
+"Project-Id-Version: Folio\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-10-12 16:53+0200\n"
 "PO-Revision-Date: 2024-05-18 16:05:52+0000\n"
+"Language: hi_IN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: GlotPress/4.0.1\n"
-"Language: hi_IN\n"
-"Project-Id-Version: Folio\n"
-
-#: data/app.gschema.xml:76
-msgid "Notebook sort order"
-msgstr "नोटबुक छंटाई क्रम"
-
-#: data/app.gschema.xml:77
-msgid "The sort order of the notebook list"
-msgstr "नोटबुक सूची का छंटाई क्रम"
-
-#: src/ui/preferences/preferences.blp:145
-msgid "Sort Order For Notebooks"
-msgstr "नोटबुक के लिए छंटाई क्रम"
-
-#: data/app.gschema.xml:71
-msgid "Note sort order"
-msgstr "नोट छंटाई क्रम"
-
-#: data/app.gschema.xml:72
-msgid "The sort order of the note list"
-msgstr "नोट सूची का छंटाई क्रम"
-
-#: src/ui/preferences/preferences.blp:150
-msgid "Sort Order For Notes"
-msgstr "नोट्स के लिए छंटाई क्रम"
-
-#: src/ui/strings.vala:62
-msgid "Modified Time - Ascending"
-msgstr "संशोधित समय - आरोही"
-
-#: src/ui/strings.vala:63
-msgid "Modified Time - Descending"
-msgstr "संशोधित समय - अवरोही"
-
-#: src/ui/strings.vala:64
-msgid "Alphabetical - Ascending"
-msgstr "वर्णानुक्रम - आरोही"
-
-#: src/ui/strings.vala:65
-msgid "Alphabetical - Descending"
-msgstr "वर्णानुक्रम - अवरोहण"
-
-#: src/ui/popup/shortcut_window.blp:114
-msgid "Display"
-msgstr "प्रदर्शन"
-
-#: src/ui/popup/shortcut_window.blp:117
-msgid "Full Screen"
-msgstr "पूर्ण स्क्रीन"
-
-#: src/ui/popup/shortcut_window.blp:122
-msgid "Zoom In"
-msgstr "जूम इन"
-
-#: src/ui/popup/shortcut_window.blp:127
-msgid "Zoom Out"
-msgstr "जूम आउट"
-
-#: src/ui/strings.vala:52
-msgid "Pick primary font for notes"
-msgstr "नोट्स के लिए प्राथमिक फॉन्ट चुनें"
-
-#: src/ui/strings.vala:53
-msgid "Pick monospace font for code"
-msgstr "कोड के लिए मोनोस्पेस फॉन्ट चुनें"
-
-#: src/ui/strings.vala:54
-msgid "File Changed On Disk"
-msgstr "डिस्क पर फाइल परिवर्तित"
-
-#: src/ui/strings.vala:55
-msgid ""
-"The file has changed on disk since it was last saved/loaded by Folio.\n"
-"\n"
-"You may do one of the following:\n"
-"\n"
-" • Reload the file (discarding any changes you have made in Folio)\n"
-" • Overwrite the file (discarding any changes made outside of Folio)\n"
-" • Cancel the operation and manually resolve the issue\n"
-"\n"
-"Note: Canceling the save if you have already moved to a new note/notebook will discard your changes."
-msgstr ""
-"फोलियो द्वारा अंतिम बार सहेजे/लोड किए जाने के बाद से फाइल डिस्क पर बदल गई है।\n"
-"\n"
-"आप निम्न में से एक कर सकते हैं:\n"
-"\n"
-" • फाइल को पुनः लोड करें (फोलियो में आपके द्वारा किए गए किसी भी परिवर्तन को खारिज करके)\n"
-" • फाइल को अधिलेखित करें (फोलियो के बाहर किए गए किसी भी परिवर्तन को खारिज करके)\n"
-" • अभियान रद्द करें और समस्या को हस्तचालित रूप से हल करें\n"
-"\n"
-"नोट: यदि आप पहले ही किसी नए नोट/नोटबुक में चले गए हैं तो सहेजना रद्द करने से आपके परिवर्तन खारिज हो जाएंगे।"
-
-#: src/ui/strings.vala:56
-msgid "Reload"
-msgstr "पुनः लोड करें"
-
-#: src/ui/strings.vala:57
-msgid "Overwrite"
-msgstr "अधिलेखित"
-
-#: src/ui/strings.vala:59
-msgid ""
-"The file has changed on disk by another application.\n"
-"\n"
-"You may do one of the following:\n"
-"\n"
-" • Reload the file (discarding any changes you have made in Folio)\n"
-" • Overwrite the file (discarding any changes made outside of Folio)"
-msgstr ""
-"फाइल किसी अन्य अनुप्रयोग द्वारा डिस्क पर बदल दी गई है।\n"
-"\n"
-"आप निम्न में से एक कर सकते हैं:\n"
-"\n"
-" • फाइल को पुनः लोड करें (फोलियो में आपके द्वारा किए गए किसी भी परिवर्तन को खारिज करके)\n"
-" • फाइल को अधिलेखित करें (फोलियो के बाहर किए गए किसी भी परिवर्तन को खारिज करके)"
-
-#: src/ui/strings.vala:61
-msgid "Note %i"
-msgstr "नोट %i"
-
-#: data/app.gschema.xml:46 src/ui/preferences/preferences.blp:213
-msgid "Trash Storage Location"
-msgstr "रद्दी संग्रहण स्थान"
-
-#: data/app.gschema.xml:47 src/ui/preferences/preferences.blp:214
-msgid "Where the trash folder is located (requires app restart)"
-msgstr "जहां रद्दी फोल्डर संग्रहीत हैं (ऐप पुनरारंभ की आवश्यकता है)"
-
-#: src/ui/strings.vala:46
-msgid "Pick where the trash can will be stored"
-msgstr "चुनें कि कूड़ादान कहां रखें"
-
-#: data/app.gschema.xml:16 src/ui/preferences/preferences.blp:128
-msgid "Use Fixed Width For Notes"
-msgstr "नोट्स के लिए निश्चित चौड़ाई का उपयोग करें"
-
-#: data/app.gschema.xml:17 src/ui/preferences/preferences.blp:129
-msgid "Use a fixed width for the text area of a note"
-msgstr "नोट के पाठ क्षेत्र के लिए एक निश्चित चौड़ाई का उपयोग करें"
-
-#: data/app.gschema.xml:37 src/ui/preferences/preferences.blp:118
-msgid "Expands the notebook list to include the notebook name"
-msgstr "नोटबुक का नाम शामिल करने के लिए नोटबुक सूची का विस्तार करता है"
-
-#: data/app.gschema.xml:51 src/ui/preferences/preferences.blp:65
-msgid "Show line numbers"
-msgstr "पंक्ति संख्याएं दिखाएं"
-
-#: data/app.gschema.xml:52 src/ui/preferences/preferences.blp:66
-msgid "Displays line numbers at the left of the note"
-msgstr "नोट के बाईं ओर पंक्ति संख्याएँ प्रदर्शित करता है"
-
-#: data/app.gschema.xml:56 src/ui/preferences/preferences.blp:76
-msgid "Show all notes"
-msgstr "सभी नोटों को दिखाएं"
-
-#: data/app.gschema.xml:57 src/ui/preferences/preferences.blp:77
-msgid "Displays the \"All Notes\" notebook at the top of the notebook list"
-msgstr "नोटबुक सूची के शीर्ष पर \"सभी नोट्स\" नोटबुक प्रदर्शित करता है"
-
-#: data/app.gschema.xml:61 src/ui/preferences/preferences.blp:163
-msgid "Enable autosave"
-msgstr "स्वतः सहेजना सक्षम करें"
-
-#: data/app.gschema.xml:62 src/ui/preferences/preferences.blp:164
-msgid "Automatically saves the current note every 30 seconds if the contents have changed (requires app restart)"
-msgstr "यदि सामग्री बदल गई है तो प्रत्येक 30 सेकंड में वर्तमान नोट स्वचालित रूप से सहेजता है (ऐप पुनरारंभ की आवश्यकता है)"
-
-#: data/app.gschema.xml:66 src/ui/preferences/preferences.blp:174
-msgid "Don't hide the Trash folder"
-msgstr "रद्दी फोल्डर को नहीं छुपाएं"
-
-#: data/app.gschema.xml:67
-msgid "The trash folder is set as a hidden folder by default, this option makes it visible"
-msgstr "रद्दी फोल्डर तयशुदा रूप से एक छिपे हुए फोल्डर के रूप में निर्धारित होता है, यह विकल्प इसे दृश्यमान बनाता है"
-
-#: data/app.metainfo.xml.in:367
-msgid "Main Folio window in light mode"
-msgstr "मुख्य फोलियो विंडो हल्के मोड में"
-
-#: data/app.metainfo.xml.in:371
-msgid "Main Folio window in dark mode"
-msgstr "मुख्य फोलियो विंडो गहरे मोड में"
-
-#: data/app.metainfo.xml.in:375
-msgid "Folio on small/mobile screens"
-msgstr "छोटे/मोबाइल स्क्रीन पर फोलियो"
-
-#: data/app.metainfo.xml.in:379
-msgid "Folio preferences screen"
-msgstr "फोलियो की प्राथमिकता स्क्रीन"
-
-#: data/app.metainfo.xml.in:383
-msgid "Folio in three pane mode"
-msgstr "तीन फलक मोड में फोलियो"
-
-#: src/ui/preferences/preferences.blp:59
-msgid "Tools"
-msgstr "टूल्स"
-
-#: data/app.gschema.xml:27 src/ui/preferences/preferences.blp:88
-msgid "Displays the formatting toolbar at the bottom of the note"
-msgstr "नोट के नीचे प्रारूपण टूलबार प्रदर्शित करता है"
-
-#: data/app.gschema.xml:32 src/ui/preferences/preferences.blp:99
-msgid "Adds a button to the markdown reference sheet on the right of the formatting toolbar"
-msgstr "प्रारूपण टूलबार के दाईं ओर मार्कडाउन संदर्भ पत्रक में एक बटन जोड़ता है"
-
-#: src/ui/preferences/preferences.blp:111
-msgid "Layout"
-msgstr "अभिन्यास"
-
-#: src/ui/preferences/preferences.blp:139
-msgid "Fixed Width To Use For Notes"
-msgstr "नोट्स के लिए उपयोग हेतु निश्चित चौड़ाई"
-
-#: src/ui/preferences/preferences.blp:140
-msgid "Sets the fixed width size of a note in px"
-msgstr "किसी नोट की निश्चित चौड़ाई का आकार px में निर्धारित करता है"
-
-#: src/ui/preferences/preferences.blp:157
-msgid "Files"
-msgstr "फाइलें"
-
-#: src/ui/preferences/preferences.blp:175
-msgid "The trash folder is set as a hidden folder by default, this option makes it visible (requires app restart)"
-msgstr "रद्दी फोल्डर को तयशुदा रूप से एक छिपे हुए फोल्डर के रूप में निर्धारित किया गया है, यह विकल्प इसे दृश्यमान बनाता है (ऐप पुनरारंभ की आवश्यकता है)"
-
-#: src/ui/strings.vala:51
-msgid "Unable to recognize URI"
-msgstr "URI को पहचानने में असमर्थ"
 
 #: data/app.desktop.in:9 src/ui/strings.vala:3
 msgid "Folio"
@@ -258,18 +30,18 @@ msgid "Notebook;Note;Notes;Text;Markdown;Notepad;Write;School;Post-it;Sticky;"
 msgstr "नोटबुक;नोट;नोट्स;पाठ;मार्कडाउन;नोटपैड;लिखें;स्कूल;इसे पोस्ट करें;स्टिकी;"
 
 #: data/app.desktop.in:22 src/ui/popup/shortcut_window.blp:17
-#: src/ui/strings.vala:8 src/ui/window/window.blp:47
-#: src/ui/window/window.blp:124
+#: src/ui/strings.vala:8 src/ui/window/window.blp:54
+#: src/ui/window/window.blp:131
 msgid "New Note"
 msgstr "नया नोट"
 
 #: data/app.desktop.in:26 src/ui/popup/shortcut_window.blp:37
-#: src/ui/strings.vala:14 src/ui/window/window.blp:149
+#: src/ui/strings.vala:14 src/ui/window/window.blp:189
 msgid "New Notebook"
 msgstr "नई नोटबुक"
 
-#: data/app.desktop.in:30 src/ui/edit_view/toolbar/toolbar.blp:90
-#: src/ui/strings.vala:39 src/ui/window/window.blp:245
+#: data/app.desktop.in:30 src/ui/edit_view/toolbar/toolbar.blp:92
+#: src/ui/strings.vala:39 src/ui/window/window.blp:291
 msgid "Markdown Cheatsheet"
 msgstr "मार्कडाउन चीटशीट"
 
@@ -277,25 +49,151 @@ msgstr "मार्कडाउन चीटशीट"
 msgid "Preferences"
 msgstr "प्राथमिकताएं"
 
-#: data/app.gschema.xml:6 src/ui/preferences/preferences.blp:18
+#: data/app.gschema.xml:6 src/ui/preferences/preferences.blp:45
 msgid "Note Font"
 msgstr "नोट फॉन्ट"
 
-#: data/app.gschema.xml:7 src/ui/preferences/preferences.blp:19
+#: data/app.gschema.xml:7 src/ui/preferences/preferences.blp:46
 msgid "The font notes will be displayed in"
 msgstr "फॉन्ट नोट्स इसमें प्रदर्शित होंगे"
 
-#: data/app.gschema.xml:11 src/ui/preferences/preferences.blp:31
+#: data/app.gschema.xml:11 src/ui/preferences/preferences.blp:58
 msgid "Monospace Font"
 msgstr "मोनोस्पेस फॉन्ट"
 
-#: data/app.gschema.xml:12 src/ui/preferences/preferences.blp:32
+#: data/app.gschema.xml:12 src/ui/preferences/preferences.blp:59
 msgid "The font code will be displayed in"
 msgstr "फॉन्ट कोड इसमें प्रदर्शित होंगे"
 
-#: data/app.gschema.xml:21 src/ui/preferences/preferences.blp:46
+#: data/app.gschema.xml:16 src/ui/preferences/preferences.blp:150
+msgid "Use Fixed Width For Notes"
+msgstr "नोट्स के लिए निश्चित चौड़ाई का उपयोग करें"
+
+#: data/app.gschema.xml:17 src/ui/preferences/preferences.blp:151
+msgid "Use a fixed width for the text area of a note"
+msgstr "नोट के पाठ क्षेत्र के लिए एक निश्चित चौड़ाई का उपयोग करें"
+
+#: data/app.gschema.xml:21 src/ui/preferences/preferences.blp:18
 msgid "OLED Mode"
 msgstr "OLED मोड"
+
+#: data/app.gschema.xml:22 src/ui/preferences/preferences.blp:19
+msgid "Makes the dark theme pitch black"
+msgstr "गहरे रंग की थीम को गहरा काला बना देता है"
+
+#: data/app.gschema.xml:26 src/ui/preferences/preferences.blp:109
+msgid "Enable Toolbar"
+msgstr "टूलबार सक्षम करें"
+
+#: data/app.gschema.xml:27 src/ui/preferences/preferences.blp:110
+msgid "Displays the formatting toolbar at the bottom of the note"
+msgstr "नोट के नीचे प्रारूपण टूलबार प्रदर्शित करता है"
+
+#: data/app.gschema.xml:31 src/ui/preferences/preferences.blp:120
+msgid "Enable Cheatsheet"
+msgstr "चीटशीट सक्षम करें"
+
+#: data/app.gschema.xml:32 src/ui/preferences/preferences.blp:121
+msgid ""
+"Adds a button to the markdown reference sheet on the right of the formatting "
+"toolbar"
+msgstr "प्रारूपण टूलबार के दाईं ओर मार्कडाउन संदर्भ पत्रक में एक बटन जोड़ता है"
+
+#: data/app.gschema.xml:36 src/ui/preferences/preferences.blp:139
+msgid "3-Pane Layout"
+msgstr "3-फलक अभिन्यास"
+
+#: data/app.gschema.xml:37 src/ui/preferences/preferences.blp:140
+msgid "Expands the notebook list to include the notebook name"
+msgstr "नोटबुक का नाम शामिल करने के लिए नोटबुक सूची का विस्तार करता है"
+
+#: data/app.gschema.xml:41 src/ui/preferences/preferences.blp:207
+msgid "Notes Storage Location"
+msgstr "नोट्स संग्रहण स्थान"
+
+#: data/app.gschema.xml:42 src/ui/preferences/preferences.blp:208
+msgid "Where the notebooks are stored (requires app restart)"
+msgstr "जहां नोटबुक संग्रहीत हैं (ऐप पुनरारंभ की आवश्यकता है)"
+
+#: data/app.gschema.xml:46 src/ui/preferences/preferences.blp:235
+msgid "Trash Storage Location"
+msgstr "रद्दी संग्रहण स्थान"
+
+#: data/app.gschema.xml:47 src/ui/preferences/preferences.blp:236
+msgid "Where the trash folder is located (requires app restart)"
+msgstr "जहां रद्दी फोल्डर संग्रहीत हैं (ऐप पुनरारंभ की आवश्यकता है)"
+
+#: data/app.gschema.xml:51 src/ui/preferences/preferences.blp:87
+msgid "Show line numbers"
+msgstr "पंक्ति संख्याएं दिखाएं"
+
+#: data/app.gschema.xml:52 src/ui/preferences/preferences.blp:88
+msgid "Displays line numbers at the left of the note"
+msgstr "नोट के बाईं ओर पंक्ति संख्याएँ प्रदर्शित करता है"
+
+#: data/app.gschema.xml:56 src/ui/preferences/preferences.blp:98
+msgid "Show all notes"
+msgstr "सभी नोटों को दिखाएं"
+
+#: data/app.gschema.xml:57 src/ui/preferences/preferences.blp:99
+msgid "Displays the \"All Notes\" notebook at the top of the notebook list"
+msgstr "नोटबुक सूची के शीर्ष पर \"सभी नोट्स\" नोटबुक प्रदर्शित करता है"
+
+#: data/app.gschema.xml:61 src/ui/preferences/preferences.blp:185
+msgid "Enable autosave"
+msgstr "स्वतः सहेजना सक्षम करें"
+
+#: data/app.gschema.xml:62 src/ui/preferences/preferences.blp:186
+msgid ""
+"Automatically saves the current note every 30 seconds if the contents have "
+"changed (requires app restart)"
+msgstr ""
+"यदि सामग्री बदल गई है तो प्रत्येक 30 सेकंड में वर्तमान नोट स्वचालित रूप से सहेजता है (ऐप "
+"पुनरारंभ की आवश्यकता है)"
+
+#: data/app.gschema.xml:66 src/ui/preferences/preferences.blp:196
+msgid "Don't hide the Trash folder"
+msgstr "रद्दी फोल्डर को नहीं छुपाएं"
+
+#: data/app.gschema.xml:67
+msgid ""
+"The trash folder is set as a hidden folder by default, this option makes it "
+"visible"
+msgstr ""
+"रद्दी फोल्डर तयशुदा रूप से एक छिपे हुए फोल्डर के रूप में निर्धारित होता है, यह विकल्प इसे "
+"दृश्यमान बनाता है"
+
+#: data/app.gschema.xml:71
+msgid "Note sort order"
+msgstr "नोट छंटाई क्रम"
+
+#: data/app.gschema.xml:72
+msgid "The sort order of the note list"
+msgstr "नोट सूची का छंटाई क्रम"
+
+#: data/app.gschema.xml:76
+msgid "Notebook sort order"
+msgstr "नोटबुक छंटाई क्रम"
+
+#: data/app.gschema.xml:77
+msgid "The sort order of the notebook list"
+msgstr "नोटबुक सूची का छंटाई क्रम"
+
+#: data/app.gschema.xml:81
+msgid "URL detection level"
+msgstr ""
+
+#: data/app.gschema.xml:82
+msgid "How agressive to look for URLs in markdown text"
+msgstr ""
+
+#: data/app.gschema.xml:86
+msgid "Line spacing"
+msgstr ""
+
+#: data/app.gschema.xml:87 src/ui/preferences/preferences.blp:74
+msgid "The line spacing for the note text"
+msgstr ""
 
 #: data/app.metainfo.xml.in:5
 msgid "Take notes in Markdown"
@@ -329,103 +227,116 @@ msgstr "नोटबुक रंग पर आधारित ऐप थीम"
 msgid "Trash can"
 msgstr "कूड़ेदान"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:23
-#: src/ui/edit_view/toolbar/toolbar.blp:131
+#: data/app.metainfo.xml.in:393
+msgid "Main Folio window in light mode"
+msgstr "मुख्य फोलियो विंडो हल्के मोड में"
+
+#: data/app.metainfo.xml.in:397
+msgid "Main Folio window in dark mode"
+msgstr "मुख्य फोलियो विंडो गहरे मोड में"
+
+#: data/app.metainfo.xml.in:401
+msgid "Folio on small/mobile screens"
+msgstr "छोटे/मोबाइल स्क्रीन पर फोलियो"
+
+#: data/app.metainfo.xml.in:405
+msgid "Folio preferences screen"
+msgstr "फोलियो की प्राथमिकता स्क्रीन"
+
+#: data/app.metainfo.xml.in:409
+msgid "Folio in three pane mode"
+msgstr "तीन फलक मोड में फोलियो"
+
+#: src/ui/edit_view/toolbar/toolbar.blp:6
 #: src/ui/widgets/markdown/heading_popover.blp:48
 msgid "Plain Text"
 msgstr "सादा पाठ"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:24
-#: src/ui/edit_view/toolbar/toolbar.blp:132
+#: src/ui/edit_view/toolbar/toolbar.blp:7
 #: src/ui/widgets/markdown/heading_popover.blp:12
 msgid "Heading 1"
 msgstr "शीर्षक 1"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:25
-#: src/ui/edit_view/toolbar/toolbar.blp:133
+#: src/ui/edit_view/toolbar/toolbar.blp:8
 #: src/ui/widgets/markdown/heading_popover.blp:18
 msgid "Heading 2"
 msgstr "शीर्षक 2"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:26
-#: src/ui/edit_view/toolbar/toolbar.blp:134
+#: src/ui/edit_view/toolbar/toolbar.blp:9
 #: src/ui/widgets/markdown/heading_popover.blp:24
 msgid "Heading 3"
 msgstr "शीर्षक 3"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:27
-#: src/ui/edit_view/toolbar/toolbar.blp:135
+#: src/ui/edit_view/toolbar/toolbar.blp:10
 #: src/ui/widgets/markdown/heading_popover.blp:30
 msgid "Heading 4"
 msgstr "शीर्षक 4"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:28
-#: src/ui/edit_view/toolbar/toolbar.blp:136
+#: src/ui/edit_view/toolbar/toolbar.blp:11
 #: src/ui/widgets/markdown/heading_popover.blp:36
 msgid "Heading 5"
 msgstr "शीर्षक 5"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:29
-#: src/ui/edit_view/toolbar/toolbar.blp:137
+#: src/ui/edit_view/toolbar/toolbar.blp:12
 #: src/ui/widgets/markdown/heading_popover.blp:42
 msgid "Heading 6"
 msgstr "शीर्षक 6"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:39
-#: src/ui/edit_view/toolbar/toolbar.blp:104
-#: src/ui/edit_view/toolbar/toolbar.blp:148
-#: src/ui/edit_view/toolbar/toolbar.blp:201 src/ui/popup/shortcut_window.blp:72
+#: src/ui/edit_view/toolbar/toolbar.blp:41
+#: src/ui/edit_view/toolbar/toolbar.blp:107
+#: src/ui/edit_view/toolbar/toolbar.blp:142
+#: src/ui/edit_view/toolbar/toolbar.blp:195 src/ui/popup/shortcut_window.blp:72
 msgid "Bold"
 msgstr "बोल्ड"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:45
-#: src/ui/edit_view/toolbar/toolbar.blp:111
-#: src/ui/edit_view/toolbar/toolbar.blp:155
-#: src/ui/edit_view/toolbar/toolbar.blp:202 src/ui/popup/shortcut_window.blp:77
+#: src/ui/edit_view/toolbar/toolbar.blp:47
+#: src/ui/edit_view/toolbar/toolbar.blp:114
+#: src/ui/edit_view/toolbar/toolbar.blp:149
+#: src/ui/edit_view/toolbar/toolbar.blp:196 src/ui/popup/shortcut_window.blp:77
 msgid "Italic"
 msgstr "इटैलिक"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:51
-#: src/ui/edit_view/toolbar/toolbar.blp:162
-#: src/ui/edit_view/toolbar/toolbar.blp:203 src/ui/popup/shortcut_window.blp:82
+#: src/ui/edit_view/toolbar/toolbar.blp:53
+#: src/ui/edit_view/toolbar/toolbar.blp:156
+#: src/ui/edit_view/toolbar/toolbar.blp:197 src/ui/popup/shortcut_window.blp:82
 msgid "Strikethrough"
 msgstr "स्ट्राइकथ्रू"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:57
-#: src/ui/edit_view/toolbar/toolbar.blp:169
-#: src/ui/edit_view/toolbar/toolbar.blp:204 src/ui/popup/shortcut_window.blp:87
+#: src/ui/edit_view/toolbar/toolbar.blp:59
+#: src/ui/edit_view/toolbar/toolbar.blp:163
+#: src/ui/edit_view/toolbar/toolbar.blp:198 src/ui/popup/shortcut_window.blp:87
 msgid "Highlight"
 msgstr "चिन्हांकन"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:67
-#: src/ui/edit_view/toolbar/toolbar.blp:193 src/ui/popup/shortcut_window.blp:92
+#: src/ui/edit_view/toolbar/toolbar.blp:69
+#: src/ui/edit_view/toolbar/toolbar.blp:187 src/ui/popup/shortcut_window.blp:92
 msgid "Insert Link"
 msgstr "लिंक डालें"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:73
-#: src/ui/edit_view/toolbar/toolbar.blp:194
+#: src/ui/edit_view/toolbar/toolbar.blp:75
+#: src/ui/edit_view/toolbar/toolbar.blp:188
 msgid "Insert Code"
 msgstr "कोड डालें"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:79
-#: src/ui/edit_view/toolbar/toolbar.blp:195
+#: src/ui/edit_view/toolbar/toolbar.blp:81
+#: src/ui/edit_view/toolbar/toolbar.blp:189
 msgid "Insert Horizontal Rule"
 msgstr "क्षैतिज कायदा डालें"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:118
+#: src/ui/edit_view/toolbar/toolbar.blp:121
 msgid "Format"
 msgstr "प्रारूप"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:181
+#: src/ui/edit_view/toolbar/toolbar.blp:175
 msgid "Insert"
 msgstr "डालें"
 
-#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:34
+#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:18
 #: src/ui/strings.vala:44 src/ui/strings.vala:58
 msgid "Cancel"
 msgstr "रद्द करें"
 
-#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:39
+#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:23
 msgid "Confirm"
 msgstr "पुष्टि करें"
 
@@ -469,37 +380,87 @@ msgstr "प्रारूपण"
 msgid "Navigation"
 msgstr "पथ-प्रदर्शन"
 
-#: src/ui/popup/shortcut_window.blp:102 src/ui/window/window.blp:216
+#: src/ui/popup/shortcut_window.blp:102 src/ui/window/window.blp:268
 msgid "Toggle Sidebar"
 msgstr "पार्श्वपट्टी टॉगल करें"
 
-#: src/ui/popup/shortcut_window.blp:107 src/ui/window/window.blp:63
+#: src/ui/popup/shortcut_window.blp:107 src/ui/window/window.blp:70
 msgid "Search Notes"
 msgstr "नोट्स खोजें"
 
-#: data/app.gschema.xml:22 src/ui/preferences/preferences.blp:47
-msgid "Makes the dark theme pitch black"
-msgstr "गहरे रंग की थीम को गहरा काला बना देता है"
+#: src/ui/popup/shortcut_window.blp:114
+msgid "Display"
+msgstr "प्रदर्शन"
 
-#: data/app.gschema.xml:26 src/ui/preferences/preferences.blp:87
-msgid "Enable Toolbar"
-msgstr "टूलबार सक्षम करें"
+#: src/ui/popup/shortcut_window.blp:117
+msgid "Full Screen"
+msgstr "पूर्ण स्क्रीन"
 
-#: data/app.gschema.xml:31 src/ui/preferences/preferences.blp:98
-msgid "Enable Cheatsheet"
-msgstr "चीटशीट सक्षम करें"
+#: src/ui/popup/shortcut_window.blp:122
+msgid "Zoom In"
+msgstr "जूम इन"
 
-#: data/app.gschema.xml:36 src/ui/preferences/preferences.blp:117
-msgid "3-Pane Layout"
-msgstr "3-फलक अभिन्यास"
+#: src/ui/popup/shortcut_window.blp:127
+msgid "Zoom Out"
+msgstr "जूम आउट"
 
-#: data/app.gschema.xml:41 src/ui/preferences/preferences.blp:185
-msgid "Notes Storage Location"
-msgstr "नोट्स संग्रहण स्थान"
+#: src/ui/preferences/preferences.blp:31
+#, fuzzy
+msgid "Markdown URL Detection"
+msgstr "मार्कडाउन चीटशीट"
 
-#: data/app.gschema.xml:42 src/ui/preferences/preferences.blp:186
-msgid "Where the notebooks are stored (requires app restart)"
-msgstr "जहां नोटबुक संग्रहीत हैं (ऐप पुनरारंभ की आवश्यकता है)"
+#: src/ui/preferences/preferences.blp:32
+msgid ""
+"Determines the level of detection of URLs in\n"
+"free form text is used:\n"
+" - Aggressive tries to find all URLs\n"
+" - Strict requires a protocol identifier (ie http://)\n"
+" - Disabled turns detection off."
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:39
+msgid "Fonts"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:73
+msgid "Line Spacing"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:81
+msgid "Tools"
+msgstr "टूल्स"
+
+#: src/ui/preferences/preferences.blp:133
+msgid "Layout"
+msgstr "अभिन्यास"
+
+#: src/ui/preferences/preferences.blp:161
+msgid "Fixed Width To Use For Notes"
+msgstr "नोट्स के लिए उपयोग हेतु निश्चित चौड़ाई"
+
+#: src/ui/preferences/preferences.blp:162
+msgid "Sets the fixed width size of a note in px"
+msgstr "किसी नोट की निश्चित चौड़ाई का आकार px में निर्धारित करता है"
+
+#: src/ui/preferences/preferences.blp:167
+msgid "Sort Order For Notebooks"
+msgstr "नोटबुक के लिए छंटाई क्रम"
+
+#: src/ui/preferences/preferences.blp:172
+msgid "Sort Order For Notes"
+msgstr "नोट्स के लिए छंटाई क्रम"
+
+#: src/ui/preferences/preferences.blp:179
+msgid "Files"
+msgstr "फाइलें"
+
+#: src/ui/preferences/preferences.blp:197
+msgid ""
+"The trash folder is set as a hidden folder by default, this option makes it "
+"visible (requires app restart)"
+msgstr ""
+"रद्दी फोल्डर को तयशुदा रूप से एक छिपे हुए फोल्डर के रूप में निर्धारित किया गया है, यह "
+"विकल्प इसे दृश्यमान बनाता है (ऐप पुनरारंभ की आवश्यकता है)"
 
 #: src/ui/strings.vala:4 src/ui/window/notebooks_bar/notebooks_bar.blp:129
 #: src/ui/window/notebooks_bar/notebooks_bar.blp:171
@@ -507,6 +468,7 @@ msgid "Trash"
 msgstr "रद्दी"
 
 #: src/ui/strings.vala:5
+#, c-format
 msgid "%d Notes"
 msgstr "%d नोट्स"
 
@@ -514,7 +476,7 @@ msgstr "%d नोट्स"
 msgid "Are you sure you want to delete everything in the trash?"
 msgstr "क्या आप वाकई कूड़ेदान में मौजूद सभी चीज़ों को मिटाना चाहते हैं?"
 
-#: src/ui/strings.vala:7 src/ui/window/window.blp:54
+#: src/ui/strings.vala:7 src/ui/window/window.blp:61
 msgid "Empty Trash"
 msgstr "रद्दी खाली करें"
 
@@ -551,10 +513,12 @@ msgid "Move"
 msgstr "स्थानान्तर"
 
 #: src/ui/strings.vala:18
+#, c-format
 msgid "Note “%s” already exists in notebook “%s”"
 msgstr "नोट “%s” नोटबुक “%s” में पहले से मौजूद है"
 
 #: src/ui/strings.vala:19
+#, c-format
 msgid "Are you sure you want to delete the note “%s”?"
 msgstr "क्या आप वाकई “%s” नोट को मिटाना चाहते हैं?"
 
@@ -563,6 +527,7 @@ msgid "Delete Note"
 msgstr "नोट मिटाएं"
 
 #: src/ui/strings.vala:21
+#, c-format
 msgid "Are you sure you want to delete the notebook “%s”?"
 msgstr "क्या आप वाकई नोटबुक “%s” को मिटाना चाहते हैं?"
 
@@ -571,34 +536,42 @@ msgid "Delete Notebook"
 msgstr "नोटबुक मिटाएं"
 
 #: src/ui/strings.vala:24
-msgid "Note name shouldn’t contain “.” or “/”"
+#, fuzzy
+msgid "Note names cannot contain a “/”"
 msgstr "नोट के नाम में “.” या “/” नहीं होना चाहिए"
 
 #: src/ui/strings.vala:25
-msgid "Note name shouldn’t be blank"
+#, fuzzy
+msgid "Note names cannot be blank"
 msgstr "नोट का नाम रिक्त नहीं होना चाहिए"
 
 #: src/ui/strings.vala:26
+#, c-format
 msgid "Note “%s” already exists"
 msgstr "नोट “%s” पहले से मौजूद है"
 
 #: src/ui/strings.vala:27
-msgid "Couldn’t create note"
+#, fuzzy
+msgid "Could not create note"
 msgstr "नोट नहीं बना सके"
 
 #: src/ui/strings.vala:28
-msgid "Couldn’t change note"
+#, fuzzy
+msgid "Could not change note"
 msgstr "नोट नहीं बदले जा सके"
 
 #: src/ui/strings.vala:29
-msgid "Couldn’t delete note"
+#, fuzzy
+msgid "Could not delete note"
 msgstr "नोट नहीं मिटा सके"
 
 #: src/ui/strings.vala:30
-msgid "Couldn’t restore note"
+#, fuzzy
+msgid "Could not restore note"
 msgstr "नोट पुनर्स्थापित नहीं कर सके"
 
 #: src/ui/strings.vala:31
+#, c-format
 msgid "Saved “%s” to “%s”"
 msgstr "“%s” को “%s” में सहेजा गया"
 
@@ -607,27 +580,33 @@ msgid "Unknown error"
 msgstr "अज्ञात त्रुटि"
 
 #: src/ui/strings.vala:33
-msgid "Notebook name shouldn’t contain “.” or “/”"
+#, fuzzy
+msgid "Notebook names cannot contain a “/”"
 msgstr "नोटबुक के नाम में “.” या “/” नहीं होना चाहिए"
 
 #: src/ui/strings.vala:34
-msgid "Notebook name shouldn’t be blank"
+#, fuzzy
+msgid "Notebook names cannot be blank"
 msgstr "नोटबुक का नाम रिक्त नहीं होना चाहिए"
 
 #: src/ui/strings.vala:35
+#, c-format
 msgid "Notebook “%s” already exists"
 msgstr "नोटबुक “%s” पहले से मौजूद है"
 
 #: src/ui/strings.vala:36
-msgid "Couldn’t create notebook"
+#, fuzzy
+msgid "Could not create notebook"
 msgstr "नोटबुक नहीं बना सके"
 
 #: src/ui/strings.vala:37
-msgid "Couldn’t change notebook"
+#, fuzzy
+msgid "Could not change notebook"
 msgstr "नोटबुक नहीं बदल सके"
 
 #: src/ui/strings.vala:38
-msgid "Couldn’t delete notebook"
+#, fuzzy
+msgid "Could not delete notebook"
 msgstr "नोटबुक नहीं मिटाई जा सकी"
 
 #: src/ui/strings.vala:40
@@ -639,7 +618,8 @@ msgid "Rename"
 msgstr "नाम बदलें"
 
 #: src/ui/strings.vala:42
-msgid "Couldn’t find an app to handle file URIs"
+#, fuzzy
+msgid "Could not find an app to handle file URIs"
 msgstr "फाइल URI को प्रबंधित करने के लिए कोई ऐप नहीं मिला"
 
 #: src/ui/strings.vala:43
@@ -649,6 +629,10 @@ msgstr "लागू करें"
 #: src/ui/strings.vala:45
 msgid "Pick where the notebooks will be stored"
 msgstr "चुनें कि नोटबुक कहां संग्रहित की जाएंगी"
+
+#: src/ui/strings.vala:46
+msgid "Pick where the trash can will be stored"
+msgstr "चुनें कि कूड़ादान कहां रखें"
 
 #: src/ui/strings.vala:47 src/ui/window/notebooks_bar/notebooks_bar.blp:59
 #: src/ui/window/notebooks_bar/notebooks_bar.blp:101
@@ -662,6 +646,130 @@ msgstr "अंतिम संशोधित"
 #: src/ui/strings.vala:50
 msgid "Extension"
 msgstr "एक्सटेंशन"
+
+#: src/ui/strings.vala:51
+msgid "Unable to recognize URI"
+msgstr "URI को पहचानने में असमर्थ"
+
+#: src/ui/strings.vala:52
+msgid "Pick primary font for notes"
+msgstr "नोट्स के लिए प्राथमिक फॉन्ट चुनें"
+
+#: src/ui/strings.vala:53
+msgid "Pick monospace font for code"
+msgstr "कोड के लिए मोनोस्पेस फॉन्ट चुनें"
+
+#: src/ui/strings.vala:54
+msgid "File Changed On Disk"
+msgstr "डिस्क पर फाइल परिवर्तित"
+
+#: src/ui/strings.vala:55
+msgid ""
+"The file has changed on disk since it was last saved/loaded by Folio.\n"
+"\n"
+"You may do one of the following:\n"
+"\n"
+" • Reload the file (discarding any changes you have made in Folio)\n"
+" • Overwrite the file (discarding any changes made outside of Folio)\n"
+" • Cancel the operation and manually resolve the issue\n"
+"\n"
+"Note: Canceling the save if you have already moved to a new note/notebook "
+"will discard your changes."
+msgstr ""
+"फोलियो द्वारा अंतिम बार सहेजे/लोड किए जाने के बाद से फाइल डिस्क पर बदल गई है।\n"
+"\n"
+"आप निम्न में से एक कर सकते हैं:\n"
+"\n"
+" • फाइल को पुनः लोड करें (फोलियो में आपके द्वारा किए गए किसी भी परिवर्तन को खारिज "
+"करके)\n"
+" • फाइल को अधिलेखित करें (फोलियो के बाहर किए गए किसी भी परिवर्तन को खारिज करके)\n"
+" • अभियान रद्द करें और समस्या को हस्तचालित रूप से हल करें\n"
+"\n"
+"नोट: यदि आप पहले ही किसी नए नोट/नोटबुक में चले गए हैं तो सहेजना रद्द करने से आपके "
+"परिवर्तन खारिज हो जाएंगे।"
+
+#: src/ui/strings.vala:56
+msgid "Reload"
+msgstr "पुनः लोड करें"
+
+#: src/ui/strings.vala:57
+msgid "Overwrite"
+msgstr "अधिलेखित"
+
+#: src/ui/strings.vala:59
+msgid ""
+"The file has changed on disk by another application.\n"
+"\n"
+"You may do one of the following:\n"
+"\n"
+" • Reload the file (discarding any changes you have made in Folio)\n"
+" • Overwrite the file (discarding any changes made outside of Folio)"
+msgstr ""
+"फाइल किसी अन्य अनुप्रयोग द्वारा डिस्क पर बदल दी गई है।\n"
+"\n"
+"आप निम्न में से एक कर सकते हैं:\n"
+"\n"
+" • फाइल को पुनः लोड करें (फोलियो में आपके द्वारा किए गए किसी भी परिवर्तन को खारिज "
+"करके)\n"
+" • फाइल को अधिलेखित करें (फोलियो के बाहर किए गए किसी भी परिवर्तन को खारिज करके)"
+
+#: src/ui/strings.vala:61
+#, c-format
+msgid "Note %i"
+msgstr "नोट %i"
+
+#: src/ui/strings.vala:62
+msgid "Modified Time - Ascending"
+msgstr "संशोधित समय - आरोही"
+
+#: src/ui/strings.vala:63
+msgid "Modified Time - Descending"
+msgstr "संशोधित समय - अवरोही"
+
+#: src/ui/strings.vala:64
+msgid "Alphabetical - Ascending"
+msgstr "वर्णानुक्रम - आरोही"
+
+#: src/ui/strings.vala:65
+msgid "Alphabetical - Descending"
+msgstr "वर्णानुक्रम - अवरोहण"
+
+#: src/ui/strings.vala:66
+#, fuzzy
+msgid "Natural - Ascending"
+msgstr "वर्णानुक्रम - आरोही"
+
+#: src/ui/strings.vala:67
+#, fuzzy
+msgid "Natural - Descending"
+msgstr "वर्णानुक्रम - अवरोहण"
+
+#: src/ui/strings.vala:68
+#, c-format
+msgid "Unable to launch external application for file %s."
+msgstr ""
+
+#: src/ui/strings.vala:69
+msgid "Aggressive"
+msgstr ""
+
+#: src/ui/strings.vala:70
+msgid "Strict"
+msgstr ""
+
+#: src/ui/strings.vala:71
+msgid "Disabled"
+msgstr ""
+
+#: src/ui/strings.vala:72
+#, fuzzy, c-format
+msgid "“%s” moved to trash"
+msgstr "रद्दी में ले जाएं"
+
+#: src/ui/strings.vala:73
+#, c-format
+msgid "“%s” restored"
+msgstr ""
 
 #: src/ui/widgets/theme_selector/theme_selector.blp:15
 msgid "Follow system style"
@@ -692,40 +800,45 @@ msgid "_Keyboard Shortcuts"
 msgstr "कीबोर्ड शॉर्टकट (_K)"
 
 #: src/ui/window/app_menu/app_menu.blp:43
-msgid "_About"
+#, fuzzy
+msgid "_About Folio"
 msgstr "फोलियो के बारे में (_A)"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:54
-msgid "Notebook Name"
-msgstr "नोटबुक नाम"
-
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:66
-msgid "Duplicate notebook names are not allowed!"
-msgstr "डुप्लिकेट नोटबुक नामों की अनुमति नहीं है!"
-
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:82
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:6
 msgid "First Characters"
 msgstr "प्रथम वर्ण"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:83
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:7
 msgid "Initials"
 msgstr "प्रथमाक्षर"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:84
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:8
 msgid "Initials: camelCase"
 msgstr "प्रथमाक्षर: camelCase"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:85
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:9
 msgid "Initials: snake_case"
 msgstr "प्रथमाक्षर: snake_case"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:86
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:10
 msgid "Icon"
 msgstr "आइकन"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:116
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:11
+msgid "Custom"
+msgstr ""
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:16
 msgid "Notebook Color"
 msgstr "नोटबुक रंग"
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:58
+msgid "Notebook Name"
+msgstr "नोटबुक नाम"
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:70
+msgid "Duplicate notebook names are not allowed!"
+msgstr "डुप्लिकेट नोटबुक नामों की अनुमति नहीं है!"
 
 #: src/ui/window/notebooks_bar/notebook_create_popup.blp:126
 msgid "Create Notebook"
@@ -743,11 +856,11 @@ msgstr "सभी रद्दी में ले जाएं"
 msgid "Notebooks"
 msgstr "नोटबुक"
 
-#: src/ui/window/sidebar/note_create_popup.blp:37
+#: src/ui/window/sidebar/note_create_popup.blp:25
 msgid "Note Name"
 msgstr "नोट नाम"
 
-#: src/ui/window/sidebar/note_create_popup.blp:45
+#: src/ui/window/sidebar/note_create_popup.blp:33
 msgid "Create Note"
 msgstr "नोट बनाएँ"
 
@@ -771,30 +884,37 @@ msgstr "रद्दी में ले जाएं"
 msgid "Open Containing Folder"
 msgstr "धारक फोल्डर खोलें"
 
-#: src/ui/window/window.blp:118
+#: src/ui/window/window.blp:123
 msgid "Get started writing"
 msgstr "लिखना शुरू करें"
 
-#: src/ui/window/window.blp:143
+#: src/ui/window/window.blp:152
+msgid "Open file in external application"
+msgstr ""
+
+#: src/ui/window/window.blp:160
+msgid "Open file"
+msgstr ""
+
+#: src/ui/window/window.blp:181
 msgid "Create a notebook"
 msgstr "एक नोटबुक बनाएं"
 
-#: src/ui/window/window.blp:168
+#: src/ui/window/window.blp:210
 msgid "Trash is empty"
 msgstr "रद्दी खाली है"
 
-#: src/ui/window/window.blp:224
-msgid "Back"
-msgstr "पीछे"
-
-#: src/ui/window/window.blp:239
+#: src/ui/window/window.blp:285
 msgid "Open in Notebook"
 msgstr "नोटबुक में खोलें"
 
-#: src/ui/window/window.blp:264
+#: src/ui/window/window.blp:312
 msgid "_Rename Note"
 msgstr "नोट का नाम बदलें (_R)"
 
-#: src/ui/window/window.blp:270
+#: src/ui/window/window.blp:319
 msgid "_Export Note"
 msgstr "नोट निर्यात करें (_E)"
+
+#~ msgid "Back"
+#~ msgstr "पीछे"

--- a/po/it.po
+++ b/po/it.po
@@ -2,244 +2,16 @@
 # This file is distributed under the same license as the Folio package.
 msgid ""
 msgstr ""
+"Project-Id-Version: Folio\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-10-12 16:53+0200\n"
 "PO-Revision-Date: 2024-05-18 03:26:22+0000\n"
+"Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: GlotPress/4.0.1\n"
-"Language: it\n"
-"Project-Id-Version: Folio\n"
-
-#: data/app.gschema.xml:76
-msgid "Notebook sort order"
-msgstr "Ordinamento del taccuino"
-
-#: data/app.gschema.xml:77
-msgid "The sort order of the notebook list"
-msgstr "L'ordinamento dell'elenco dei taccuini"
-
-#: src/ui/preferences/preferences.blp:145
-msgid "Sort Order For Notebooks"
-msgstr "Ordinamento per i taccuini"
-
-#: data/app.gschema.xml:71
-msgid "Note sort order"
-msgstr "Ordinamento della note"
-
-#: data/app.gschema.xml:72
-msgid "The sort order of the note list"
-msgstr "L'ordinamento dell'elenco delle note"
-
-#: src/ui/preferences/preferences.blp:150
-msgid "Sort Order For Notes"
-msgstr "Ordinamento per le note"
-
-#: src/ui/strings.vala:62
-msgid "Modified Time - Ascending"
-msgstr "Orario modificato - Crescente"
-
-#: src/ui/strings.vala:63
-msgid "Modified Time - Descending"
-msgstr "Orario modificato - Discendente"
-
-#: src/ui/strings.vala:64
-msgid "Alphabetical - Ascending"
-msgstr "Alfabetico - Ascendente"
-
-#: src/ui/strings.vala:65
-msgid "Alphabetical - Descending"
-msgstr "Alfabetico - Discendente"
-
-#: src/ui/popup/shortcut_window.blp:114
-msgid "Display"
-msgstr "Schermo"
-
-#: src/ui/popup/shortcut_window.blp:117
-msgid "Full Screen"
-msgstr "A schermo intero"
-
-#: src/ui/popup/shortcut_window.blp:122
-msgid "Zoom In"
-msgstr "Ingrandire"
-
-#: src/ui/popup/shortcut_window.blp:127
-msgid "Zoom Out"
-msgstr "Rimpicciolire"
-
-#: src/ui/strings.vala:52
-msgid "Pick primary font for notes"
-msgstr "Scegli il carattere principale per le note"
-
-#: src/ui/strings.vala:53
-msgid "Pick monospace font for code"
-msgstr "Scegli il carattere a spaziatura fissa per il codice"
-
-#: src/ui/strings.vala:54
-msgid "File Changed On Disk"
-msgstr "File modificato su disco"
-
-#: src/ui/strings.vala:55
-msgid ""
-"The file has changed on disk since it was last saved/loaded by Folio.\n"
-"\n"
-"You may do one of the following:\n"
-"\n"
-" • Reload the file (discarding any changes you have made in Folio)\n"
-" • Overwrite the file (discarding any changes made outside of Folio)\n"
-" • Cancel the operation and manually resolve the issue\n"
-"\n"
-"Note: Canceling the save if you have already moved to a new note/notebook will discard your changes."
-msgstr ""
-"Il file è cambiato sul disco dall'ultima volta che è stato salvato/caricato da Folio.\n"
-"\n"
-"Puoi effettuare una delle seguenti operazioni:\n"
-"\n"
-" • Ricarica il file (annullando eventuali modifiche apportate in Folio)\n"
-" • Sovrascrivi il file (annullando eventuali modifiche apportate all'esterno di Folio)\n"
-" • Annulla l'operazione e risolvi manualmente il problema\n"
-"\n"
-"Nota: l'annullamento del salvataggio se sei già passato a una nuova nota/taccuino annullerà le modifiche."
-
-#: src/ui/strings.vala:56
-msgid "Reload"
-msgstr "Ricarica"
-
-#: src/ui/strings.vala:57
-msgid "Overwrite"
-msgstr "Sovrascrivi"
-
-#: src/ui/strings.vala:59
-msgid ""
-"The file has changed on disk by another application.\n"
-"\n"
-"You may do one of the following:\n"
-"\n"
-" • Reload the file (discarding any changes you have made in Folio)\n"
-" • Overwrite the file (discarding any changes made outside of Folio)"
-msgstr ""
-"Il file è stato modificato sul disco da un'altra applicazione.\n"
-"\n"
-"Puoi effettuare una delle seguenti operazioni:\n"
-"\n"
-" • Ricarica il file (annullando eventuali modifiche apportate in Folio)\n"
-" • Sovrascrivi il file (annullando eventuali modifiche apportate al di fuori di Folio)"
-
-#: src/ui/strings.vala:61
-msgid "Note %i"
-msgstr "Nota %i"
-
-#: data/app.gschema.xml:46 src/ui/preferences/preferences.blp:213
-msgid "Trash Storage Location"
-msgstr "Posizione di archiviazione del cestino"
-
-#: data/app.gschema.xml:47 src/ui/preferences/preferences.blp:214
-msgid "Where the trash folder is located (requires app restart)"
-msgstr "Dove si trova la cartella cestino (richiede il riavvio dell'app)"
-
-#: src/ui/strings.vala:46
-msgid "Pick where the trash can will be stored"
-msgstr "Scegli dove verrà depositato il cestino"
-
-#: data/app.gschema.xml:16 src/ui/preferences/preferences.blp:128
-msgid "Use Fixed Width For Notes"
-msgstr "Usa larghezza fissa per le note"
-
-#: data/app.gschema.xml:17 src/ui/preferences/preferences.blp:129
-msgid "Use a fixed width for the text area of a note"
-msgstr "Utilizza una larghezza fissa per l'area di testo di una nota"
-
-#: data/app.gschema.xml:37 src/ui/preferences/preferences.blp:118
-msgid "Expands the notebook list to include the notebook name"
-msgstr "Espande l'elenco dei taccuini per includere il nome del taccuino"
-
-#: data/app.gschema.xml:51 src/ui/preferences/preferences.blp:65
-msgid "Show line numbers"
-msgstr "Mostra i numeri di riga"
-
-#: data/app.gschema.xml:52 src/ui/preferences/preferences.blp:66
-msgid "Displays line numbers at the left of the note"
-msgstr "Visualizza i numeri di riga a sinistra della nota"
-
-#: data/app.gschema.xml:56 src/ui/preferences/preferences.blp:76
-msgid "Show all notes"
-msgstr "Mostra tutte le note"
-
-#: data/app.gschema.xml:57 src/ui/preferences/preferences.blp:77
-msgid "Displays the \"All Notes\" notebook at the top of the notebook list"
-msgstr "Visualizza il taccuino \"Tutte le note\" nella parte superiore dell'elenco dei taccuini"
-
-#: data/app.gschema.xml:61 src/ui/preferences/preferences.blp:163
-msgid "Enable autosave"
-msgstr "Abilita il salvataggio automatico"
-
-#: data/app.gschema.xml:62 src/ui/preferences/preferences.blp:164
-msgid "Automatically saves the current note every 30 seconds if the contents have changed (requires app restart)"
-msgstr "Salva automaticamente la nota corrente ogni 30 secondi se i contenuti sono cambiati (richiede il riavvio dell'app)"
-
-#: data/app.gschema.xml:66 src/ui/preferences/preferences.blp:174
-msgid "Don't hide the Trash folder"
-msgstr "Non nascondere la cartella Cestino"
-
-#: data/app.gschema.xml:67
-msgid "The trash folder is set as a hidden folder by default, this option makes it visible"
-msgstr "La cartella del cestino è impostata come cartella nascosta per impostazione predefinita, questa opzione la rende visibile"
-
-#: data/app.metainfo.xml.in:367
-msgid "Main Folio window in light mode"
-msgstr "Finestra principale di Folio in modalità chiara"
-
-#: data/app.metainfo.xml.in:371
-msgid "Main Folio window in dark mode"
-msgstr "Finestra principale di Folio in modalità scura"
-
-#: data/app.metainfo.xml.in:375
-msgid "Folio on small/mobile screens"
-msgstr "Folio su schermi piccoli/mobili"
-
-#: data/app.metainfo.xml.in:379
-msgid "Folio preferences screen"
-msgstr "Schermata delle preferenze di Folio"
-
-#: data/app.metainfo.xml.in:383
-msgid "Folio in three pane mode"
-msgstr "Folio in modalità a tre riquadri"
-
-#: src/ui/preferences/preferences.blp:59
-msgid "Tools"
-msgstr "Strumenti"
-
-#: data/app.gschema.xml:27 src/ui/preferences/preferences.blp:88
-msgid "Displays the formatting toolbar at the bottom of the note"
-msgstr "Visualizza la barra degli strumenti di formattazione nella parte inferiore della nota"
-
-#: data/app.gschema.xml:32 src/ui/preferences/preferences.blp:99
-msgid "Adds a button to the markdown reference sheet on the right of the formatting toolbar"
-msgstr "Aggiunge un pulsante al foglio di riferimento del markdown a destra della barra degli strumenti di formattazione"
-
-#: src/ui/preferences/preferences.blp:111
-msgid "Layout"
-msgstr "Layout"
-
-#: src/ui/preferences/preferences.blp:139
-msgid "Fixed Width To Use For Notes"
-msgstr "Larghezza fissa da utilizzare per le note"
-
-#: src/ui/preferences/preferences.blp:140
-msgid "Sets the fixed width size of a note in px"
-msgstr "Imposta la dimensione della larghezza fissa di una nota in px"
-
-#: src/ui/preferences/preferences.blp:157
-msgid "Files"
-msgstr "File"
-
-#: src/ui/preferences/preferences.blp:175
-msgid "The trash folder is set as a hidden folder by default, this option makes it visible (requires app restart)"
-msgstr "La cartella del cestino è impostata come cartella nascosta per impostazione predefinita, questa opzione la rende visibile (richiede il riavvio dell'app)"
-
-#: src/ui/strings.vala:51
-msgid "Unable to recognize URI"
-msgstr "Impossibile riconoscere l'URI"
 
 #: data/app.desktop.in:9 src/ui/strings.vala:3
 msgid "Folio"
@@ -255,21 +27,23 @@ msgstr "Prendi nota"
 
 #: data/app.desktop.in:13
 msgid "Notebook;Note;Notes;Text;Markdown;Notepad;Write;School;Post-it;Sticky;"
-msgstr "Notebook;Note;Notes;Text;Markdown;Notepad;Write;School;Post-it;Sticky;Quaderno;Testo;Blocco;Taccuino"
+msgstr ""
+"Notebook;Note;Notes;Text;Markdown;Notepad;Write;School;Post-it;Sticky;"
+"Quaderno;Testo;Blocco;Taccuino"
 
 #: data/app.desktop.in:22 src/ui/popup/shortcut_window.blp:17
-#: src/ui/strings.vala:8 src/ui/window/window.blp:47
-#: src/ui/window/window.blp:124
+#: src/ui/strings.vala:8 src/ui/window/window.blp:54
+#: src/ui/window/window.blp:131
 msgid "New Note"
 msgstr "Nuova nota"
 
 #: data/app.desktop.in:26 src/ui/popup/shortcut_window.blp:37
-#: src/ui/strings.vala:14 src/ui/window/window.blp:149
+#: src/ui/strings.vala:14 src/ui/window/window.blp:189
 msgid "New Notebook"
 msgstr "Nuovo taccuino"
 
-#: data/app.desktop.in:30 src/ui/edit_view/toolbar/toolbar.blp:90
-#: src/ui/strings.vala:39 src/ui/window/window.blp:245
+#: data/app.desktop.in:30 src/ui/edit_view/toolbar/toolbar.blp:92
+#: src/ui/strings.vala:39 src/ui/window/window.blp:291
 msgid "Markdown Cheatsheet"
 msgstr "Guida rapida al markdown"
 
@@ -277,25 +51,157 @@ msgstr "Guida rapida al markdown"
 msgid "Preferences"
 msgstr "Preferenze"
 
-#: data/app.gschema.xml:6 src/ui/preferences/preferences.blp:18
+#: data/app.gschema.xml:6 src/ui/preferences/preferences.blp:45
 msgid "Note Font"
 msgstr "Carattere delle note"
 
-#: data/app.gschema.xml:7 src/ui/preferences/preferences.blp:19
+#: data/app.gschema.xml:7 src/ui/preferences/preferences.blp:46
 msgid "The font notes will be displayed in"
 msgstr "Il carattere in cui visualizzare le note"
 
-#: data/app.gschema.xml:11 src/ui/preferences/preferences.blp:31
+#: data/app.gschema.xml:11 src/ui/preferences/preferences.blp:58
 msgid "Monospace Font"
 msgstr "Carattere monospazio"
 
-#: data/app.gschema.xml:12 src/ui/preferences/preferences.blp:32
+#: data/app.gschema.xml:12 src/ui/preferences/preferences.blp:59
 msgid "The font code will be displayed in"
 msgstr "Il codice del carattere verrà visualizzato in"
 
-#: data/app.gschema.xml:21 src/ui/preferences/preferences.blp:46
+#: data/app.gschema.xml:16 src/ui/preferences/preferences.blp:150
+msgid "Use Fixed Width For Notes"
+msgstr "Usa larghezza fissa per le note"
+
+#: data/app.gschema.xml:17 src/ui/preferences/preferences.blp:151
+msgid "Use a fixed width for the text area of a note"
+msgstr "Utilizza una larghezza fissa per l'area di testo di una nota"
+
+#: data/app.gschema.xml:21 src/ui/preferences/preferences.blp:18
 msgid "OLED Mode"
 msgstr "Modalità OLED"
+
+#: data/app.gschema.xml:22 src/ui/preferences/preferences.blp:19
+msgid "Makes the dark theme pitch black"
+msgstr "Rende il tema scuro completamente nero"
+
+#: data/app.gschema.xml:26 src/ui/preferences/preferences.blp:109
+msgid "Enable Toolbar"
+msgstr "abilita barra degli strumenti"
+
+#: data/app.gschema.xml:27 src/ui/preferences/preferences.blp:110
+msgid "Displays the formatting toolbar at the bottom of the note"
+msgstr ""
+"Visualizza la barra degli strumenti di formattazione nella parte inferiore "
+"della nota"
+
+#: data/app.gschema.xml:31 src/ui/preferences/preferences.blp:120
+msgid "Enable Cheatsheet"
+msgstr "Abilita il foglio informativo"
+
+#: data/app.gschema.xml:32 src/ui/preferences/preferences.blp:121
+msgid ""
+"Adds a button to the markdown reference sheet on the right of the formatting "
+"toolbar"
+msgstr ""
+"Aggiunge un pulsante al foglio di riferimento del markdown a destra della "
+"barra degli strumenti di formattazione"
+
+#: data/app.gschema.xml:36 src/ui/preferences/preferences.blp:139
+msgid "3-Pane Layout"
+msgstr "Layout a 3 riquadri"
+
+#: data/app.gschema.xml:37 src/ui/preferences/preferences.blp:140
+msgid "Expands the notebook list to include the notebook name"
+msgstr "Espande l'elenco dei taccuini per includere il nome del taccuino"
+
+#: data/app.gschema.xml:41 src/ui/preferences/preferences.blp:207
+msgid "Notes Storage Location"
+msgstr "Posizione delle note"
+
+#: data/app.gschema.xml:42 src/ui/preferences/preferences.blp:208
+msgid "Where the notebooks are stored (requires app restart)"
+msgstr "Dove salvare i taccuini (riavvio richiesto)"
+
+#: data/app.gschema.xml:46 src/ui/preferences/preferences.blp:235
+msgid "Trash Storage Location"
+msgstr "Posizione di archiviazione del cestino"
+
+#: data/app.gschema.xml:47 src/ui/preferences/preferences.blp:236
+msgid "Where the trash folder is located (requires app restart)"
+msgstr "Dove si trova la cartella cestino (richiede il riavvio dell'app)"
+
+#: data/app.gschema.xml:51 src/ui/preferences/preferences.blp:87
+msgid "Show line numbers"
+msgstr "Mostra i numeri di riga"
+
+#: data/app.gschema.xml:52 src/ui/preferences/preferences.blp:88
+msgid "Displays line numbers at the left of the note"
+msgstr "Visualizza i numeri di riga a sinistra della nota"
+
+#: data/app.gschema.xml:56 src/ui/preferences/preferences.blp:98
+msgid "Show all notes"
+msgstr "Mostra tutte le note"
+
+#: data/app.gschema.xml:57 src/ui/preferences/preferences.blp:99
+msgid "Displays the \"All Notes\" notebook at the top of the notebook list"
+msgstr ""
+"Visualizza il taccuino \"Tutte le note\" nella parte superiore dell'elenco "
+"dei taccuini"
+
+#: data/app.gschema.xml:61 src/ui/preferences/preferences.blp:185
+msgid "Enable autosave"
+msgstr "Abilita il salvataggio automatico"
+
+#: data/app.gschema.xml:62 src/ui/preferences/preferences.blp:186
+msgid ""
+"Automatically saves the current note every 30 seconds if the contents have "
+"changed (requires app restart)"
+msgstr ""
+"Salva automaticamente la nota corrente ogni 30 secondi se i contenuti sono "
+"cambiati (richiede il riavvio dell'app)"
+
+#: data/app.gschema.xml:66 src/ui/preferences/preferences.blp:196
+msgid "Don't hide the Trash folder"
+msgstr "Non nascondere la cartella Cestino"
+
+#: data/app.gschema.xml:67
+msgid ""
+"The trash folder is set as a hidden folder by default, this option makes it "
+"visible"
+msgstr ""
+"La cartella del cestino è impostata come cartella nascosta per impostazione "
+"predefinita, questa opzione la rende visibile"
+
+#: data/app.gschema.xml:71
+msgid "Note sort order"
+msgstr "Ordinamento della note"
+
+#: data/app.gschema.xml:72
+msgid "The sort order of the note list"
+msgstr "L'ordinamento dell'elenco delle note"
+
+#: data/app.gschema.xml:76
+msgid "Notebook sort order"
+msgstr "Ordinamento del taccuino"
+
+#: data/app.gschema.xml:77
+msgid "The sort order of the notebook list"
+msgstr "L'ordinamento dell'elenco dei taccuini"
+
+#: data/app.gschema.xml:81
+msgid "URL detection level"
+msgstr ""
+
+#: data/app.gschema.xml:82
+msgid "How agressive to look for URLs in markdown text"
+msgstr ""
+
+#: data/app.gschema.xml:86
+msgid "Line spacing"
+msgstr ""
+
+#: data/app.gschema.xml:87 src/ui/preferences/preferences.blp:74
+msgid "The line spacing for the note text"
+msgstr ""
 
 #: data/app.metainfo.xml.in:5
 msgid "Take notes in Markdown"
@@ -329,103 +235,116 @@ msgstr "Temi dell'app basati sul colore del taccuino"
 msgid "Trash can"
 msgstr "Cestino"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:23
-#: src/ui/edit_view/toolbar/toolbar.blp:131
+#: data/app.metainfo.xml.in:393
+msgid "Main Folio window in light mode"
+msgstr "Finestra principale di Folio in modalità chiara"
+
+#: data/app.metainfo.xml.in:397
+msgid "Main Folio window in dark mode"
+msgstr "Finestra principale di Folio in modalità scura"
+
+#: data/app.metainfo.xml.in:401
+msgid "Folio on small/mobile screens"
+msgstr "Folio su schermi piccoli/mobili"
+
+#: data/app.metainfo.xml.in:405
+msgid "Folio preferences screen"
+msgstr "Schermata delle preferenze di Folio"
+
+#: data/app.metainfo.xml.in:409
+msgid "Folio in three pane mode"
+msgstr "Folio in modalità a tre riquadri"
+
+#: src/ui/edit_view/toolbar/toolbar.blp:6
 #: src/ui/widgets/markdown/heading_popover.blp:48
 msgid "Plain Text"
 msgstr "Testo normale"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:24
-#: src/ui/edit_view/toolbar/toolbar.blp:132
+#: src/ui/edit_view/toolbar/toolbar.blp:7
 #: src/ui/widgets/markdown/heading_popover.blp:12
 msgid "Heading 1"
 msgstr "Intestazione 1"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:25
-#: src/ui/edit_view/toolbar/toolbar.blp:133
+#: src/ui/edit_view/toolbar/toolbar.blp:8
 #: src/ui/widgets/markdown/heading_popover.blp:18
 msgid "Heading 2"
 msgstr "Intestazione 2"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:26
-#: src/ui/edit_view/toolbar/toolbar.blp:134
+#: src/ui/edit_view/toolbar/toolbar.blp:9
 #: src/ui/widgets/markdown/heading_popover.blp:24
 msgid "Heading 3"
 msgstr "Intestazione 3"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:27
-#: src/ui/edit_view/toolbar/toolbar.blp:135
+#: src/ui/edit_view/toolbar/toolbar.blp:10
 #: src/ui/widgets/markdown/heading_popover.blp:30
 msgid "Heading 4"
 msgstr "Intestazione 4"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:28
-#: src/ui/edit_view/toolbar/toolbar.blp:136
+#: src/ui/edit_view/toolbar/toolbar.blp:11
 #: src/ui/widgets/markdown/heading_popover.blp:36
 msgid "Heading 5"
 msgstr "Intestazione 5"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:29
-#: src/ui/edit_view/toolbar/toolbar.blp:137
+#: src/ui/edit_view/toolbar/toolbar.blp:12
 #: src/ui/widgets/markdown/heading_popover.blp:42
 msgid "Heading 6"
 msgstr "Intestazione 6"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:39
-#: src/ui/edit_view/toolbar/toolbar.blp:104
-#: src/ui/edit_view/toolbar/toolbar.blp:148
-#: src/ui/edit_view/toolbar/toolbar.blp:201 src/ui/popup/shortcut_window.blp:72
+#: src/ui/edit_view/toolbar/toolbar.blp:41
+#: src/ui/edit_view/toolbar/toolbar.blp:107
+#: src/ui/edit_view/toolbar/toolbar.blp:142
+#: src/ui/edit_view/toolbar/toolbar.blp:195 src/ui/popup/shortcut_window.blp:72
 msgid "Bold"
 msgstr "Grassetto"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:45
-#: src/ui/edit_view/toolbar/toolbar.blp:111
-#: src/ui/edit_view/toolbar/toolbar.blp:155
-#: src/ui/edit_view/toolbar/toolbar.blp:202 src/ui/popup/shortcut_window.blp:77
+#: src/ui/edit_view/toolbar/toolbar.blp:47
+#: src/ui/edit_view/toolbar/toolbar.blp:114
+#: src/ui/edit_view/toolbar/toolbar.blp:149
+#: src/ui/edit_view/toolbar/toolbar.blp:196 src/ui/popup/shortcut_window.blp:77
 msgid "Italic"
 msgstr "Corsivo"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:51
-#: src/ui/edit_view/toolbar/toolbar.blp:162
-#: src/ui/edit_view/toolbar/toolbar.blp:203 src/ui/popup/shortcut_window.blp:82
+#: src/ui/edit_view/toolbar/toolbar.blp:53
+#: src/ui/edit_view/toolbar/toolbar.blp:156
+#: src/ui/edit_view/toolbar/toolbar.blp:197 src/ui/popup/shortcut_window.blp:82
 msgid "Strikethrough"
 msgstr "Barrato"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:57
-#: src/ui/edit_view/toolbar/toolbar.blp:169
-#: src/ui/edit_view/toolbar/toolbar.blp:204 src/ui/popup/shortcut_window.blp:87
+#: src/ui/edit_view/toolbar/toolbar.blp:59
+#: src/ui/edit_view/toolbar/toolbar.blp:163
+#: src/ui/edit_view/toolbar/toolbar.blp:198 src/ui/popup/shortcut_window.blp:87
 msgid "Highlight"
 msgstr "Evidenziato"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:67
-#: src/ui/edit_view/toolbar/toolbar.blp:193 src/ui/popup/shortcut_window.blp:92
+#: src/ui/edit_view/toolbar/toolbar.blp:69
+#: src/ui/edit_view/toolbar/toolbar.blp:187 src/ui/popup/shortcut_window.blp:92
 msgid "Insert Link"
 msgstr "Inserisci collegamento"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:73
-#: src/ui/edit_view/toolbar/toolbar.blp:194
+#: src/ui/edit_view/toolbar/toolbar.blp:75
+#: src/ui/edit_view/toolbar/toolbar.blp:188
 msgid "Insert Code"
 msgstr "Inserisci codice"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:79
-#: src/ui/edit_view/toolbar/toolbar.blp:195
+#: src/ui/edit_view/toolbar/toolbar.blp:81
+#: src/ui/edit_view/toolbar/toolbar.blp:189
 msgid "Insert Horizontal Rule"
 msgstr "Inserisci regola orizzontale"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:118
+#: src/ui/edit_view/toolbar/toolbar.blp:121
 msgid "Format"
 msgstr "Formato"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:181
+#: src/ui/edit_view/toolbar/toolbar.blp:175
 msgid "Insert"
 msgstr "Inserisci"
 
-#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:34
+#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:18
 #: src/ui/strings.vala:44 src/ui/strings.vala:58
 msgid "Cancel"
 msgstr "Annulla"
 
-#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:39
+#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:23
 msgid "Confirm"
 msgstr "Conferma"
 
@@ -469,37 +388,87 @@ msgstr "Formattazione"
 msgid "Navigation"
 msgstr "Navigazione"
 
-#: src/ui/popup/shortcut_window.blp:102 src/ui/window/window.blp:216
+#: src/ui/popup/shortcut_window.blp:102 src/ui/window/window.blp:268
 msgid "Toggle Sidebar"
 msgstr "Mostra la barra laterale"
 
-#: src/ui/popup/shortcut_window.blp:107 src/ui/window/window.blp:63
+#: src/ui/popup/shortcut_window.blp:107 src/ui/window/window.blp:70
 msgid "Search Notes"
 msgstr "Cerca note"
 
-#: data/app.gschema.xml:22 src/ui/preferences/preferences.blp:47
-msgid "Makes the dark theme pitch black"
-msgstr "Rende il tema scuro completamente nero"
+#: src/ui/popup/shortcut_window.blp:114
+msgid "Display"
+msgstr "Schermo"
 
-#: data/app.gschema.xml:26 src/ui/preferences/preferences.blp:87
-msgid "Enable Toolbar"
-msgstr "abilita barra degli strumenti"
+#: src/ui/popup/shortcut_window.blp:117
+msgid "Full Screen"
+msgstr "A schermo intero"
 
-#: data/app.gschema.xml:31 src/ui/preferences/preferences.blp:98
-msgid "Enable Cheatsheet"
-msgstr "Abilita il foglio informativo"
+#: src/ui/popup/shortcut_window.blp:122
+msgid "Zoom In"
+msgstr "Ingrandire"
 
-#: data/app.gschema.xml:36 src/ui/preferences/preferences.blp:117
-msgid "3-Pane Layout"
-msgstr "Layout a 3 riquadri"
+#: src/ui/popup/shortcut_window.blp:127
+msgid "Zoom Out"
+msgstr "Rimpicciolire"
 
-#: data/app.gschema.xml:41 src/ui/preferences/preferences.blp:185
-msgid "Notes Storage Location"
-msgstr "Posizione delle note"
+#: src/ui/preferences/preferences.blp:31
+#, fuzzy
+msgid "Markdown URL Detection"
+msgstr "Guida rapida al markdown"
 
-#: data/app.gschema.xml:42 src/ui/preferences/preferences.blp:186
-msgid "Where the notebooks are stored (requires app restart)"
-msgstr "Dove salvare i taccuini (riavvio richiesto)"
+#: src/ui/preferences/preferences.blp:32
+msgid ""
+"Determines the level of detection of URLs in\n"
+"free form text is used:\n"
+" - Aggressive tries to find all URLs\n"
+" - Strict requires a protocol identifier (ie http://)\n"
+" - Disabled turns detection off."
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:39
+msgid "Fonts"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:73
+msgid "Line Spacing"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:81
+msgid "Tools"
+msgstr "Strumenti"
+
+#: src/ui/preferences/preferences.blp:133
+msgid "Layout"
+msgstr "Layout"
+
+#: src/ui/preferences/preferences.blp:161
+msgid "Fixed Width To Use For Notes"
+msgstr "Larghezza fissa da utilizzare per le note"
+
+#: src/ui/preferences/preferences.blp:162
+msgid "Sets the fixed width size of a note in px"
+msgstr "Imposta la dimensione della larghezza fissa di una nota in px"
+
+#: src/ui/preferences/preferences.blp:167
+msgid "Sort Order For Notebooks"
+msgstr "Ordinamento per i taccuini"
+
+#: src/ui/preferences/preferences.blp:172
+msgid "Sort Order For Notes"
+msgstr "Ordinamento per le note"
+
+#: src/ui/preferences/preferences.blp:179
+msgid "Files"
+msgstr "File"
+
+#: src/ui/preferences/preferences.blp:197
+msgid ""
+"The trash folder is set as a hidden folder by default, this option makes it "
+"visible (requires app restart)"
+msgstr ""
+"La cartella del cestino è impostata come cartella nascosta per impostazione "
+"predefinita, questa opzione la rende visibile (richiede il riavvio dell'app)"
 
 #: src/ui/strings.vala:4 src/ui/window/notebooks_bar/notebooks_bar.blp:129
 #: src/ui/window/notebooks_bar/notebooks_bar.blp:171
@@ -507,6 +476,7 @@ msgid "Trash"
 msgstr "Cestino"
 
 #: src/ui/strings.vala:5
+#, c-format
 msgid "%d Notes"
 msgstr "%d note"
 
@@ -514,7 +484,7 @@ msgstr "%d note"
 msgid "Are you sure you want to delete everything in the trash?"
 msgstr "Eliminare tutte le note dal cestino?"
 
-#: src/ui/strings.vala:7 src/ui/window/window.blp:54
+#: src/ui/strings.vala:7 src/ui/window/window.blp:61
 msgid "Empty Trash"
 msgstr "Svuota cestino"
 
@@ -551,10 +521,12 @@ msgid "Move"
 msgstr "Sposta"
 
 #: src/ui/strings.vala:18
+#, c-format
 msgid "Note “%s” already exists in notebook “%s”"
 msgstr "Esiste già la nota \"%s\" nel taccuino \"%s\""
 
 #: src/ui/strings.vala:19
+#, c-format
 msgid "Are you sure you want to delete the note “%s”?"
 msgstr "Eliminare la nota \"%s\"?"
 
@@ -563,6 +535,7 @@ msgid "Delete Note"
 msgstr "Elimina nota"
 
 #: src/ui/strings.vala:21
+#, c-format
 msgid "Are you sure you want to delete the notebook “%s”?"
 msgstr "Eliminare il taccuino \"%s\"?"
 
@@ -571,34 +544,42 @@ msgid "Delete Notebook"
 msgstr "Elimina taccuino"
 
 #: src/ui/strings.vala:24
-msgid "Note name shouldn’t contain “.” or “/”"
+#, fuzzy
+msgid "Note names cannot contain a “/”"
 msgstr "Il nome della nota non può contenere \".\" o \"/\""
 
 #: src/ui/strings.vala:25
-msgid "Note name shouldn’t be blank"
+#, fuzzy
+msgid "Note names cannot be blank"
 msgstr "Il nome della nota non può essere vuoto"
 
 #: src/ui/strings.vala:26
+#, c-format
 msgid "Note “%s” already exists"
 msgstr "Esiste già la nota \"%s\""
 
 #: src/ui/strings.vala:27
-msgid "Couldn’t create note"
+#, fuzzy
+msgid "Could not create note"
 msgstr "Impossibile creare la nota"
 
 #: src/ui/strings.vala:28
-msgid "Couldn’t change note"
+#, fuzzy
+msgid "Could not change note"
 msgstr "Impossibile modificare la nota"
 
 #: src/ui/strings.vala:29
-msgid "Couldn’t delete note"
+#, fuzzy
+msgid "Could not delete note"
 msgstr "Impossibile eliminare la nota"
 
 #: src/ui/strings.vala:30
-msgid "Couldn’t restore note"
+#, fuzzy
+msgid "Could not restore note"
 msgstr "Impossibile ripristinare la nota"
 
 #: src/ui/strings.vala:31
+#, c-format
 msgid "Saved “%s” to “%s”"
 msgstr "\"%s\" salvato in \"%s\""
 
@@ -607,27 +588,33 @@ msgid "Unknown error"
 msgstr "Errore sconosciuto"
 
 #: src/ui/strings.vala:33
-msgid "Notebook name shouldn’t contain “.” or “/”"
+#, fuzzy
+msgid "Notebook names cannot contain a “/”"
 msgstr "Il nome del taccuino non può contenere \".\" o \"/\""
 
 #: src/ui/strings.vala:34
-msgid "Notebook name shouldn’t be blank"
+#, fuzzy
+msgid "Notebook names cannot be blank"
 msgstr "Il nome del taccuino non può essere vuoto"
 
 #: src/ui/strings.vala:35
+#, c-format
 msgid "Notebook “%s” already exists"
 msgstr "Esiste già il taccuino \"%s\""
 
 #: src/ui/strings.vala:36
-msgid "Couldn’t create notebook"
+#, fuzzy
+msgid "Could not create notebook"
 msgstr "Impossibile creare il taccuino"
 
 #: src/ui/strings.vala:37
-msgid "Couldn’t change notebook"
+#, fuzzy
+msgid "Could not change notebook"
 msgstr "Impossibile modificare il taccuino"
 
 #: src/ui/strings.vala:38
-msgid "Couldn’t delete notebook"
+#, fuzzy
+msgid "Could not delete notebook"
 msgstr "Impossibile eliminare il taccuino"
 
 #: src/ui/strings.vala:40
@@ -639,7 +626,8 @@ msgid "Rename"
 msgstr "Rinomina"
 
 #: src/ui/strings.vala:42
-msgid "Couldn’t find an app to handle file URIs"
+#, fuzzy
+msgid "Could not find an app to handle file URIs"
 msgstr "Impossibile trovare un'app per gestire gli URI dei file"
 
 #: src/ui/strings.vala:43
@@ -649,6 +637,10 @@ msgstr "Applica"
 #: src/ui/strings.vala:45
 msgid "Pick where the notebooks will be stored"
 msgstr "Scegliere il percorso dove salvare le note"
+
+#: src/ui/strings.vala:46
+msgid "Pick where the trash can will be stored"
+msgstr "Scegli dove verrà depositato il cestino"
 
 #: src/ui/strings.vala:47 src/ui/window/notebooks_bar/notebooks_bar.blp:59
 #: src/ui/window/notebooks_bar/notebooks_bar.blp:101
@@ -662,6 +654,131 @@ msgstr "Ultima modifica"
 #: src/ui/strings.vala:50
 msgid "Extension"
 msgstr "Estensione"
+
+#: src/ui/strings.vala:51
+msgid "Unable to recognize URI"
+msgstr "Impossibile riconoscere l'URI"
+
+#: src/ui/strings.vala:52
+msgid "Pick primary font for notes"
+msgstr "Scegli il carattere principale per le note"
+
+#: src/ui/strings.vala:53
+msgid "Pick monospace font for code"
+msgstr "Scegli il carattere a spaziatura fissa per il codice"
+
+#: src/ui/strings.vala:54
+msgid "File Changed On Disk"
+msgstr "File modificato su disco"
+
+#: src/ui/strings.vala:55
+msgid ""
+"The file has changed on disk since it was last saved/loaded by Folio.\n"
+"\n"
+"You may do one of the following:\n"
+"\n"
+" • Reload the file (discarding any changes you have made in Folio)\n"
+" • Overwrite the file (discarding any changes made outside of Folio)\n"
+" • Cancel the operation and manually resolve the issue\n"
+"\n"
+"Note: Canceling the save if you have already moved to a new note/notebook "
+"will discard your changes."
+msgstr ""
+"Il file è cambiato sul disco dall'ultima volta che è stato salvato/caricato "
+"da Folio.\n"
+"\n"
+"Puoi effettuare una delle seguenti operazioni:\n"
+"\n"
+" • Ricarica il file (annullando eventuali modifiche apportate in Folio)\n"
+" • Sovrascrivi il file (annullando eventuali modifiche apportate all'esterno "
+"di Folio)\n"
+" • Annulla l'operazione e risolvi manualmente il problema\n"
+"\n"
+"Nota: l'annullamento del salvataggio se sei già passato a una nuova nota/"
+"taccuino annullerà le modifiche."
+
+#: src/ui/strings.vala:56
+msgid "Reload"
+msgstr "Ricarica"
+
+#: src/ui/strings.vala:57
+msgid "Overwrite"
+msgstr "Sovrascrivi"
+
+#: src/ui/strings.vala:59
+msgid ""
+"The file has changed on disk by another application.\n"
+"\n"
+"You may do one of the following:\n"
+"\n"
+" • Reload the file (discarding any changes you have made in Folio)\n"
+" • Overwrite the file (discarding any changes made outside of Folio)"
+msgstr ""
+"Il file è stato modificato sul disco da un'altra applicazione.\n"
+"\n"
+"Puoi effettuare una delle seguenti operazioni:\n"
+"\n"
+" • Ricarica il file (annullando eventuali modifiche apportate in Folio)\n"
+" • Sovrascrivi il file (annullando eventuali modifiche apportate al di fuori "
+"di Folio)"
+
+#: src/ui/strings.vala:61
+#, c-format
+msgid "Note %i"
+msgstr "Nota %i"
+
+#: src/ui/strings.vala:62
+msgid "Modified Time - Ascending"
+msgstr "Orario modificato - Crescente"
+
+#: src/ui/strings.vala:63
+msgid "Modified Time - Descending"
+msgstr "Orario modificato - Discendente"
+
+#: src/ui/strings.vala:64
+msgid "Alphabetical - Ascending"
+msgstr "Alfabetico - Ascendente"
+
+#: src/ui/strings.vala:65
+msgid "Alphabetical - Descending"
+msgstr "Alfabetico - Discendente"
+
+#: src/ui/strings.vala:66
+#, fuzzy
+msgid "Natural - Ascending"
+msgstr "Alfabetico - Ascendente"
+
+#: src/ui/strings.vala:67
+#, fuzzy
+msgid "Natural - Descending"
+msgstr "Alfabetico - Discendente"
+
+#: src/ui/strings.vala:68
+#, c-format
+msgid "Unable to launch external application for file %s."
+msgstr ""
+
+#: src/ui/strings.vala:69
+msgid "Aggressive"
+msgstr ""
+
+#: src/ui/strings.vala:70
+msgid "Strict"
+msgstr ""
+
+#: src/ui/strings.vala:71
+msgid "Disabled"
+msgstr ""
+
+#: src/ui/strings.vala:72
+#, fuzzy, c-format
+msgid "“%s” moved to trash"
+msgstr "Sposta nel cestino"
+
+#: src/ui/strings.vala:73
+#, c-format
+msgid "“%s” restored"
+msgstr ""
 
 #: src/ui/widgets/theme_selector/theme_selector.blp:15
 msgid "Follow system style"
@@ -692,40 +809,45 @@ msgid "_Keyboard Shortcuts"
 msgstr "Scorciatoie da tastiera"
 
 #: src/ui/window/app_menu/app_menu.blp:43
-msgid "_About"
+#, fuzzy
+msgid "_About Folio"
 msgstr "Informazioni"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:54
-msgid "Notebook Name"
-msgstr "Nome del taccuino"
-
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:66
-msgid "Duplicate notebook names are not allowed!"
-msgstr "Non è consentito duplicare i nomi dei quaderni!"
-
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:82
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:6
 msgid "First Characters"
 msgstr "Prime lettere"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:83
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:7
 msgid "Initials"
 msgstr "Iniziali"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:84
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:8
 msgid "Initials: camelCase"
 msgstr "Iniziali: camelCase"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:85
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:9
 msgid "Initials: snake_case"
 msgstr "Iniziali: snake_case"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:86
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:10
 msgid "Icon"
 msgstr "Icona"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:116
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:11
+msgid "Custom"
+msgstr ""
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:16
 msgid "Notebook Color"
 msgstr "Colore del taccuino"
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:58
+msgid "Notebook Name"
+msgstr "Nome del taccuino"
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:70
+msgid "Duplicate notebook names are not allowed!"
+msgstr "Non è consentito duplicare i nomi dei quaderni!"
 
 #: src/ui/window/notebooks_bar/notebook_create_popup.blp:126
 msgid "Create Notebook"
@@ -743,11 +865,11 @@ msgstr "Sposta tutto nel cestino"
 msgid "Notebooks"
 msgstr "Taccuini"
 
-#: src/ui/window/sidebar/note_create_popup.blp:37
+#: src/ui/window/sidebar/note_create_popup.blp:25
 msgid "Note Name"
 msgstr "Nome della nota"
 
-#: src/ui/window/sidebar/note_create_popup.blp:45
+#: src/ui/window/sidebar/note_create_popup.blp:33
 msgid "Create Note"
 msgstr "Crea nota"
 
@@ -771,30 +893,37 @@ msgstr "Sposta nel cestino"
 msgid "Open Containing Folder"
 msgstr "Apri in File"
 
-#: src/ui/window/window.blp:118
+#: src/ui/window/window.blp:123
 msgid "Get started writing"
 msgstr "Comincia a scrivere"
 
-#: src/ui/window/window.blp:143
+#: src/ui/window/window.blp:152
+msgid "Open file in external application"
+msgstr ""
+
+#: src/ui/window/window.blp:160
+msgid "Open file"
+msgstr ""
+
+#: src/ui/window/window.blp:181
 msgid "Create a notebook"
 msgstr "Crea un taccuino"
 
-#: src/ui/window/window.blp:168
+#: src/ui/window/window.blp:210
 msgid "Trash is empty"
 msgstr "Il cestino è vuoto"
 
-#: src/ui/window/window.blp:224
-msgid "Back"
-msgstr "Indietro"
-
-#: src/ui/window/window.blp:239
+#: src/ui/window/window.blp:285
 msgid "Open in Notebook"
 msgstr "Apri nel taccuino"
 
-#: src/ui/window/window.blp:264
+#: src/ui/window/window.blp:312
 msgid "_Rename Note"
 msgstr "Rinomina nota"
 
-#: src/ui/window/window.blp:270
+#: src/ui/window/window.blp:319
 msgid "_Export Note"
 msgstr "Esporta nota"
+
+#~ msgid "Back"
+#~ msgstr "Indietro"

--- a/po/ko.po
+++ b/po/ko.po
@@ -2,229 +2,16 @@
 # This file is distributed under the same license as the Folio package.
 msgid ""
 msgstr ""
+"Project-Id-Version: Folio\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-10-12 16:53+0200\n"
 "PO-Revision-Date: 2024-03-02 16:57:38+0000\n"
+"Language: ko_KR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: GlotPress/4.0.0\n"
-"Language: ko_KR\n"
-"Project-Id-Version: Folio\n"
-
-#: data/app.gschema.xml:76
-msgid "Notebook sort order"
-msgstr ""
-
-#: data/app.gschema.xml:77
-msgid "The sort order of the notebook list"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:145
-msgid "Sort Order For Notebooks"
-msgstr ""
-
-#: data/app.gschema.xml:71
-msgid "Note sort order"
-msgstr ""
-
-#: data/app.gschema.xml:72
-msgid "The sort order of the note list"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:150
-msgid "Sort Order For Notes"
-msgstr ""
-
-#: src/ui/strings.vala:62
-msgid "Modified Time - Ascending"
-msgstr ""
-
-#: src/ui/strings.vala:63
-msgid "Modified Time - Descending"
-msgstr ""
-
-#: src/ui/strings.vala:64
-msgid "Alphabetical - Ascending"
-msgstr ""
-
-#: src/ui/strings.vala:65
-msgid "Alphabetical - Descending"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:114
-msgid "Display"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:117
-msgid "Full Screen"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:122
-msgid "Zoom In"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:127
-msgid "Zoom Out"
-msgstr ""
-
-#: src/ui/strings.vala:52
-msgid "Pick primary font for notes"
-msgstr ""
-
-#: src/ui/strings.vala:53
-msgid "Pick monospace font for code"
-msgstr ""
-
-#: src/ui/strings.vala:54
-msgid "File Changed On Disk"
-msgstr ""
-
-#: src/ui/strings.vala:55
-msgid ""
-"The file has changed on disk since it was last saved/loaded by Folio.\n"
-"\n"
-"You may do one of the following:\n"
-"\n"
-" • Reload the file (discarding any changes you have made in Folio)\n"
-" • Overwrite the file (discarding any changes made outside of Folio)\n"
-" • Cancel the operation and manually resolve the issue\n"
-"\n"
-"Note: Canceling the save if you have already moved to a new note/notebook will discard your changes."
-msgstr ""
-
-#: src/ui/strings.vala:56
-msgid "Reload"
-msgstr ""
-
-#: src/ui/strings.vala:57
-msgid "Overwrite"
-msgstr ""
-
-#: src/ui/strings.vala:59
-msgid ""
-"The file has changed on disk by another application.\n"
-"\n"
-"You may do one of the following:\n"
-"\n"
-" • Reload the file (discarding any changes you have made in Folio)\n"
-" • Overwrite the file (discarding any changes made outside of Folio)"
-msgstr ""
-
-#: src/ui/strings.vala:61
-msgid "Note %i"
-msgstr ""
-
-#: data/app.gschema.xml:46 src/ui/preferences/preferences.blp:213
-msgid "Trash Storage Location"
-msgstr ""
-
-#: data/app.gschema.xml:47 src/ui/preferences/preferences.blp:214
-msgid "Where the trash folder is located (requires app restart)"
-msgstr ""
-
-#: src/ui/strings.vala:46
-msgid "Pick where the trash can will be stored"
-msgstr ""
-
-#: data/app.gschema.xml:16 src/ui/preferences/preferences.blp:128
-msgid "Use Fixed Width For Notes"
-msgstr ""
-
-#: data/app.gschema.xml:17 src/ui/preferences/preferences.blp:129
-msgid "Use a fixed width for the text area of a note"
-msgstr ""
-
-#: data/app.gschema.xml:37 src/ui/preferences/preferences.blp:118
-msgid "Expands the notebook list to include the notebook name"
-msgstr ""
-
-#: data/app.gschema.xml:51 src/ui/preferences/preferences.blp:65
-msgid "Show line numbers"
-msgstr ""
-
-#: data/app.gschema.xml:52 src/ui/preferences/preferences.blp:66
-msgid "Displays line numbers at the left of the note"
-msgstr ""
-
-#: data/app.gschema.xml:56 src/ui/preferences/preferences.blp:76
-msgid "Show all notes"
-msgstr ""
-
-#: data/app.gschema.xml:57 src/ui/preferences/preferences.blp:77
-msgid "Displays the \"All Notes\" notebook at the top of the notebook list"
-msgstr ""
-
-#: data/app.gschema.xml:61 src/ui/preferences/preferences.blp:163
-msgid "Enable autosave"
-msgstr ""
-
-#: data/app.gschema.xml:62 src/ui/preferences/preferences.blp:164
-msgid "Automatically saves the current note every 30 seconds if the contents have changed (requires app restart)"
-msgstr ""
-
-#: data/app.gschema.xml:66 src/ui/preferences/preferences.blp:174
-msgid "Don't hide the Trash folder"
-msgstr ""
-
-#: data/app.gschema.xml:67
-msgid "The trash folder is set as a hidden folder by default, this option makes it visible"
-msgstr ""
-
-#: data/app.metainfo.xml.in:367
-msgid "Main Folio window in light mode"
-msgstr ""
-
-#: data/app.metainfo.xml.in:371
-msgid "Main Folio window in dark mode"
-msgstr ""
-
-#: data/app.metainfo.xml.in:375
-msgid "Folio on small/mobile screens"
-msgstr ""
-
-#: data/app.metainfo.xml.in:379
-msgid "Folio preferences screen"
-msgstr ""
-
-#: data/app.metainfo.xml.in:383
-msgid "Folio in three pane mode"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:59
-msgid "Tools"
-msgstr ""
-
-#: data/app.gschema.xml:27 src/ui/preferences/preferences.blp:88
-msgid "Displays the formatting toolbar at the bottom of the note"
-msgstr ""
-
-#: data/app.gschema.xml:32 src/ui/preferences/preferences.blp:99
-msgid "Adds a button to the markdown reference sheet on the right of the formatting toolbar"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:111
-msgid "Layout"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:139
-msgid "Fixed Width To Use For Notes"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:140
-msgid "Sets the fixed width size of a note in px"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:157
-msgid "Files"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:175
-msgid "The trash folder is set as a hidden folder by default, this option makes it visible (requires app restart)"
-msgstr ""
-
-#: src/ui/strings.vala:51
-msgid "Unable to recognize URI"
-msgstr ""
 
 #: data/app.desktop.in:9 src/ui/strings.vala:3
 msgid "Folio"
@@ -243,18 +30,18 @@ msgid "Notebook;Note;Notes;Text;Markdown;Notepad;Write;School;Post-it;Sticky;"
 msgstr ""
 
 #: data/app.desktop.in:22 src/ui/popup/shortcut_window.blp:17
-#: src/ui/strings.vala:8 src/ui/window/window.blp:47
-#: src/ui/window/window.blp:124
+#: src/ui/strings.vala:8 src/ui/window/window.blp:54
+#: src/ui/window/window.blp:131
 msgid "New Note"
 msgstr "새 노트"
 
 #: data/app.desktop.in:26 src/ui/popup/shortcut_window.blp:37
-#: src/ui/strings.vala:14 src/ui/window/window.blp:149
+#: src/ui/strings.vala:14 src/ui/window/window.blp:189
 msgid "New Notebook"
 msgstr "새 필기장"
 
-#: data/app.desktop.in:30 src/ui/edit_view/toolbar/toolbar.blp:90
-#: src/ui/strings.vala:39 src/ui/window/window.blp:245
+#: data/app.desktop.in:30 src/ui/edit_view/toolbar/toolbar.blp:92
+#: src/ui/strings.vala:39 src/ui/window/window.blp:291
 msgid "Markdown Cheatsheet"
 msgstr "마크다운 치트시트"
 
@@ -262,25 +49,147 @@ msgstr "마크다운 치트시트"
 msgid "Preferences"
 msgstr "기본 설정"
 
-#: data/app.gschema.xml:6 src/ui/preferences/preferences.blp:18
+#: data/app.gschema.xml:6 src/ui/preferences/preferences.blp:45
 msgid "Note Font"
 msgstr "노트 글꼴"
 
-#: data/app.gschema.xml:7 src/ui/preferences/preferences.blp:19
+#: data/app.gschema.xml:7 src/ui/preferences/preferences.blp:46
 msgid "The font notes will be displayed in"
 msgstr "노트의 내용이 이 글꼴로 표시됨"
 
-#: data/app.gschema.xml:11 src/ui/preferences/preferences.blp:31
+#: data/app.gschema.xml:11 src/ui/preferences/preferences.blp:58
 msgid "Monospace Font"
 msgstr ""
 
-#: data/app.gschema.xml:12 src/ui/preferences/preferences.blp:32
+#: data/app.gschema.xml:12 src/ui/preferences/preferences.blp:59
 msgid "The font code will be displayed in"
 msgstr ""
 
-#: data/app.gschema.xml:21 src/ui/preferences/preferences.blp:46
+#: data/app.gschema.xml:16 src/ui/preferences/preferences.blp:150
+msgid "Use Fixed Width For Notes"
+msgstr ""
+
+#: data/app.gschema.xml:17 src/ui/preferences/preferences.blp:151
+msgid "Use a fixed width for the text area of a note"
+msgstr ""
+
+#: data/app.gschema.xml:21 src/ui/preferences/preferences.blp:18
 msgid "OLED Mode"
 msgstr "OLED 모드"
+
+#: data/app.gschema.xml:22 src/ui/preferences/preferences.blp:19
+msgid "Makes the dark theme pitch black"
+msgstr "다트 테마를 완전한 검은색으로 변경합니다"
+
+#: data/app.gschema.xml:26 src/ui/preferences/preferences.blp:109
+msgid "Enable Toolbar"
+msgstr ""
+
+#: data/app.gschema.xml:27 src/ui/preferences/preferences.blp:110
+msgid "Displays the formatting toolbar at the bottom of the note"
+msgstr ""
+
+#: data/app.gschema.xml:31 src/ui/preferences/preferences.blp:120
+msgid "Enable Cheatsheet"
+msgstr ""
+
+#: data/app.gschema.xml:32 src/ui/preferences/preferences.blp:121
+msgid ""
+"Adds a button to the markdown reference sheet on the right of the formatting "
+"toolbar"
+msgstr ""
+
+#: data/app.gschema.xml:36 src/ui/preferences/preferences.blp:139
+msgid "3-Pane Layout"
+msgstr ""
+
+#: data/app.gschema.xml:37 src/ui/preferences/preferences.blp:140
+msgid "Expands the notebook list to include the notebook name"
+msgstr ""
+
+#: data/app.gschema.xml:41 src/ui/preferences/preferences.blp:207
+msgid "Notes Storage Location"
+msgstr "노트 저장소 위치"
+
+#: data/app.gschema.xml:42 src/ui/preferences/preferences.blp:208
+msgid "Where the notebooks are stored (requires app restart)"
+msgstr "필기장이 저장될 위치 (프로그램 재시작 필요)"
+
+#: data/app.gschema.xml:46 src/ui/preferences/preferences.blp:235
+msgid "Trash Storage Location"
+msgstr ""
+
+#: data/app.gschema.xml:47 src/ui/preferences/preferences.blp:236
+msgid "Where the trash folder is located (requires app restart)"
+msgstr ""
+
+#: data/app.gschema.xml:51 src/ui/preferences/preferences.blp:87
+msgid "Show line numbers"
+msgstr ""
+
+#: data/app.gschema.xml:52 src/ui/preferences/preferences.blp:88
+msgid "Displays line numbers at the left of the note"
+msgstr ""
+
+#: data/app.gschema.xml:56 src/ui/preferences/preferences.blp:98
+msgid "Show all notes"
+msgstr ""
+
+#: data/app.gschema.xml:57 src/ui/preferences/preferences.blp:99
+msgid "Displays the \"All Notes\" notebook at the top of the notebook list"
+msgstr ""
+
+#: data/app.gschema.xml:61 src/ui/preferences/preferences.blp:185
+msgid "Enable autosave"
+msgstr ""
+
+#: data/app.gschema.xml:62 src/ui/preferences/preferences.blp:186
+msgid ""
+"Automatically saves the current note every 30 seconds if the contents have "
+"changed (requires app restart)"
+msgstr ""
+
+#: data/app.gschema.xml:66 src/ui/preferences/preferences.blp:196
+msgid "Don't hide the Trash folder"
+msgstr ""
+
+#: data/app.gschema.xml:67
+msgid ""
+"The trash folder is set as a hidden folder by default, this option makes it "
+"visible"
+msgstr ""
+
+#: data/app.gschema.xml:71
+msgid "Note sort order"
+msgstr ""
+
+#: data/app.gschema.xml:72
+msgid "The sort order of the note list"
+msgstr ""
+
+#: data/app.gschema.xml:76
+msgid "Notebook sort order"
+msgstr ""
+
+#: data/app.gschema.xml:77
+msgid "The sort order of the notebook list"
+msgstr ""
+
+#: data/app.gschema.xml:81
+msgid "URL detection level"
+msgstr ""
+
+#: data/app.gschema.xml:82
+msgid "How agressive to look for URLs in markdown text"
+msgstr ""
+
+#: data/app.gschema.xml:86
+msgid "Line spacing"
+msgstr ""
+
+#: data/app.gschema.xml:87 src/ui/preferences/preferences.blp:74
+msgid "The line spacing for the note text"
+msgstr ""
 
 #: data/app.metainfo.xml.in:5
 msgid "Take notes in Markdown"
@@ -314,103 +223,116 @@ msgstr ""
 msgid "Trash can"
 msgstr "휴지통"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:23
-#: src/ui/edit_view/toolbar/toolbar.blp:131
+#: data/app.metainfo.xml.in:393
+msgid "Main Folio window in light mode"
+msgstr ""
+
+#: data/app.metainfo.xml.in:397
+msgid "Main Folio window in dark mode"
+msgstr ""
+
+#: data/app.metainfo.xml.in:401
+msgid "Folio on small/mobile screens"
+msgstr ""
+
+#: data/app.metainfo.xml.in:405
+msgid "Folio preferences screen"
+msgstr ""
+
+#: data/app.metainfo.xml.in:409
+msgid "Folio in three pane mode"
+msgstr ""
+
+#: src/ui/edit_view/toolbar/toolbar.blp:6
 #: src/ui/widgets/markdown/heading_popover.blp:48
 msgid "Plain Text"
 msgstr "일반 텍스트"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:24
-#: src/ui/edit_view/toolbar/toolbar.blp:132
+#: src/ui/edit_view/toolbar/toolbar.blp:7
 #: src/ui/widgets/markdown/heading_popover.blp:12
 msgid "Heading 1"
 msgstr "제목 1"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:25
-#: src/ui/edit_view/toolbar/toolbar.blp:133
+#: src/ui/edit_view/toolbar/toolbar.blp:8
 #: src/ui/widgets/markdown/heading_popover.blp:18
 msgid "Heading 2"
 msgstr "제목 2"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:26
-#: src/ui/edit_view/toolbar/toolbar.blp:134
+#: src/ui/edit_view/toolbar/toolbar.blp:9
 #: src/ui/widgets/markdown/heading_popover.blp:24
 msgid "Heading 3"
 msgstr "제목 3"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:27
-#: src/ui/edit_view/toolbar/toolbar.blp:135
+#: src/ui/edit_view/toolbar/toolbar.blp:10
 #: src/ui/widgets/markdown/heading_popover.blp:30
 msgid "Heading 4"
 msgstr "제목 4"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:28
-#: src/ui/edit_view/toolbar/toolbar.blp:136
+#: src/ui/edit_view/toolbar/toolbar.blp:11
 #: src/ui/widgets/markdown/heading_popover.blp:36
 msgid "Heading 5"
 msgstr "제목 5"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:29
-#: src/ui/edit_view/toolbar/toolbar.blp:137
+#: src/ui/edit_view/toolbar/toolbar.blp:12
 #: src/ui/widgets/markdown/heading_popover.blp:42
 msgid "Heading 6"
 msgstr "제목 6"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:39
-#: src/ui/edit_view/toolbar/toolbar.blp:104
-#: src/ui/edit_view/toolbar/toolbar.blp:148
-#: src/ui/edit_view/toolbar/toolbar.blp:201 src/ui/popup/shortcut_window.blp:72
+#: src/ui/edit_view/toolbar/toolbar.blp:41
+#: src/ui/edit_view/toolbar/toolbar.blp:107
+#: src/ui/edit_view/toolbar/toolbar.blp:142
+#: src/ui/edit_view/toolbar/toolbar.blp:195 src/ui/popup/shortcut_window.blp:72
 msgid "Bold"
 msgstr "굵게"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:45
-#: src/ui/edit_view/toolbar/toolbar.blp:111
-#: src/ui/edit_view/toolbar/toolbar.blp:155
-#: src/ui/edit_view/toolbar/toolbar.blp:202 src/ui/popup/shortcut_window.blp:77
+#: src/ui/edit_view/toolbar/toolbar.blp:47
+#: src/ui/edit_view/toolbar/toolbar.blp:114
+#: src/ui/edit_view/toolbar/toolbar.blp:149
+#: src/ui/edit_view/toolbar/toolbar.blp:196 src/ui/popup/shortcut_window.blp:77
 msgid "Italic"
 msgstr "기울임꼴"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:51
-#: src/ui/edit_view/toolbar/toolbar.blp:162
-#: src/ui/edit_view/toolbar/toolbar.blp:203 src/ui/popup/shortcut_window.blp:82
+#: src/ui/edit_view/toolbar/toolbar.blp:53
+#: src/ui/edit_view/toolbar/toolbar.blp:156
+#: src/ui/edit_view/toolbar/toolbar.blp:197 src/ui/popup/shortcut_window.blp:82
 msgid "Strikethrough"
 msgstr "밑줄"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:57
-#: src/ui/edit_view/toolbar/toolbar.blp:169
-#: src/ui/edit_view/toolbar/toolbar.blp:204 src/ui/popup/shortcut_window.blp:87
+#: src/ui/edit_view/toolbar/toolbar.blp:59
+#: src/ui/edit_view/toolbar/toolbar.blp:163
+#: src/ui/edit_view/toolbar/toolbar.blp:198 src/ui/popup/shortcut_window.blp:87
 msgid "Highlight"
 msgstr "강조"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:67
-#: src/ui/edit_view/toolbar/toolbar.blp:193 src/ui/popup/shortcut_window.blp:92
+#: src/ui/edit_view/toolbar/toolbar.blp:69
+#: src/ui/edit_view/toolbar/toolbar.blp:187 src/ui/popup/shortcut_window.blp:92
 msgid "Insert Link"
 msgstr "링크 삽입"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:73
-#: src/ui/edit_view/toolbar/toolbar.blp:194
+#: src/ui/edit_view/toolbar/toolbar.blp:75
+#: src/ui/edit_view/toolbar/toolbar.blp:188
 msgid "Insert Code"
 msgstr "코드 삽입"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:79
-#: src/ui/edit_view/toolbar/toolbar.blp:195
+#: src/ui/edit_view/toolbar/toolbar.blp:81
+#: src/ui/edit_view/toolbar/toolbar.blp:189
 msgid "Insert Horizontal Rule"
 msgstr ""
 
-#: src/ui/edit_view/toolbar/toolbar.blp:118
+#: src/ui/edit_view/toolbar/toolbar.blp:121
 msgid "Format"
 msgstr ""
 
-#: src/ui/edit_view/toolbar/toolbar.blp:181
+#: src/ui/edit_view/toolbar/toolbar.blp:175
 msgid "Insert"
 msgstr ""
 
-#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:34
+#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:18
 #: src/ui/strings.vala:44 src/ui/strings.vala:58
 msgid "Cancel"
 msgstr "취소"
 
-#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:39
+#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:23
 msgid "Confirm"
 msgstr "계속"
 
@@ -454,37 +376,85 @@ msgstr "형식"
 msgid "Navigation"
 msgstr "탐색"
 
-#: src/ui/popup/shortcut_window.blp:102 src/ui/window/window.blp:216
+#: src/ui/popup/shortcut_window.blp:102 src/ui/window/window.blp:268
 msgid "Toggle Sidebar"
 msgstr "사이드바 토글"
 
-#: src/ui/popup/shortcut_window.blp:107 src/ui/window/window.blp:63
+#: src/ui/popup/shortcut_window.blp:107 src/ui/window/window.blp:70
 msgid "Search Notes"
 msgstr "노트 찾기"
 
-#: data/app.gschema.xml:22 src/ui/preferences/preferences.blp:47
-msgid "Makes the dark theme pitch black"
-msgstr "다트 테마를 완전한 검은색으로 변경합니다"
-
-#: data/app.gschema.xml:26 src/ui/preferences/preferences.blp:87
-msgid "Enable Toolbar"
+#: src/ui/popup/shortcut_window.blp:114
+msgid "Display"
 msgstr ""
 
-#: data/app.gschema.xml:31 src/ui/preferences/preferences.blp:98
-msgid "Enable Cheatsheet"
+#: src/ui/popup/shortcut_window.blp:117
+msgid "Full Screen"
 msgstr ""
 
-#: data/app.gschema.xml:36 src/ui/preferences/preferences.blp:117
-msgid "3-Pane Layout"
+#: src/ui/popup/shortcut_window.blp:122
+msgid "Zoom In"
 msgstr ""
 
-#: data/app.gschema.xml:41 src/ui/preferences/preferences.blp:185
-msgid "Notes Storage Location"
-msgstr "노트 저장소 위치"
+#: src/ui/popup/shortcut_window.blp:127
+msgid "Zoom Out"
+msgstr ""
 
-#: data/app.gschema.xml:42 src/ui/preferences/preferences.blp:186
-msgid "Where the notebooks are stored (requires app restart)"
-msgstr "필기장이 저장될 위치 (프로그램 재시작 필요)"
+#: src/ui/preferences/preferences.blp:31
+#, fuzzy
+msgid "Markdown URL Detection"
+msgstr "마크다운 치트시트"
+
+#: src/ui/preferences/preferences.blp:32
+msgid ""
+"Determines the level of detection of URLs in\n"
+"free form text is used:\n"
+" - Aggressive tries to find all URLs\n"
+" - Strict requires a protocol identifier (ie http://)\n"
+" - Disabled turns detection off."
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:39
+msgid "Fonts"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:73
+msgid "Line Spacing"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:81
+msgid "Tools"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:133
+msgid "Layout"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:161
+msgid "Fixed Width To Use For Notes"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:162
+msgid "Sets the fixed width size of a note in px"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:167
+msgid "Sort Order For Notebooks"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:172
+msgid "Sort Order For Notes"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:179
+msgid "Files"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:197
+msgid ""
+"The trash folder is set as a hidden folder by default, this option makes it "
+"visible (requires app restart)"
+msgstr ""
 
 #: src/ui/strings.vala:4 src/ui/window/notebooks_bar/notebooks_bar.blp:129
 #: src/ui/window/notebooks_bar/notebooks_bar.blp:171
@@ -492,6 +462,7 @@ msgid "Trash"
 msgstr "버리기"
 
 #: src/ui/strings.vala:5
+#, c-format
 msgid "%d Notes"
 msgstr "노트 %d개"
 
@@ -499,7 +470,7 @@ msgstr "노트 %d개"
 msgid "Are you sure you want to delete everything in the trash?"
 msgstr "휴지통에 있는 모든 내용을 삭제하시겠습니까?"
 
-#: src/ui/strings.vala:7 src/ui/window/window.blp:54
+#: src/ui/strings.vala:7 src/ui/window/window.blp:61
 msgid "Empty Trash"
 msgstr "휴지통 비우기"
 
@@ -536,10 +507,12 @@ msgid "Move"
 msgstr "이동"
 
 #: src/ui/strings.vala:18
+#, c-format
 msgid "Note “%s” already exists in notebook “%s”"
 msgstr "노트 \"%s\"(이)가 필기장 \"%s\"에 이미 존재합니다"
 
 #: src/ui/strings.vala:19
+#, c-format
 msgid "Are you sure you want to delete the note “%s”?"
 msgstr "노트 \"%s\"(을)를 삭제하시겠습니까?"
 
@@ -548,6 +521,7 @@ msgid "Delete Note"
 msgstr "노트 삭제"
 
 #: src/ui/strings.vala:21
+#, c-format
 msgid "Are you sure you want to delete the notebook “%s”?"
 msgstr "필기장 \"%s\"(을)를 삭제하시겠습니까?"
 
@@ -556,34 +530,42 @@ msgid "Delete Notebook"
 msgstr "필기장 삭제"
 
 #: src/ui/strings.vala:24
-msgid "Note name shouldn’t contain “.” or “/”"
+#, fuzzy
+msgid "Note names cannot contain a “/”"
 msgstr "노트 이름에는 \".\"이나 \"/\"을 포함할 수 없습니다"
 
 #: src/ui/strings.vala:25
-msgid "Note name shouldn’t be blank"
+#, fuzzy
+msgid "Note names cannot be blank"
 msgstr "노트 이름은 공백으로 설정할 수 없습니다"
 
 #: src/ui/strings.vala:26
+#, c-format
 msgid "Note “%s” already exists"
 msgstr "노트 \"%s\"(이)가 이미 존재함"
 
 #: src/ui/strings.vala:27
-msgid "Couldn’t create note"
+#, fuzzy
+msgid "Could not create note"
 msgstr "필기장을 만들 수 없음"
 
 #: src/ui/strings.vala:28
-msgid "Couldn’t change note"
+#, fuzzy
+msgid "Could not change note"
 msgstr "노트를 변경할 수 없음"
 
 #: src/ui/strings.vala:29
-msgid "Couldn’t delete note"
+#, fuzzy
+msgid "Could not delete note"
 msgstr "노트를 삭제할 수 없음"
 
 #: src/ui/strings.vala:30
-msgid "Couldn’t restore note"
+#, fuzzy
+msgid "Could not restore note"
 msgstr "노트를 복구할 수 없음"
 
 #: src/ui/strings.vala:31
+#, c-format
 msgid "Saved “%s” to “%s”"
 msgstr "\"%s\"(을)를 \"%s\"(으)로 저장하였습니다"
 
@@ -592,27 +574,33 @@ msgid "Unknown error"
 msgstr "알 수 없는 오류"
 
 #: src/ui/strings.vala:33
-msgid "Notebook name shouldn’t contain “.” or “/”"
+#, fuzzy
+msgid "Notebook names cannot contain a “/”"
 msgstr "필기장 이름에는 \".\"이나 \"/\"을 포함할 수 없습니다"
 
 #: src/ui/strings.vala:34
-msgid "Notebook name shouldn’t be blank"
+#, fuzzy
+msgid "Notebook names cannot be blank"
 msgstr "필기장 이름은 공백으로 설정할 수 없습니다"
 
 #: src/ui/strings.vala:35
+#, c-format
 msgid "Notebook “%s” already exists"
 msgstr "필기장 \"%s\"(이)가 이미 존재함"
 
 #: src/ui/strings.vala:36
-msgid "Couldn’t create notebook"
+#, fuzzy
+msgid "Could not create notebook"
 msgstr "필기장을 만들 수 없음"
 
 #: src/ui/strings.vala:37
-msgid "Couldn’t change notebook"
+#, fuzzy
+msgid "Could not change notebook"
 msgstr "필기장을 변경할 수 없음"
 
 #: src/ui/strings.vala:38
-msgid "Couldn’t delete notebook"
+#, fuzzy
+msgid "Could not delete notebook"
 msgstr "필기장을 삭제할 수 없음"
 
 #: src/ui/strings.vala:40
@@ -624,7 +612,7 @@ msgid "Rename"
 msgstr "이름 바꾸기"
 
 #: src/ui/strings.vala:42
-msgid "Couldn’t find an app to handle file URIs"
+msgid "Could not find an app to handle file URIs"
 msgstr ""
 
 #: src/ui/strings.vala:43
@@ -634,6 +622,10 @@ msgstr "적용"
 #: src/ui/strings.vala:45
 msgid "Pick where the notebooks will be stored"
 msgstr "필기장이 저장될 위치를 선택"
+
+#: src/ui/strings.vala:46
+msgid "Pick where the trash can will be stored"
+msgstr ""
 
 #: src/ui/strings.vala:47 src/ui/window/notebooks_bar/notebooks_bar.blp:59
 #: src/ui/window/notebooks_bar/notebooks_bar.blp:101
@@ -646,6 +638,110 @@ msgstr ""
 
 #: src/ui/strings.vala:50
 msgid "Extension"
+msgstr ""
+
+#: src/ui/strings.vala:51
+msgid "Unable to recognize URI"
+msgstr ""
+
+#: src/ui/strings.vala:52
+msgid "Pick primary font for notes"
+msgstr ""
+
+#: src/ui/strings.vala:53
+msgid "Pick monospace font for code"
+msgstr ""
+
+#: src/ui/strings.vala:54
+msgid "File Changed On Disk"
+msgstr ""
+
+#: src/ui/strings.vala:55
+msgid ""
+"The file has changed on disk since it was last saved/loaded by Folio.\n"
+"\n"
+"You may do one of the following:\n"
+"\n"
+" • Reload the file (discarding any changes you have made in Folio)\n"
+" • Overwrite the file (discarding any changes made outside of Folio)\n"
+" • Cancel the operation and manually resolve the issue\n"
+"\n"
+"Note: Canceling the save if you have already moved to a new note/notebook "
+"will discard your changes."
+msgstr ""
+
+#: src/ui/strings.vala:56
+msgid "Reload"
+msgstr ""
+
+#: src/ui/strings.vala:57
+msgid "Overwrite"
+msgstr ""
+
+#: src/ui/strings.vala:59
+msgid ""
+"The file has changed on disk by another application.\n"
+"\n"
+"You may do one of the following:\n"
+"\n"
+" • Reload the file (discarding any changes you have made in Folio)\n"
+" • Overwrite the file (discarding any changes made outside of Folio)"
+msgstr ""
+
+#: src/ui/strings.vala:61
+#, c-format
+msgid "Note %i"
+msgstr ""
+
+#: src/ui/strings.vala:62
+msgid "Modified Time - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:63
+msgid "Modified Time - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:64
+msgid "Alphabetical - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:65
+msgid "Alphabetical - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:66
+msgid "Natural - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:67
+msgid "Natural - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:68
+#, c-format
+msgid "Unable to launch external application for file %s."
+msgstr ""
+
+#: src/ui/strings.vala:69
+msgid "Aggressive"
+msgstr ""
+
+#: src/ui/strings.vala:70
+msgid "Strict"
+msgstr ""
+
+#: src/ui/strings.vala:71
+msgid "Disabled"
+msgstr ""
+
+#: src/ui/strings.vala:72
+#, fuzzy, c-format
+msgid "“%s” moved to trash"
+msgstr "휴지통으로 이동"
+
+#: src/ui/strings.vala:73
+#, c-format
+msgid "“%s” restored"
 msgstr ""
 
 #: src/ui/widgets/theme_selector/theme_selector.blp:15
@@ -677,40 +773,45 @@ msgid "_Keyboard Shortcuts"
 msgstr "키보드 바로 가기(_K)"
 
 #: src/ui/window/app_menu/app_menu.blp:43
-msgid "_About"
+#, fuzzy
+msgid "_About Folio"
 msgstr "정보(_A)"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:54
-msgid "Notebook Name"
-msgstr "필기장 이름"
-
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:66
-msgid "Duplicate notebook names are not allowed!"
-msgstr ""
-
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:82
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:6
 msgid "First Characters"
 msgstr "첫 글자"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:83
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:7
 msgid "Initials"
 msgstr "이니셜"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:84
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:8
 msgid "Initials: camelCase"
 msgstr ""
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:85
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:9
 msgid "Initials: snake_case"
 msgstr ""
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:86
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:10
 msgid "Icon"
 msgstr "아이콘"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:116
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:11
+msgid "Custom"
+msgstr ""
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:16
 msgid "Notebook Color"
 msgstr "필기장 색상"
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:58
+msgid "Notebook Name"
+msgstr "필기장 이름"
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:70
+msgid "Duplicate notebook names are not allowed!"
+msgstr ""
 
 #: src/ui/window/notebooks_bar/notebook_create_popup.blp:126
 msgid "Create Notebook"
@@ -728,11 +829,11 @@ msgstr "모두 휴지통으로 이동"
 msgid "Notebooks"
 msgstr ""
 
-#: src/ui/window/sidebar/note_create_popup.blp:37
+#: src/ui/window/sidebar/note_create_popup.blp:25
 msgid "Note Name"
 msgstr "노트 이름"
 
-#: src/ui/window/sidebar/note_create_popup.blp:45
+#: src/ui/window/sidebar/note_create_popup.blp:33
 msgid "Create Note"
 msgstr "노트 만들기"
 
@@ -756,30 +857,37 @@ msgstr "휴지통으로 이동"
 msgid "Open Containing Folder"
 msgstr "포함하는 폴더 열기"
 
-#: src/ui/window/window.blp:118
+#: src/ui/window/window.blp:123
 msgid "Get started writing"
 msgstr "작성하기"
 
-#: src/ui/window/window.blp:143
+#: src/ui/window/window.blp:152
+msgid "Open file in external application"
+msgstr ""
+
+#: src/ui/window/window.blp:160
+msgid "Open file"
+msgstr ""
+
+#: src/ui/window/window.blp:181
 msgid "Create a notebook"
 msgstr "필기장 만들기"
 
-#: src/ui/window/window.blp:168
+#: src/ui/window/window.blp:210
 msgid "Trash is empty"
 msgstr "휴지통이 비어 있음"
 
-#: src/ui/window/window.blp:224
-msgid "Back"
-msgstr "뒤로"
-
-#: src/ui/window/window.blp:239
+#: src/ui/window/window.blp:285
 msgid "Open in Notebook"
 msgstr "필기장에서 열기"
 
-#: src/ui/window/window.blp:264
+#: src/ui/window/window.blp:312
 msgid "_Rename Note"
 msgstr "노트 이름 바꾸기(_R)"
 
-#: src/ui/window/window.blp:270
+#: src/ui/window/window.blp:319
 msgid "_Export Note"
 msgstr "노트 내보내기(_E)"
+
+#~ msgid "Back"
+#~ msgstr "뒤로"

--- a/po/nl_BE.po
+++ b/po/nl_BE.po
@@ -2,229 +2,16 @@
 # This file is distributed under the same license as the Folio package.
 msgid ""
 msgstr ""
+"Project-Id-Version: Folio\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-10-12 16:53+0200\n"
 "PO-Revision-Date: 2024-03-02 16:58:11+0000\n"
+"Language: nl_BE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: GlotPress/4.0.0\n"
-"Language: nl_BE\n"
-"Project-Id-Version: Folio\n"
-
-#: data/app.gschema.xml:76
-msgid "Notebook sort order"
-msgstr ""
-
-#: data/app.gschema.xml:77
-msgid "The sort order of the notebook list"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:145
-msgid "Sort Order For Notebooks"
-msgstr ""
-
-#: data/app.gschema.xml:71
-msgid "Note sort order"
-msgstr ""
-
-#: data/app.gschema.xml:72
-msgid "The sort order of the note list"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:150
-msgid "Sort Order For Notes"
-msgstr ""
-
-#: src/ui/strings.vala:62
-msgid "Modified Time - Ascending"
-msgstr ""
-
-#: src/ui/strings.vala:63
-msgid "Modified Time - Descending"
-msgstr ""
-
-#: src/ui/strings.vala:64
-msgid "Alphabetical - Ascending"
-msgstr ""
-
-#: src/ui/strings.vala:65
-msgid "Alphabetical - Descending"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:114
-msgid "Display"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:117
-msgid "Full Screen"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:122
-msgid "Zoom In"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:127
-msgid "Zoom Out"
-msgstr ""
-
-#: src/ui/strings.vala:52
-msgid "Pick primary font for notes"
-msgstr ""
-
-#: src/ui/strings.vala:53
-msgid "Pick monospace font for code"
-msgstr ""
-
-#: src/ui/strings.vala:54
-msgid "File Changed On Disk"
-msgstr ""
-
-#: src/ui/strings.vala:55
-msgid ""
-"The file has changed on disk since it was last saved/loaded by Folio.\n"
-"\n"
-"You may do one of the following:\n"
-"\n"
-" • Reload the file (discarding any changes you have made in Folio)\n"
-" • Overwrite the file (discarding any changes made outside of Folio)\n"
-" • Cancel the operation and manually resolve the issue\n"
-"\n"
-"Note: Canceling the save if you have already moved to a new note/notebook will discard your changes."
-msgstr ""
-
-#: src/ui/strings.vala:56
-msgid "Reload"
-msgstr ""
-
-#: src/ui/strings.vala:57
-msgid "Overwrite"
-msgstr ""
-
-#: src/ui/strings.vala:59
-msgid ""
-"The file has changed on disk by another application.\n"
-"\n"
-"You may do one of the following:\n"
-"\n"
-" • Reload the file (discarding any changes you have made in Folio)\n"
-" • Overwrite the file (discarding any changes made outside of Folio)"
-msgstr ""
-
-#: src/ui/strings.vala:61
-msgid "Note %i"
-msgstr ""
-
-#: data/app.gschema.xml:46 src/ui/preferences/preferences.blp:213
-msgid "Trash Storage Location"
-msgstr ""
-
-#: data/app.gschema.xml:47 src/ui/preferences/preferences.blp:214
-msgid "Where the trash folder is located (requires app restart)"
-msgstr ""
-
-#: src/ui/strings.vala:46
-msgid "Pick where the trash can will be stored"
-msgstr ""
-
-#: data/app.gschema.xml:16 src/ui/preferences/preferences.blp:128
-msgid "Use Fixed Width For Notes"
-msgstr ""
-
-#: data/app.gschema.xml:17 src/ui/preferences/preferences.blp:129
-msgid "Use a fixed width for the text area of a note"
-msgstr ""
-
-#: data/app.gschema.xml:37 src/ui/preferences/preferences.blp:118
-msgid "Expands the notebook list to include the notebook name"
-msgstr ""
-
-#: data/app.gschema.xml:51 src/ui/preferences/preferences.blp:65
-msgid "Show line numbers"
-msgstr ""
-
-#: data/app.gschema.xml:52 src/ui/preferences/preferences.blp:66
-msgid "Displays line numbers at the left of the note"
-msgstr ""
-
-#: data/app.gschema.xml:56 src/ui/preferences/preferences.blp:76
-msgid "Show all notes"
-msgstr ""
-
-#: data/app.gschema.xml:57 src/ui/preferences/preferences.blp:77
-msgid "Displays the \"All Notes\" notebook at the top of the notebook list"
-msgstr ""
-
-#: data/app.gschema.xml:61 src/ui/preferences/preferences.blp:163
-msgid "Enable autosave"
-msgstr ""
-
-#: data/app.gschema.xml:62 src/ui/preferences/preferences.blp:164
-msgid "Automatically saves the current note every 30 seconds if the contents have changed (requires app restart)"
-msgstr ""
-
-#: data/app.gschema.xml:66 src/ui/preferences/preferences.blp:174
-msgid "Don't hide the Trash folder"
-msgstr ""
-
-#: data/app.gschema.xml:67
-msgid "The trash folder is set as a hidden folder by default, this option makes it visible"
-msgstr ""
-
-#: data/app.metainfo.xml.in:367
-msgid "Main Folio window in light mode"
-msgstr ""
-
-#: data/app.metainfo.xml.in:371
-msgid "Main Folio window in dark mode"
-msgstr ""
-
-#: data/app.metainfo.xml.in:375
-msgid "Folio on small/mobile screens"
-msgstr ""
-
-#: data/app.metainfo.xml.in:379
-msgid "Folio preferences screen"
-msgstr ""
-
-#: data/app.metainfo.xml.in:383
-msgid "Folio in three pane mode"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:59
-msgid "Tools"
-msgstr ""
-
-#: data/app.gschema.xml:27 src/ui/preferences/preferences.blp:88
-msgid "Displays the formatting toolbar at the bottom of the note"
-msgstr ""
-
-#: data/app.gschema.xml:32 src/ui/preferences/preferences.blp:99
-msgid "Adds a button to the markdown reference sheet on the right of the formatting toolbar"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:111
-msgid "Layout"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:139
-msgid "Fixed Width To Use For Notes"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:140
-msgid "Sets the fixed width size of a note in px"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:157
-msgid "Files"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:175
-msgid "The trash folder is set as a hidden folder by default, this option makes it visible (requires app restart)"
-msgstr ""
-
-#: src/ui/strings.vala:51
-msgid "Unable to recognize URI"
-msgstr ""
 
 #: data/app.desktop.in:9 src/ui/strings.vala:3
 msgid "Folio"
@@ -240,21 +27,23 @@ msgstr "Notities nemen"
 
 #: data/app.desktop.in:13
 msgid "Notebook;Note;Notes;Text;Markdown;Notepad;Write;School;Post-it;Sticky;"
-msgstr "Notitieboek;Notitie;Notities;Tekst;Markdown;Kladblok;Schrijven;School;Post-it;Sticky;"
+msgstr ""
+"Notitieboek;Notitie;Notities;Tekst;Markdown;Kladblok;Schrijven;School;Post-"
+"it;Sticky;"
 
 #: data/app.desktop.in:22 src/ui/popup/shortcut_window.blp:17
-#: src/ui/strings.vala:8 src/ui/window/window.blp:47
-#: src/ui/window/window.blp:124
+#: src/ui/strings.vala:8 src/ui/window/window.blp:54
+#: src/ui/window/window.blp:131
 msgid "New Note"
 msgstr "Nieuwe notitie"
 
 #: data/app.desktop.in:26 src/ui/popup/shortcut_window.blp:37
-#: src/ui/strings.vala:14 src/ui/window/window.blp:149
+#: src/ui/strings.vala:14 src/ui/window/window.blp:189
 msgid "New Notebook"
 msgstr "Nieuw notitieboek"
 
-#: data/app.desktop.in:30 src/ui/edit_view/toolbar/toolbar.blp:90
-#: src/ui/strings.vala:39 src/ui/window/window.blp:245
+#: data/app.desktop.in:30 src/ui/edit_view/toolbar/toolbar.blp:92
+#: src/ui/strings.vala:39 src/ui/window/window.blp:291
 msgid "Markdown Cheatsheet"
 msgstr "Markdown cheatsheet"
 
@@ -262,25 +51,149 @@ msgstr "Markdown cheatsheet"
 msgid "Preferences"
 msgstr "Voorkeuren"
 
-#: data/app.gschema.xml:6 src/ui/preferences/preferences.blp:18
+#: data/app.gschema.xml:6 src/ui/preferences/preferences.blp:45
 msgid "Note Font"
 msgstr "Notitielettertype"
 
-#: data/app.gschema.xml:7 src/ui/preferences/preferences.blp:19
+#: data/app.gschema.xml:7 src/ui/preferences/preferences.blp:46
 msgid "The font notes will be displayed in"
 msgstr "De lettertypes worden weergegeven in"
 
-#: data/app.gschema.xml:11 src/ui/preferences/preferences.blp:31
+#: data/app.gschema.xml:11 src/ui/preferences/preferences.blp:58
 msgid "Monospace Font"
 msgstr ""
 
-#: data/app.gschema.xml:12 src/ui/preferences/preferences.blp:32
+#: data/app.gschema.xml:12 src/ui/preferences/preferences.blp:59
 msgid "The font code will be displayed in"
 msgstr ""
 
-#: data/app.gschema.xml:21 src/ui/preferences/preferences.blp:46
+#: data/app.gschema.xml:16 src/ui/preferences/preferences.blp:150
+msgid "Use Fixed Width For Notes"
+msgstr ""
+
+#: data/app.gschema.xml:17 src/ui/preferences/preferences.blp:151
+msgid "Use a fixed width for the text area of a note"
+msgstr ""
+
+#: data/app.gschema.xml:21 src/ui/preferences/preferences.blp:18
 msgid "OLED Mode"
 msgstr "OLED-modus"
+
+#: data/app.gschema.xml:22 src/ui/preferences/preferences.blp:19
+msgid "Makes the dark theme pitch black"
+msgstr "Maakt het donker thema pikzwart"
+
+#: data/app.gschema.xml:26 src/ui/preferences/preferences.blp:109
+msgid "Enable Toolbar"
+msgstr ""
+
+#: data/app.gschema.xml:27 src/ui/preferences/preferences.blp:110
+msgid "Displays the formatting toolbar at the bottom of the note"
+msgstr ""
+
+#: data/app.gschema.xml:31 src/ui/preferences/preferences.blp:120
+msgid "Enable Cheatsheet"
+msgstr ""
+
+#: data/app.gschema.xml:32 src/ui/preferences/preferences.blp:121
+msgid ""
+"Adds a button to the markdown reference sheet on the right of the formatting "
+"toolbar"
+msgstr ""
+
+#: data/app.gschema.xml:36 src/ui/preferences/preferences.blp:139
+msgid "3-Pane Layout"
+msgstr ""
+
+#: data/app.gschema.xml:37 src/ui/preferences/preferences.blp:140
+msgid "Expands the notebook list to include the notebook name"
+msgstr ""
+
+#: data/app.gschema.xml:41 src/ui/preferences/preferences.blp:207
+msgid "Notes Storage Location"
+msgstr "Notities opslaglocatie"
+
+#: data/app.gschema.xml:42 src/ui/preferences/preferences.blp:208
+msgid "Where the notebooks are stored (requires app restart)"
+msgstr ""
+"Waar de notitieboeken worden opgeslagen (vereist opnieuw opstarten van de "
+"app)"
+
+#: data/app.gschema.xml:46 src/ui/preferences/preferences.blp:235
+msgid "Trash Storage Location"
+msgstr ""
+
+#: data/app.gschema.xml:47 src/ui/preferences/preferences.blp:236
+msgid "Where the trash folder is located (requires app restart)"
+msgstr ""
+
+#: data/app.gschema.xml:51 src/ui/preferences/preferences.blp:87
+msgid "Show line numbers"
+msgstr ""
+
+#: data/app.gschema.xml:52 src/ui/preferences/preferences.blp:88
+msgid "Displays line numbers at the left of the note"
+msgstr ""
+
+#: data/app.gschema.xml:56 src/ui/preferences/preferences.blp:98
+msgid "Show all notes"
+msgstr ""
+
+#: data/app.gschema.xml:57 src/ui/preferences/preferences.blp:99
+msgid "Displays the \"All Notes\" notebook at the top of the notebook list"
+msgstr ""
+
+#: data/app.gschema.xml:61 src/ui/preferences/preferences.blp:185
+msgid "Enable autosave"
+msgstr ""
+
+#: data/app.gschema.xml:62 src/ui/preferences/preferences.blp:186
+msgid ""
+"Automatically saves the current note every 30 seconds if the contents have "
+"changed (requires app restart)"
+msgstr ""
+
+#: data/app.gschema.xml:66 src/ui/preferences/preferences.blp:196
+msgid "Don't hide the Trash folder"
+msgstr ""
+
+#: data/app.gschema.xml:67
+msgid ""
+"The trash folder is set as a hidden folder by default, this option makes it "
+"visible"
+msgstr ""
+
+#: data/app.gschema.xml:71
+msgid "Note sort order"
+msgstr ""
+
+#: data/app.gschema.xml:72
+msgid "The sort order of the note list"
+msgstr ""
+
+#: data/app.gschema.xml:76
+msgid "Notebook sort order"
+msgstr ""
+
+#: data/app.gschema.xml:77
+msgid "The sort order of the notebook list"
+msgstr ""
+
+#: data/app.gschema.xml:81
+msgid "URL detection level"
+msgstr ""
+
+#: data/app.gschema.xml:82
+msgid "How agressive to look for URLs in markdown text"
+msgstr ""
+
+#: data/app.gschema.xml:86
+msgid "Line spacing"
+msgstr ""
+
+#: data/app.gschema.xml:87 src/ui/preferences/preferences.blp:74
+msgid "The line spacing for the note text"
+msgstr ""
 
 #: data/app.metainfo.xml.in:5
 msgid "Take notes in Markdown"
@@ -314,103 +227,116 @@ msgstr ""
 msgid "Trash can"
 msgstr "Prullenbak"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:23
-#: src/ui/edit_view/toolbar/toolbar.blp:131
+#: data/app.metainfo.xml.in:393
+msgid "Main Folio window in light mode"
+msgstr ""
+
+#: data/app.metainfo.xml.in:397
+msgid "Main Folio window in dark mode"
+msgstr ""
+
+#: data/app.metainfo.xml.in:401
+msgid "Folio on small/mobile screens"
+msgstr ""
+
+#: data/app.metainfo.xml.in:405
+msgid "Folio preferences screen"
+msgstr ""
+
+#: data/app.metainfo.xml.in:409
+msgid "Folio in three pane mode"
+msgstr ""
+
+#: src/ui/edit_view/toolbar/toolbar.blp:6
 #: src/ui/widgets/markdown/heading_popover.blp:48
 msgid "Plain Text"
 msgstr "Platte tekst"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:24
-#: src/ui/edit_view/toolbar/toolbar.blp:132
+#: src/ui/edit_view/toolbar/toolbar.blp:7
 #: src/ui/widgets/markdown/heading_popover.blp:12
 msgid "Heading 1"
 msgstr "Kop 1"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:25
-#: src/ui/edit_view/toolbar/toolbar.blp:133
+#: src/ui/edit_view/toolbar/toolbar.blp:8
 #: src/ui/widgets/markdown/heading_popover.blp:18
 msgid "Heading 2"
 msgstr "Kop 2"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:26
-#: src/ui/edit_view/toolbar/toolbar.blp:134
+#: src/ui/edit_view/toolbar/toolbar.blp:9
 #: src/ui/widgets/markdown/heading_popover.blp:24
 msgid "Heading 3"
 msgstr "Kop 3"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:27
-#: src/ui/edit_view/toolbar/toolbar.blp:135
+#: src/ui/edit_view/toolbar/toolbar.blp:10
 #: src/ui/widgets/markdown/heading_popover.blp:30
 msgid "Heading 4"
 msgstr "Kop 4"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:28
-#: src/ui/edit_view/toolbar/toolbar.blp:136
+#: src/ui/edit_view/toolbar/toolbar.blp:11
 #: src/ui/widgets/markdown/heading_popover.blp:36
 msgid "Heading 5"
 msgstr "Kop 5"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:29
-#: src/ui/edit_view/toolbar/toolbar.blp:137
+#: src/ui/edit_view/toolbar/toolbar.blp:12
 #: src/ui/widgets/markdown/heading_popover.blp:42
 msgid "Heading 6"
 msgstr "Kop 6"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:39
-#: src/ui/edit_view/toolbar/toolbar.blp:104
-#: src/ui/edit_view/toolbar/toolbar.blp:148
-#: src/ui/edit_view/toolbar/toolbar.blp:201 src/ui/popup/shortcut_window.blp:72
+#: src/ui/edit_view/toolbar/toolbar.blp:41
+#: src/ui/edit_view/toolbar/toolbar.blp:107
+#: src/ui/edit_view/toolbar/toolbar.blp:142
+#: src/ui/edit_view/toolbar/toolbar.blp:195 src/ui/popup/shortcut_window.blp:72
 msgid "Bold"
 msgstr "Vet"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:45
-#: src/ui/edit_view/toolbar/toolbar.blp:111
-#: src/ui/edit_view/toolbar/toolbar.blp:155
-#: src/ui/edit_view/toolbar/toolbar.blp:202 src/ui/popup/shortcut_window.blp:77
+#: src/ui/edit_view/toolbar/toolbar.blp:47
+#: src/ui/edit_view/toolbar/toolbar.blp:114
+#: src/ui/edit_view/toolbar/toolbar.blp:149
+#: src/ui/edit_view/toolbar/toolbar.blp:196 src/ui/popup/shortcut_window.blp:77
 msgid "Italic"
 msgstr "Cursief"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:51
-#: src/ui/edit_view/toolbar/toolbar.blp:162
-#: src/ui/edit_view/toolbar/toolbar.blp:203 src/ui/popup/shortcut_window.blp:82
+#: src/ui/edit_view/toolbar/toolbar.blp:53
+#: src/ui/edit_view/toolbar/toolbar.blp:156
+#: src/ui/edit_view/toolbar/toolbar.blp:197 src/ui/popup/shortcut_window.blp:82
 msgid "Strikethrough"
 msgstr "Doorhalen"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:57
-#: src/ui/edit_view/toolbar/toolbar.blp:169
-#: src/ui/edit_view/toolbar/toolbar.blp:204 src/ui/popup/shortcut_window.blp:87
+#: src/ui/edit_view/toolbar/toolbar.blp:59
+#: src/ui/edit_view/toolbar/toolbar.blp:163
+#: src/ui/edit_view/toolbar/toolbar.blp:198 src/ui/popup/shortcut_window.blp:87
 msgid "Highlight"
 msgstr "Markeren"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:67
-#: src/ui/edit_view/toolbar/toolbar.blp:193 src/ui/popup/shortcut_window.blp:92
+#: src/ui/edit_view/toolbar/toolbar.blp:69
+#: src/ui/edit_view/toolbar/toolbar.blp:187 src/ui/popup/shortcut_window.blp:92
 msgid "Insert Link"
 msgstr "Link toevoegen"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:73
-#: src/ui/edit_view/toolbar/toolbar.blp:194
+#: src/ui/edit_view/toolbar/toolbar.blp:75
+#: src/ui/edit_view/toolbar/toolbar.blp:188
 msgid "Insert Code"
 msgstr "Code toevoegen"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:79
-#: src/ui/edit_view/toolbar/toolbar.blp:195
+#: src/ui/edit_view/toolbar/toolbar.blp:81
+#: src/ui/edit_view/toolbar/toolbar.blp:189
 msgid "Insert Horizontal Rule"
 msgstr ""
 
-#: src/ui/edit_view/toolbar/toolbar.blp:118
+#: src/ui/edit_view/toolbar/toolbar.blp:121
 msgid "Format"
 msgstr ""
 
-#: src/ui/edit_view/toolbar/toolbar.blp:181
+#: src/ui/edit_view/toolbar/toolbar.blp:175
 msgid "Insert"
 msgstr ""
 
-#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:34
+#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:18
 #: src/ui/strings.vala:44 src/ui/strings.vala:58
 msgid "Cancel"
 msgstr "Annuleren"
 
-#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:39
+#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:23
 msgid "Confirm"
 msgstr "Bevestigen"
 
@@ -454,37 +380,85 @@ msgstr "Opmaken"
 msgid "Navigation"
 msgstr "Navigatie"
 
-#: src/ui/popup/shortcut_window.blp:102 src/ui/window/window.blp:216
+#: src/ui/popup/shortcut_window.blp:102 src/ui/window/window.blp:268
 msgid "Toggle Sidebar"
 msgstr "Zijbalk aan/uitzetten"
 
-#: src/ui/popup/shortcut_window.blp:107 src/ui/window/window.blp:63
+#: src/ui/popup/shortcut_window.blp:107 src/ui/window/window.blp:70
 msgid "Search Notes"
 msgstr "Notities zoeken"
 
-#: data/app.gschema.xml:22 src/ui/preferences/preferences.blp:47
-msgid "Makes the dark theme pitch black"
-msgstr "Maakt het donker thema pikzwart"
-
-#: data/app.gschema.xml:26 src/ui/preferences/preferences.blp:87
-msgid "Enable Toolbar"
+#: src/ui/popup/shortcut_window.blp:114
+msgid "Display"
 msgstr ""
 
-#: data/app.gschema.xml:31 src/ui/preferences/preferences.blp:98
-msgid "Enable Cheatsheet"
+#: src/ui/popup/shortcut_window.blp:117
+msgid "Full Screen"
 msgstr ""
 
-#: data/app.gschema.xml:36 src/ui/preferences/preferences.blp:117
-msgid "3-Pane Layout"
+#: src/ui/popup/shortcut_window.blp:122
+msgid "Zoom In"
 msgstr ""
 
-#: data/app.gschema.xml:41 src/ui/preferences/preferences.blp:185
-msgid "Notes Storage Location"
-msgstr "Notities opslaglocatie"
+#: src/ui/popup/shortcut_window.blp:127
+msgid "Zoom Out"
+msgstr ""
 
-#: data/app.gschema.xml:42 src/ui/preferences/preferences.blp:186
-msgid "Where the notebooks are stored (requires app restart)"
-msgstr "Waar de notitieboeken worden opgeslagen (vereist opnieuw opstarten van de app)"
+#: src/ui/preferences/preferences.blp:31
+#, fuzzy
+msgid "Markdown URL Detection"
+msgstr "Markdown cheatsheet"
+
+#: src/ui/preferences/preferences.blp:32
+msgid ""
+"Determines the level of detection of URLs in\n"
+"free form text is used:\n"
+" - Aggressive tries to find all URLs\n"
+" - Strict requires a protocol identifier (ie http://)\n"
+" - Disabled turns detection off."
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:39
+msgid "Fonts"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:73
+msgid "Line Spacing"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:81
+msgid "Tools"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:133
+msgid "Layout"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:161
+msgid "Fixed Width To Use For Notes"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:162
+msgid "Sets the fixed width size of a note in px"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:167
+msgid "Sort Order For Notebooks"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:172
+msgid "Sort Order For Notes"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:179
+msgid "Files"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:197
+msgid ""
+"The trash folder is set as a hidden folder by default, this option makes it "
+"visible (requires app restart)"
+msgstr ""
 
 #: src/ui/strings.vala:4 src/ui/window/notebooks_bar/notebooks_bar.blp:129
 #: src/ui/window/notebooks_bar/notebooks_bar.blp:171
@@ -492,6 +466,7 @@ msgid "Trash"
 msgstr "Prullenbak"
 
 #: src/ui/strings.vala:5
+#, c-format
 msgid "%d Notes"
 msgstr "%d Notities"
 
@@ -499,7 +474,7 @@ msgstr "%d Notities"
 msgid "Are you sure you want to delete everything in the trash?"
 msgstr "Weet je zeker dat je alles uit de prullenbak wilt verwijderen?"
 
-#: src/ui/strings.vala:7 src/ui/window/window.blp:54
+#: src/ui/strings.vala:7 src/ui/window/window.blp:61
 msgid "Empty Trash"
 msgstr "Prullenbak legen"
 
@@ -536,10 +511,12 @@ msgid "Move"
 msgstr "Verplaatsen"
 
 #: src/ui/strings.vala:18
+#, c-format
 msgid "Note “%s” already exists in notebook “%s”"
 msgstr "Notitie “%s” bestaat al in notitieboek “%s”"
 
 #: src/ui/strings.vala:19
+#, c-format
 msgid "Are you sure you want to delete the note “%s”?"
 msgstr "Weet je zeker dat je notitie “%s” wilt verwijderen?"
 
@@ -548,6 +525,7 @@ msgid "Delete Note"
 msgstr "Notitie verwijderen"
 
 #: src/ui/strings.vala:21
+#, c-format
 msgid "Are you sure you want to delete the notebook “%s”?"
 msgstr "Weet je zeker dat je notitieboek “%s” wilt verwijderen?"
 
@@ -556,34 +534,42 @@ msgid "Delete Notebook"
 msgstr "Notitieboek verwijderen"
 
 #: src/ui/strings.vala:24
-msgid "Note name shouldn’t contain “.” or “/”"
+#, fuzzy
+msgid "Note names cannot contain a “/”"
 msgstr "Notitienaam mag geen “.” of “/” bevatten"
 
 #: src/ui/strings.vala:25
-msgid "Note name shouldn’t be blank"
+#, fuzzy
+msgid "Note names cannot be blank"
 msgstr "Notitienaam mag niet leeg zijn"
 
 #: src/ui/strings.vala:26
+#, c-format
 msgid "Note “%s” already exists"
 msgstr "Notitie “%s” bestaat al"
 
 #: src/ui/strings.vala:27
-msgid "Couldn’t create note"
+#, fuzzy
+msgid "Could not create note"
 msgstr "Kon notitie niet maken"
 
 #: src/ui/strings.vala:28
-msgid "Couldn’t change note"
+#, fuzzy
+msgid "Could not change note"
 msgstr "Kon notitie niet veranderen"
 
 #: src/ui/strings.vala:29
-msgid "Couldn’t delete note"
+#, fuzzy
+msgid "Could not delete note"
 msgstr "Kon notitie niet verwijderen"
 
 #: src/ui/strings.vala:30
-msgid "Couldn’t restore note"
+#, fuzzy
+msgid "Could not restore note"
 msgstr "Kon notitie niet herstellen"
 
 #: src/ui/strings.vala:31
+#, c-format
 msgid "Saved “%s” to “%s”"
 msgstr "\"%s\" naar \"%s\" opgeslagen"
 
@@ -592,27 +578,33 @@ msgid "Unknown error"
 msgstr "Onbekende fout"
 
 #: src/ui/strings.vala:33
-msgid "Notebook name shouldn’t contain “.” or “/”"
+#, fuzzy
+msgid "Notebook names cannot contain a “/”"
 msgstr "Notitieboeknaam mag geen “.” of “/” bevatten"
 
 #: src/ui/strings.vala:34
-msgid "Notebook name shouldn’t be blank"
+#, fuzzy
+msgid "Notebook names cannot be blank"
 msgstr "Notitieboeknaam mag niet leeg zijn"
 
 #: src/ui/strings.vala:35
+#, c-format
 msgid "Notebook “%s” already exists"
 msgstr "Notitieboek “%s” bestaat al"
 
 #: src/ui/strings.vala:36
-msgid "Couldn’t create notebook"
+#, fuzzy
+msgid "Could not create notebook"
 msgstr "Kon notitieboek niet maken"
 
 #: src/ui/strings.vala:37
-msgid "Couldn’t change notebook"
+#, fuzzy
+msgid "Could not change notebook"
 msgstr "Kon notitieboek niet veranderen"
 
 #: src/ui/strings.vala:38
-msgid "Couldn’t delete notebook"
+#, fuzzy
+msgid "Could not delete notebook"
 msgstr "Kon notitieboek niet verwijderen"
 
 #: src/ui/strings.vala:40
@@ -624,7 +616,7 @@ msgid "Rename"
 msgstr "Hernoemen"
 
 #: src/ui/strings.vala:42
-msgid "Couldn’t find an app to handle file URIs"
+msgid "Could not find an app to handle file URIs"
 msgstr ""
 
 #: src/ui/strings.vala:43
@@ -634,6 +626,10 @@ msgstr "Toepassen"
 #: src/ui/strings.vala:45
 msgid "Pick where the notebooks will be stored"
 msgstr "Kies waar de notitieboeken worden opgeslagen"
+
+#: src/ui/strings.vala:46
+msgid "Pick where the trash can will be stored"
+msgstr ""
 
 #: src/ui/strings.vala:47 src/ui/window/notebooks_bar/notebooks_bar.blp:59
 #: src/ui/window/notebooks_bar/notebooks_bar.blp:101
@@ -646,6 +642,110 @@ msgstr ""
 
 #: src/ui/strings.vala:50
 msgid "Extension"
+msgstr ""
+
+#: src/ui/strings.vala:51
+msgid "Unable to recognize URI"
+msgstr ""
+
+#: src/ui/strings.vala:52
+msgid "Pick primary font for notes"
+msgstr ""
+
+#: src/ui/strings.vala:53
+msgid "Pick monospace font for code"
+msgstr ""
+
+#: src/ui/strings.vala:54
+msgid "File Changed On Disk"
+msgstr ""
+
+#: src/ui/strings.vala:55
+msgid ""
+"The file has changed on disk since it was last saved/loaded by Folio.\n"
+"\n"
+"You may do one of the following:\n"
+"\n"
+" • Reload the file (discarding any changes you have made in Folio)\n"
+" • Overwrite the file (discarding any changes made outside of Folio)\n"
+" • Cancel the operation and manually resolve the issue\n"
+"\n"
+"Note: Canceling the save if you have already moved to a new note/notebook "
+"will discard your changes."
+msgstr ""
+
+#: src/ui/strings.vala:56
+msgid "Reload"
+msgstr ""
+
+#: src/ui/strings.vala:57
+msgid "Overwrite"
+msgstr ""
+
+#: src/ui/strings.vala:59
+msgid ""
+"The file has changed on disk by another application.\n"
+"\n"
+"You may do one of the following:\n"
+"\n"
+" • Reload the file (discarding any changes you have made in Folio)\n"
+" • Overwrite the file (discarding any changes made outside of Folio)"
+msgstr ""
+
+#: src/ui/strings.vala:61
+#, c-format
+msgid "Note %i"
+msgstr ""
+
+#: src/ui/strings.vala:62
+msgid "Modified Time - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:63
+msgid "Modified Time - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:64
+msgid "Alphabetical - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:65
+msgid "Alphabetical - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:66
+msgid "Natural - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:67
+msgid "Natural - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:68
+#, c-format
+msgid "Unable to launch external application for file %s."
+msgstr ""
+
+#: src/ui/strings.vala:69
+msgid "Aggressive"
+msgstr ""
+
+#: src/ui/strings.vala:70
+msgid "Strict"
+msgstr ""
+
+#: src/ui/strings.vala:71
+msgid "Disabled"
+msgstr ""
+
+#: src/ui/strings.vala:72
+#, fuzzy, c-format
+msgid "“%s” moved to trash"
+msgstr "Naar prullenbak verplaatsen"
+
+#: src/ui/strings.vala:73
+#, c-format
+msgid "“%s” restored"
 msgstr ""
 
 #: src/ui/widgets/theme_selector/theme_selector.blp:15
@@ -677,40 +777,45 @@ msgid "_Keyboard Shortcuts"
 msgstr "_Sneltoetsen"
 
 #: src/ui/window/app_menu/app_menu.blp:43
-msgid "_About"
+#, fuzzy
+msgid "_About Folio"
 msgstr "_Over"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:54
-msgid "Notebook Name"
-msgstr "Notitieboeknaam"
-
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:66
-msgid "Duplicate notebook names are not allowed!"
-msgstr ""
-
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:82
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:6
 msgid "First Characters"
 msgstr "Eerste tekens en symbolen"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:83
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:7
 msgid "Initials"
 msgstr "Initialen"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:84
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:8
 msgid "Initials: camelCase"
 msgstr "Initialen: camelCase"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:85
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:9
 msgid "Initials: snake_case"
 msgstr "Initialen: snake_case"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:86
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:10
 msgid "Icon"
 msgstr "Icoon"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:116
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:11
+msgid "Custom"
+msgstr ""
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:16
 msgid "Notebook Color"
 msgstr "Notitieboekkleur"
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:58
+msgid "Notebook Name"
+msgstr "Notitieboeknaam"
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:70
+msgid "Duplicate notebook names are not allowed!"
+msgstr ""
 
 #: src/ui/window/notebooks_bar/notebook_create_popup.blp:126
 msgid "Create Notebook"
@@ -728,11 +833,11 @@ msgstr "Alles naar de prullenbak verplaatsen"
 msgid "Notebooks"
 msgstr ""
 
-#: src/ui/window/sidebar/note_create_popup.blp:37
+#: src/ui/window/sidebar/note_create_popup.blp:25
 msgid "Note Name"
 msgstr "Notitienaam"
 
-#: src/ui/window/sidebar/note_create_popup.blp:45
+#: src/ui/window/sidebar/note_create_popup.blp:33
 msgid "Create Note"
 msgstr "Notitie maken"
 
@@ -756,30 +861,37 @@ msgstr "Naar prullenbak verplaatsen"
 msgid "Open Containing Folder"
 msgstr "Map openen"
 
-#: src/ui/window/window.blp:118
+#: src/ui/window/window.blp:123
 msgid "Get started writing"
 msgstr "Begin met schrijven"
 
-#: src/ui/window/window.blp:143
+#: src/ui/window/window.blp:152
+msgid "Open file in external application"
+msgstr ""
+
+#: src/ui/window/window.blp:160
+msgid "Open file"
+msgstr ""
+
+#: src/ui/window/window.blp:181
 msgid "Create a notebook"
 msgstr "Een notitieboek maken"
 
-#: src/ui/window/window.blp:168
+#: src/ui/window/window.blp:210
 msgid "Trash is empty"
 msgstr "Prullenbak is leeg"
 
-#: src/ui/window/window.blp:224
-msgid "Back"
-msgstr "Terug"
-
-#: src/ui/window/window.blp:239
+#: src/ui/window/window.blp:285
 msgid "Open in Notebook"
 msgstr "In notitieboek openen"
 
-#: src/ui/window/window.blp:264
+#: src/ui/window/window.blp:312
 msgid "_Rename Note"
 msgstr "Notitie _hernoemen"
 
-#: src/ui/window/window.blp:270
+#: src/ui/window/window.blp:319
 msgid "_Export Note"
 msgstr "Notitie _exporteren"
+
+#~ msgid "Back"
+#~ msgstr "Terug"

--- a/po/nl_NL.po
+++ b/po/nl_NL.po
@@ -2,229 +2,16 @@
 # This file is distributed under the same license as the Folio package.
 msgid ""
 msgstr ""
+"Project-Id-Version: Folio\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-10-12 16:53+0200\n"
 "PO-Revision-Date: 2024-03-02 16:58:41+0000\n"
+"Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: GlotPress/4.0.0\n"
-"Language: nl\n"
-"Project-Id-Version: Folio\n"
-
-#: data/app.gschema.xml:76
-msgid "Notebook sort order"
-msgstr ""
-
-#: data/app.gschema.xml:77
-msgid "The sort order of the notebook list"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:145
-msgid "Sort Order For Notebooks"
-msgstr ""
-
-#: data/app.gschema.xml:71
-msgid "Note sort order"
-msgstr ""
-
-#: data/app.gschema.xml:72
-msgid "The sort order of the note list"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:150
-msgid "Sort Order For Notes"
-msgstr ""
-
-#: src/ui/strings.vala:62
-msgid "Modified Time - Ascending"
-msgstr ""
-
-#: src/ui/strings.vala:63
-msgid "Modified Time - Descending"
-msgstr ""
-
-#: src/ui/strings.vala:64
-msgid "Alphabetical - Ascending"
-msgstr ""
-
-#: src/ui/strings.vala:65
-msgid "Alphabetical - Descending"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:114
-msgid "Display"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:117
-msgid "Full Screen"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:122
-msgid "Zoom In"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:127
-msgid "Zoom Out"
-msgstr ""
-
-#: src/ui/strings.vala:52
-msgid "Pick primary font for notes"
-msgstr ""
-
-#: src/ui/strings.vala:53
-msgid "Pick monospace font for code"
-msgstr ""
-
-#: src/ui/strings.vala:54
-msgid "File Changed On Disk"
-msgstr ""
-
-#: src/ui/strings.vala:55
-msgid ""
-"The file has changed on disk since it was last saved/loaded by Folio.\n"
-"\n"
-"You may do one of the following:\n"
-"\n"
-" • Reload the file (discarding any changes you have made in Folio)\n"
-" • Overwrite the file (discarding any changes made outside of Folio)\n"
-" • Cancel the operation and manually resolve the issue\n"
-"\n"
-"Note: Canceling the save if you have already moved to a new note/notebook will discard your changes."
-msgstr ""
-
-#: src/ui/strings.vala:56
-msgid "Reload"
-msgstr ""
-
-#: src/ui/strings.vala:57
-msgid "Overwrite"
-msgstr ""
-
-#: src/ui/strings.vala:59
-msgid ""
-"The file has changed on disk by another application.\n"
-"\n"
-"You may do one of the following:\n"
-"\n"
-" • Reload the file (discarding any changes you have made in Folio)\n"
-" • Overwrite the file (discarding any changes made outside of Folio)"
-msgstr ""
-
-#: src/ui/strings.vala:61
-msgid "Note %i"
-msgstr ""
-
-#: data/app.gschema.xml:46 src/ui/preferences/preferences.blp:213
-msgid "Trash Storage Location"
-msgstr ""
-
-#: data/app.gschema.xml:47 src/ui/preferences/preferences.blp:214
-msgid "Where the trash folder is located (requires app restart)"
-msgstr ""
-
-#: src/ui/strings.vala:46
-msgid "Pick where the trash can will be stored"
-msgstr ""
-
-#: data/app.gschema.xml:16 src/ui/preferences/preferences.blp:128
-msgid "Use Fixed Width For Notes"
-msgstr ""
-
-#: data/app.gschema.xml:17 src/ui/preferences/preferences.blp:129
-msgid "Use a fixed width for the text area of a note"
-msgstr ""
-
-#: data/app.gschema.xml:37 src/ui/preferences/preferences.blp:118
-msgid "Expands the notebook list to include the notebook name"
-msgstr ""
-
-#: data/app.gschema.xml:51 src/ui/preferences/preferences.blp:65
-msgid "Show line numbers"
-msgstr ""
-
-#: data/app.gschema.xml:52 src/ui/preferences/preferences.blp:66
-msgid "Displays line numbers at the left of the note"
-msgstr ""
-
-#: data/app.gschema.xml:56 src/ui/preferences/preferences.blp:76
-msgid "Show all notes"
-msgstr ""
-
-#: data/app.gschema.xml:57 src/ui/preferences/preferences.blp:77
-msgid "Displays the \"All Notes\" notebook at the top of the notebook list"
-msgstr ""
-
-#: data/app.gschema.xml:61 src/ui/preferences/preferences.blp:163
-msgid "Enable autosave"
-msgstr ""
-
-#: data/app.gschema.xml:62 src/ui/preferences/preferences.blp:164
-msgid "Automatically saves the current note every 30 seconds if the contents have changed (requires app restart)"
-msgstr ""
-
-#: data/app.gschema.xml:66 src/ui/preferences/preferences.blp:174
-msgid "Don't hide the Trash folder"
-msgstr ""
-
-#: data/app.gschema.xml:67
-msgid "The trash folder is set as a hidden folder by default, this option makes it visible"
-msgstr ""
-
-#: data/app.metainfo.xml.in:367
-msgid "Main Folio window in light mode"
-msgstr ""
-
-#: data/app.metainfo.xml.in:371
-msgid "Main Folio window in dark mode"
-msgstr ""
-
-#: data/app.metainfo.xml.in:375
-msgid "Folio on small/mobile screens"
-msgstr ""
-
-#: data/app.metainfo.xml.in:379
-msgid "Folio preferences screen"
-msgstr ""
-
-#: data/app.metainfo.xml.in:383
-msgid "Folio in three pane mode"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:59
-msgid "Tools"
-msgstr ""
-
-#: data/app.gschema.xml:27 src/ui/preferences/preferences.blp:88
-msgid "Displays the formatting toolbar at the bottom of the note"
-msgstr ""
-
-#: data/app.gschema.xml:32 src/ui/preferences/preferences.blp:99
-msgid "Adds a button to the markdown reference sheet on the right of the formatting toolbar"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:111
-msgid "Layout"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:139
-msgid "Fixed Width To Use For Notes"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:140
-msgid "Sets the fixed width size of a note in px"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:157
-msgid "Files"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:175
-msgid "The trash folder is set as a hidden folder by default, this option makes it visible (requires app restart)"
-msgstr ""
-
-#: src/ui/strings.vala:51
-msgid "Unable to recognize URI"
-msgstr ""
 
 #: data/app.desktop.in:9 src/ui/strings.vala:3
 msgid "Folio"
@@ -240,21 +27,23 @@ msgstr "Notities nemen"
 
 #: data/app.desktop.in:13
 msgid "Notebook;Note;Notes;Text;Markdown;Notepad;Write;School;Post-it;Sticky;"
-msgstr "Notitieboek;Notitie;Notities;Tekst;Markdown;Kladblok;Schrijven;School;Post-it;Sticky;"
+msgstr ""
+"Notitieboek;Notitie;Notities;Tekst;Markdown;Kladblok;Schrijven;School;Post-"
+"it;Sticky;"
 
 #: data/app.desktop.in:22 src/ui/popup/shortcut_window.blp:17
-#: src/ui/strings.vala:8 src/ui/window/window.blp:47
-#: src/ui/window/window.blp:124
+#: src/ui/strings.vala:8 src/ui/window/window.blp:54
+#: src/ui/window/window.blp:131
 msgid "New Note"
 msgstr "Nieuwe notitie"
 
 #: data/app.desktop.in:26 src/ui/popup/shortcut_window.blp:37
-#: src/ui/strings.vala:14 src/ui/window/window.blp:149
+#: src/ui/strings.vala:14 src/ui/window/window.blp:189
 msgid "New Notebook"
 msgstr "Nieuw notitieboek"
 
-#: data/app.desktop.in:30 src/ui/edit_view/toolbar/toolbar.blp:90
-#: src/ui/strings.vala:39 src/ui/window/window.blp:245
+#: data/app.desktop.in:30 src/ui/edit_view/toolbar/toolbar.blp:92
+#: src/ui/strings.vala:39 src/ui/window/window.blp:291
 msgid "Markdown Cheatsheet"
 msgstr "Markdown cheatsheet"
 
@@ -262,25 +51,149 @@ msgstr "Markdown cheatsheet"
 msgid "Preferences"
 msgstr "Voorkeuren"
 
-#: data/app.gschema.xml:6 src/ui/preferences/preferences.blp:18
+#: data/app.gschema.xml:6 src/ui/preferences/preferences.blp:45
 msgid "Note Font"
 msgstr "Notitielettertype"
 
-#: data/app.gschema.xml:7 src/ui/preferences/preferences.blp:19
+#: data/app.gschema.xml:7 src/ui/preferences/preferences.blp:46
 msgid "The font notes will be displayed in"
 msgstr "De lettertypes worden weergegeven in"
 
-#: data/app.gschema.xml:11 src/ui/preferences/preferences.blp:31
+#: data/app.gschema.xml:11 src/ui/preferences/preferences.blp:58
 msgid "Monospace Font"
 msgstr ""
 
-#: data/app.gschema.xml:12 src/ui/preferences/preferences.blp:32
+#: data/app.gschema.xml:12 src/ui/preferences/preferences.blp:59
 msgid "The font code will be displayed in"
 msgstr ""
 
-#: data/app.gschema.xml:21 src/ui/preferences/preferences.blp:46
+#: data/app.gschema.xml:16 src/ui/preferences/preferences.blp:150
+msgid "Use Fixed Width For Notes"
+msgstr ""
+
+#: data/app.gschema.xml:17 src/ui/preferences/preferences.blp:151
+msgid "Use a fixed width for the text area of a note"
+msgstr ""
+
+#: data/app.gschema.xml:21 src/ui/preferences/preferences.blp:18
 msgid "OLED Mode"
 msgstr "OLED-modus"
+
+#: data/app.gschema.xml:22 src/ui/preferences/preferences.blp:19
+msgid "Makes the dark theme pitch black"
+msgstr "Maakt het donker thema pikzwart"
+
+#: data/app.gschema.xml:26 src/ui/preferences/preferences.blp:109
+msgid "Enable Toolbar"
+msgstr ""
+
+#: data/app.gschema.xml:27 src/ui/preferences/preferences.blp:110
+msgid "Displays the formatting toolbar at the bottom of the note"
+msgstr ""
+
+#: data/app.gschema.xml:31 src/ui/preferences/preferences.blp:120
+msgid "Enable Cheatsheet"
+msgstr ""
+
+#: data/app.gschema.xml:32 src/ui/preferences/preferences.blp:121
+msgid ""
+"Adds a button to the markdown reference sheet on the right of the formatting "
+"toolbar"
+msgstr ""
+
+#: data/app.gschema.xml:36 src/ui/preferences/preferences.blp:139
+msgid "3-Pane Layout"
+msgstr ""
+
+#: data/app.gschema.xml:37 src/ui/preferences/preferences.blp:140
+msgid "Expands the notebook list to include the notebook name"
+msgstr ""
+
+#: data/app.gschema.xml:41 src/ui/preferences/preferences.blp:207
+msgid "Notes Storage Location"
+msgstr "Notities opslaglocatie"
+
+#: data/app.gschema.xml:42 src/ui/preferences/preferences.blp:208
+msgid "Where the notebooks are stored (requires app restart)"
+msgstr ""
+"Waar de notitieboeken worden opgeslagen (vereist opnieuw opstarten van de "
+"app)"
+
+#: data/app.gschema.xml:46 src/ui/preferences/preferences.blp:235
+msgid "Trash Storage Location"
+msgstr ""
+
+#: data/app.gschema.xml:47 src/ui/preferences/preferences.blp:236
+msgid "Where the trash folder is located (requires app restart)"
+msgstr ""
+
+#: data/app.gschema.xml:51 src/ui/preferences/preferences.blp:87
+msgid "Show line numbers"
+msgstr ""
+
+#: data/app.gschema.xml:52 src/ui/preferences/preferences.blp:88
+msgid "Displays line numbers at the left of the note"
+msgstr ""
+
+#: data/app.gschema.xml:56 src/ui/preferences/preferences.blp:98
+msgid "Show all notes"
+msgstr ""
+
+#: data/app.gschema.xml:57 src/ui/preferences/preferences.blp:99
+msgid "Displays the \"All Notes\" notebook at the top of the notebook list"
+msgstr ""
+
+#: data/app.gschema.xml:61 src/ui/preferences/preferences.blp:185
+msgid "Enable autosave"
+msgstr ""
+
+#: data/app.gschema.xml:62 src/ui/preferences/preferences.blp:186
+msgid ""
+"Automatically saves the current note every 30 seconds if the contents have "
+"changed (requires app restart)"
+msgstr ""
+
+#: data/app.gschema.xml:66 src/ui/preferences/preferences.blp:196
+msgid "Don't hide the Trash folder"
+msgstr ""
+
+#: data/app.gschema.xml:67
+msgid ""
+"The trash folder is set as a hidden folder by default, this option makes it "
+"visible"
+msgstr ""
+
+#: data/app.gschema.xml:71
+msgid "Note sort order"
+msgstr ""
+
+#: data/app.gschema.xml:72
+msgid "The sort order of the note list"
+msgstr ""
+
+#: data/app.gschema.xml:76
+msgid "Notebook sort order"
+msgstr ""
+
+#: data/app.gschema.xml:77
+msgid "The sort order of the notebook list"
+msgstr ""
+
+#: data/app.gschema.xml:81
+msgid "URL detection level"
+msgstr ""
+
+#: data/app.gschema.xml:82
+msgid "How agressive to look for URLs in markdown text"
+msgstr ""
+
+#: data/app.gschema.xml:86
+msgid "Line spacing"
+msgstr ""
+
+#: data/app.gschema.xml:87 src/ui/preferences/preferences.blp:74
+msgid "The line spacing for the note text"
+msgstr ""
 
 #: data/app.metainfo.xml.in:5
 msgid "Take notes in Markdown"
@@ -314,103 +227,116 @@ msgstr ""
 msgid "Trash can"
 msgstr "Prullenbak"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:23
-#: src/ui/edit_view/toolbar/toolbar.blp:131
+#: data/app.metainfo.xml.in:393
+msgid "Main Folio window in light mode"
+msgstr ""
+
+#: data/app.metainfo.xml.in:397
+msgid "Main Folio window in dark mode"
+msgstr ""
+
+#: data/app.metainfo.xml.in:401
+msgid "Folio on small/mobile screens"
+msgstr ""
+
+#: data/app.metainfo.xml.in:405
+msgid "Folio preferences screen"
+msgstr ""
+
+#: data/app.metainfo.xml.in:409
+msgid "Folio in three pane mode"
+msgstr ""
+
+#: src/ui/edit_view/toolbar/toolbar.blp:6
 #: src/ui/widgets/markdown/heading_popover.blp:48
 msgid "Plain Text"
 msgstr "Platte tekst"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:24
-#: src/ui/edit_view/toolbar/toolbar.blp:132
+#: src/ui/edit_view/toolbar/toolbar.blp:7
 #: src/ui/widgets/markdown/heading_popover.blp:12
 msgid "Heading 1"
 msgstr "Kop 1"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:25
-#: src/ui/edit_view/toolbar/toolbar.blp:133
+#: src/ui/edit_view/toolbar/toolbar.blp:8
 #: src/ui/widgets/markdown/heading_popover.blp:18
 msgid "Heading 2"
 msgstr "Kop 2"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:26
-#: src/ui/edit_view/toolbar/toolbar.blp:134
+#: src/ui/edit_view/toolbar/toolbar.blp:9
 #: src/ui/widgets/markdown/heading_popover.blp:24
 msgid "Heading 3"
 msgstr "Kop 3"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:27
-#: src/ui/edit_view/toolbar/toolbar.blp:135
+#: src/ui/edit_view/toolbar/toolbar.blp:10
 #: src/ui/widgets/markdown/heading_popover.blp:30
 msgid "Heading 4"
 msgstr "Kop 4"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:28
-#: src/ui/edit_view/toolbar/toolbar.blp:136
+#: src/ui/edit_view/toolbar/toolbar.blp:11
 #: src/ui/widgets/markdown/heading_popover.blp:36
 msgid "Heading 5"
 msgstr "Kop 5"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:29
-#: src/ui/edit_view/toolbar/toolbar.blp:137
+#: src/ui/edit_view/toolbar/toolbar.blp:12
 #: src/ui/widgets/markdown/heading_popover.blp:42
 msgid "Heading 6"
 msgstr "Kop 6"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:39
-#: src/ui/edit_view/toolbar/toolbar.blp:104
-#: src/ui/edit_view/toolbar/toolbar.blp:148
-#: src/ui/edit_view/toolbar/toolbar.blp:201 src/ui/popup/shortcut_window.blp:72
+#: src/ui/edit_view/toolbar/toolbar.blp:41
+#: src/ui/edit_view/toolbar/toolbar.blp:107
+#: src/ui/edit_view/toolbar/toolbar.blp:142
+#: src/ui/edit_view/toolbar/toolbar.blp:195 src/ui/popup/shortcut_window.blp:72
 msgid "Bold"
 msgstr "Vet"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:45
-#: src/ui/edit_view/toolbar/toolbar.blp:111
-#: src/ui/edit_view/toolbar/toolbar.blp:155
-#: src/ui/edit_view/toolbar/toolbar.blp:202 src/ui/popup/shortcut_window.blp:77
+#: src/ui/edit_view/toolbar/toolbar.blp:47
+#: src/ui/edit_view/toolbar/toolbar.blp:114
+#: src/ui/edit_view/toolbar/toolbar.blp:149
+#: src/ui/edit_view/toolbar/toolbar.blp:196 src/ui/popup/shortcut_window.blp:77
 msgid "Italic"
 msgstr "Cursief"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:51
-#: src/ui/edit_view/toolbar/toolbar.blp:162
-#: src/ui/edit_view/toolbar/toolbar.blp:203 src/ui/popup/shortcut_window.blp:82
+#: src/ui/edit_view/toolbar/toolbar.blp:53
+#: src/ui/edit_view/toolbar/toolbar.blp:156
+#: src/ui/edit_view/toolbar/toolbar.blp:197 src/ui/popup/shortcut_window.blp:82
 msgid "Strikethrough"
 msgstr "Doorhalen"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:57
-#: src/ui/edit_view/toolbar/toolbar.blp:169
-#: src/ui/edit_view/toolbar/toolbar.blp:204 src/ui/popup/shortcut_window.blp:87
+#: src/ui/edit_view/toolbar/toolbar.blp:59
+#: src/ui/edit_view/toolbar/toolbar.blp:163
+#: src/ui/edit_view/toolbar/toolbar.blp:198 src/ui/popup/shortcut_window.blp:87
 msgid "Highlight"
 msgstr "Markeren"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:67
-#: src/ui/edit_view/toolbar/toolbar.blp:193 src/ui/popup/shortcut_window.blp:92
+#: src/ui/edit_view/toolbar/toolbar.blp:69
+#: src/ui/edit_view/toolbar/toolbar.blp:187 src/ui/popup/shortcut_window.blp:92
 msgid "Insert Link"
 msgstr "Link toevoegen"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:73
-#: src/ui/edit_view/toolbar/toolbar.blp:194
+#: src/ui/edit_view/toolbar/toolbar.blp:75
+#: src/ui/edit_view/toolbar/toolbar.blp:188
 msgid "Insert Code"
 msgstr "Code toevoegen"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:79
-#: src/ui/edit_view/toolbar/toolbar.blp:195
+#: src/ui/edit_view/toolbar/toolbar.blp:81
+#: src/ui/edit_view/toolbar/toolbar.blp:189
 msgid "Insert Horizontal Rule"
 msgstr ""
 
-#: src/ui/edit_view/toolbar/toolbar.blp:118
+#: src/ui/edit_view/toolbar/toolbar.blp:121
 msgid "Format"
 msgstr ""
 
-#: src/ui/edit_view/toolbar/toolbar.blp:181
+#: src/ui/edit_view/toolbar/toolbar.blp:175
 msgid "Insert"
 msgstr ""
 
-#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:34
+#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:18
 #: src/ui/strings.vala:44 src/ui/strings.vala:58
 msgid "Cancel"
 msgstr "Annuleren"
 
-#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:39
+#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:23
 msgid "Confirm"
 msgstr "Bevestigen"
 
@@ -454,37 +380,85 @@ msgstr "Opmaken"
 msgid "Navigation"
 msgstr "Navigatie"
 
-#: src/ui/popup/shortcut_window.blp:102 src/ui/window/window.blp:216
+#: src/ui/popup/shortcut_window.blp:102 src/ui/window/window.blp:268
 msgid "Toggle Sidebar"
 msgstr "Zijbalk aan/uitzetten"
 
-#: src/ui/popup/shortcut_window.blp:107 src/ui/window/window.blp:63
+#: src/ui/popup/shortcut_window.blp:107 src/ui/window/window.blp:70
 msgid "Search Notes"
 msgstr "Notities zoeken"
 
-#: data/app.gschema.xml:22 src/ui/preferences/preferences.blp:47
-msgid "Makes the dark theme pitch black"
-msgstr "Maakt het donker thema pikzwart"
-
-#: data/app.gschema.xml:26 src/ui/preferences/preferences.blp:87
-msgid "Enable Toolbar"
+#: src/ui/popup/shortcut_window.blp:114
+msgid "Display"
 msgstr ""
 
-#: data/app.gschema.xml:31 src/ui/preferences/preferences.blp:98
-msgid "Enable Cheatsheet"
+#: src/ui/popup/shortcut_window.blp:117
+msgid "Full Screen"
 msgstr ""
 
-#: data/app.gschema.xml:36 src/ui/preferences/preferences.blp:117
-msgid "3-Pane Layout"
+#: src/ui/popup/shortcut_window.blp:122
+msgid "Zoom In"
 msgstr ""
 
-#: data/app.gschema.xml:41 src/ui/preferences/preferences.blp:185
-msgid "Notes Storage Location"
-msgstr "Notities opslaglocatie"
+#: src/ui/popup/shortcut_window.blp:127
+msgid "Zoom Out"
+msgstr ""
 
-#: data/app.gschema.xml:42 src/ui/preferences/preferences.blp:186
-msgid "Where the notebooks are stored (requires app restart)"
-msgstr "Waar de notitieboeken worden opgeslagen (vereist opnieuw opstarten van de app)"
+#: src/ui/preferences/preferences.blp:31
+#, fuzzy
+msgid "Markdown URL Detection"
+msgstr "Markdown cheatsheet"
+
+#: src/ui/preferences/preferences.blp:32
+msgid ""
+"Determines the level of detection of URLs in\n"
+"free form text is used:\n"
+" - Aggressive tries to find all URLs\n"
+" - Strict requires a protocol identifier (ie http://)\n"
+" - Disabled turns detection off."
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:39
+msgid "Fonts"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:73
+msgid "Line Spacing"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:81
+msgid "Tools"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:133
+msgid "Layout"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:161
+msgid "Fixed Width To Use For Notes"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:162
+msgid "Sets the fixed width size of a note in px"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:167
+msgid "Sort Order For Notebooks"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:172
+msgid "Sort Order For Notes"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:179
+msgid "Files"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:197
+msgid ""
+"The trash folder is set as a hidden folder by default, this option makes it "
+"visible (requires app restart)"
+msgstr ""
 
 #: src/ui/strings.vala:4 src/ui/window/notebooks_bar/notebooks_bar.blp:129
 #: src/ui/window/notebooks_bar/notebooks_bar.blp:171
@@ -492,6 +466,7 @@ msgid "Trash"
 msgstr "Prullenbak"
 
 #: src/ui/strings.vala:5
+#, c-format
 msgid "%d Notes"
 msgstr "%d Notities"
 
@@ -499,7 +474,7 @@ msgstr "%d Notities"
 msgid "Are you sure you want to delete everything in the trash?"
 msgstr "Weet je zeker dat je alles uit de prullenbak wilt verwijderen?"
 
-#: src/ui/strings.vala:7 src/ui/window/window.blp:54
+#: src/ui/strings.vala:7 src/ui/window/window.blp:61
 msgid "Empty Trash"
 msgstr "Prullenbak legen"
 
@@ -536,10 +511,12 @@ msgid "Move"
 msgstr "Verplaatsen"
 
 #: src/ui/strings.vala:18
+#, c-format
 msgid "Note “%s” already exists in notebook “%s”"
 msgstr "Notitie “%s” bestaat al in notitieboek “%s”"
 
 #: src/ui/strings.vala:19
+#, c-format
 msgid "Are you sure you want to delete the note “%s”?"
 msgstr "Weet je zeker dat je notitie “%s” wilt verwijderen?"
 
@@ -548,6 +525,7 @@ msgid "Delete Note"
 msgstr "Notitie verwijderen"
 
 #: src/ui/strings.vala:21
+#, c-format
 msgid "Are you sure you want to delete the notebook “%s”?"
 msgstr "Weet je zeker dat je notitieboek “%s” wilt verwijderen?"
 
@@ -556,34 +534,42 @@ msgid "Delete Notebook"
 msgstr "Notitieboek verwijderen"
 
 #: src/ui/strings.vala:24
-msgid "Note name shouldn’t contain “.” or “/”"
+#, fuzzy
+msgid "Note names cannot contain a “/”"
 msgstr "Notitienaam mag geen “.” of “/” bevatten"
 
 #: src/ui/strings.vala:25
-msgid "Note name shouldn’t be blank"
+#, fuzzy
+msgid "Note names cannot be blank"
 msgstr "Notitienaam mag niet leeg zijn"
 
 #: src/ui/strings.vala:26
+#, c-format
 msgid "Note “%s” already exists"
 msgstr "Notitie “%s” bestaat al"
 
 #: src/ui/strings.vala:27
-msgid "Couldn’t create note"
+#, fuzzy
+msgid "Could not create note"
 msgstr "Kon notitie niet maken"
 
 #: src/ui/strings.vala:28
-msgid "Couldn’t change note"
+#, fuzzy
+msgid "Could not change note"
 msgstr "Kon notitie niet veranderen"
 
 #: src/ui/strings.vala:29
-msgid "Couldn’t delete note"
+#, fuzzy
+msgid "Could not delete note"
 msgstr "Kon notitie niet verwijderen"
 
 #: src/ui/strings.vala:30
-msgid "Couldn’t restore note"
+#, fuzzy
+msgid "Could not restore note"
 msgstr "Kon notitie niet herstellen"
 
 #: src/ui/strings.vala:31
+#, c-format
 msgid "Saved “%s” to “%s”"
 msgstr "\"%s\" naar \"%s\" opgeslagen"
 
@@ -592,27 +578,33 @@ msgid "Unknown error"
 msgstr "Onbekende fout"
 
 #: src/ui/strings.vala:33
-msgid "Notebook name shouldn’t contain “.” or “/”"
+#, fuzzy
+msgid "Notebook names cannot contain a “/”"
 msgstr "Notitieboeknaam mag geen “.” of “/” bevatten"
 
 #: src/ui/strings.vala:34
-msgid "Notebook name shouldn’t be blank"
+#, fuzzy
+msgid "Notebook names cannot be blank"
 msgstr "Notitieboeknaam mag niet leeg zijn"
 
 #: src/ui/strings.vala:35
+#, c-format
 msgid "Notebook “%s” already exists"
 msgstr "Notitieboek “%s” bestaat al"
 
 #: src/ui/strings.vala:36
-msgid "Couldn’t create notebook"
+#, fuzzy
+msgid "Could not create notebook"
 msgstr "Kon notitieboek niet maken"
 
 #: src/ui/strings.vala:37
-msgid "Couldn’t change notebook"
+#, fuzzy
+msgid "Could not change notebook"
 msgstr "Kon notitieboek niet veranderen"
 
 #: src/ui/strings.vala:38
-msgid "Couldn’t delete notebook"
+#, fuzzy
+msgid "Could not delete notebook"
 msgstr "Kon notitieboek niet verwijderen"
 
 #: src/ui/strings.vala:40
@@ -624,7 +616,7 @@ msgid "Rename"
 msgstr "Hernoemen"
 
 #: src/ui/strings.vala:42
-msgid "Couldn’t find an app to handle file URIs"
+msgid "Could not find an app to handle file URIs"
 msgstr ""
 
 #: src/ui/strings.vala:43
@@ -634,6 +626,10 @@ msgstr "Toepassen"
 #: src/ui/strings.vala:45
 msgid "Pick where the notebooks will be stored"
 msgstr "Kies waar de notitieboeken worden opgeslagen"
+
+#: src/ui/strings.vala:46
+msgid "Pick where the trash can will be stored"
+msgstr ""
 
 #: src/ui/strings.vala:47 src/ui/window/notebooks_bar/notebooks_bar.blp:59
 #: src/ui/window/notebooks_bar/notebooks_bar.blp:101
@@ -646,6 +642,110 @@ msgstr ""
 
 #: src/ui/strings.vala:50
 msgid "Extension"
+msgstr ""
+
+#: src/ui/strings.vala:51
+msgid "Unable to recognize URI"
+msgstr ""
+
+#: src/ui/strings.vala:52
+msgid "Pick primary font for notes"
+msgstr ""
+
+#: src/ui/strings.vala:53
+msgid "Pick monospace font for code"
+msgstr ""
+
+#: src/ui/strings.vala:54
+msgid "File Changed On Disk"
+msgstr ""
+
+#: src/ui/strings.vala:55
+msgid ""
+"The file has changed on disk since it was last saved/loaded by Folio.\n"
+"\n"
+"You may do one of the following:\n"
+"\n"
+" • Reload the file (discarding any changes you have made in Folio)\n"
+" • Overwrite the file (discarding any changes made outside of Folio)\n"
+" • Cancel the operation and manually resolve the issue\n"
+"\n"
+"Note: Canceling the save if you have already moved to a new note/notebook "
+"will discard your changes."
+msgstr ""
+
+#: src/ui/strings.vala:56
+msgid "Reload"
+msgstr ""
+
+#: src/ui/strings.vala:57
+msgid "Overwrite"
+msgstr ""
+
+#: src/ui/strings.vala:59
+msgid ""
+"The file has changed on disk by another application.\n"
+"\n"
+"You may do one of the following:\n"
+"\n"
+" • Reload the file (discarding any changes you have made in Folio)\n"
+" • Overwrite the file (discarding any changes made outside of Folio)"
+msgstr ""
+
+#: src/ui/strings.vala:61
+#, c-format
+msgid "Note %i"
+msgstr ""
+
+#: src/ui/strings.vala:62
+msgid "Modified Time - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:63
+msgid "Modified Time - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:64
+msgid "Alphabetical - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:65
+msgid "Alphabetical - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:66
+msgid "Natural - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:67
+msgid "Natural - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:68
+#, c-format
+msgid "Unable to launch external application for file %s."
+msgstr ""
+
+#: src/ui/strings.vala:69
+msgid "Aggressive"
+msgstr ""
+
+#: src/ui/strings.vala:70
+msgid "Strict"
+msgstr ""
+
+#: src/ui/strings.vala:71
+msgid "Disabled"
+msgstr ""
+
+#: src/ui/strings.vala:72
+#, fuzzy, c-format
+msgid "“%s” moved to trash"
+msgstr "Naar prullenbak verplaatsen"
+
+#: src/ui/strings.vala:73
+#, c-format
+msgid "“%s” restored"
 msgstr ""
 
 #: src/ui/widgets/theme_selector/theme_selector.blp:15
@@ -677,40 +777,45 @@ msgid "_Keyboard Shortcuts"
 msgstr "_Sneltoetsen"
 
 #: src/ui/window/app_menu/app_menu.blp:43
-msgid "_About"
+#, fuzzy
+msgid "_About Folio"
 msgstr "_Over"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:54
-msgid "Notebook Name"
-msgstr "Notitieboeknaam"
-
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:66
-msgid "Duplicate notebook names are not allowed!"
-msgstr ""
-
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:82
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:6
 msgid "First Characters"
 msgstr "Eerste tekens en symbolen"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:83
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:7
 msgid "Initials"
 msgstr "Initialen"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:84
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:8
 msgid "Initials: camelCase"
 msgstr "Initialen: camelCase"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:85
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:9
 msgid "Initials: snake_case"
 msgstr "Initialen: snake_case"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:86
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:10
 msgid "Icon"
 msgstr "Icoon"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:116
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:11
+msgid "Custom"
+msgstr ""
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:16
 msgid "Notebook Color"
 msgstr "Notitieboekkleur"
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:58
+msgid "Notebook Name"
+msgstr "Notitieboeknaam"
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:70
+msgid "Duplicate notebook names are not allowed!"
+msgstr ""
 
 #: src/ui/window/notebooks_bar/notebook_create_popup.blp:126
 msgid "Create Notebook"
@@ -728,11 +833,11 @@ msgstr "Alles naar de prullenbak verplaatsen"
 msgid "Notebooks"
 msgstr ""
 
-#: src/ui/window/sidebar/note_create_popup.blp:37
+#: src/ui/window/sidebar/note_create_popup.blp:25
 msgid "Note Name"
 msgstr "Notitienaam"
 
-#: src/ui/window/sidebar/note_create_popup.blp:45
+#: src/ui/window/sidebar/note_create_popup.blp:33
 msgid "Create Note"
 msgstr "Notitie maken"
 
@@ -756,30 +861,37 @@ msgstr "Naar prullenbak verplaatsen"
 msgid "Open Containing Folder"
 msgstr "Map openen"
 
-#: src/ui/window/window.blp:118
+#: src/ui/window/window.blp:123
 msgid "Get started writing"
 msgstr "Begin met schrijven"
 
-#: src/ui/window/window.blp:143
+#: src/ui/window/window.blp:152
+msgid "Open file in external application"
+msgstr ""
+
+#: src/ui/window/window.blp:160
+msgid "Open file"
+msgstr ""
+
+#: src/ui/window/window.blp:181
 msgid "Create a notebook"
 msgstr "Een notitieboek maken"
 
-#: src/ui/window/window.blp:168
+#: src/ui/window/window.blp:210
 msgid "Trash is empty"
 msgstr "Prullenbak is leeg"
 
-#: src/ui/window/window.blp:224
-msgid "Back"
-msgstr "Terug"
-
-#: src/ui/window/window.blp:239
+#: src/ui/window/window.blp:285
 msgid "Open in Notebook"
 msgstr "In notitieboek openen"
 
-#: src/ui/window/window.blp:264
+#: src/ui/window/window.blp:312
 msgid "_Rename Note"
 msgstr "Notitie _hernoemen"
 
-#: src/ui/window/window.blp:270
+#: src/ui/window/window.blp:319
 msgid "_Export Note"
 msgstr "Notitie _exporteren"
+
+#~ msgid "Back"
+#~ msgstr "Terug"

--- a/po/oc.po
+++ b/po/oc.po
@@ -2,229 +2,16 @@
 # This file is distributed under the same license as the Folio package.
 msgid ""
 msgstr ""
+"Project-Id-Version: Folio\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-10-12 16:53+0200\n"
 "PO-Revision-Date: 2024-03-02 16:59:00+0000\n"
+"Language: oc\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: GlotPress/4.0.0\n"
-"Language: oc\n"
-"Project-Id-Version: Folio\n"
-
-#: data/app.gschema.xml:76
-msgid "Notebook sort order"
-msgstr ""
-
-#: data/app.gschema.xml:77
-msgid "The sort order of the notebook list"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:145
-msgid "Sort Order For Notebooks"
-msgstr ""
-
-#: data/app.gschema.xml:71
-msgid "Note sort order"
-msgstr ""
-
-#: data/app.gschema.xml:72
-msgid "The sort order of the note list"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:150
-msgid "Sort Order For Notes"
-msgstr ""
-
-#: src/ui/strings.vala:62
-msgid "Modified Time - Ascending"
-msgstr ""
-
-#: src/ui/strings.vala:63
-msgid "Modified Time - Descending"
-msgstr ""
-
-#: src/ui/strings.vala:64
-msgid "Alphabetical - Ascending"
-msgstr ""
-
-#: src/ui/strings.vala:65
-msgid "Alphabetical - Descending"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:114
-msgid "Display"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:117
-msgid "Full Screen"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:122
-msgid "Zoom In"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:127
-msgid "Zoom Out"
-msgstr ""
-
-#: src/ui/strings.vala:52
-msgid "Pick primary font for notes"
-msgstr ""
-
-#: src/ui/strings.vala:53
-msgid "Pick monospace font for code"
-msgstr ""
-
-#: src/ui/strings.vala:54
-msgid "File Changed On Disk"
-msgstr ""
-
-#: src/ui/strings.vala:55
-msgid ""
-"The file has changed on disk since it was last saved/loaded by Folio.\n"
-"\n"
-"You may do one of the following:\n"
-"\n"
-" • Reload the file (discarding any changes you have made in Folio)\n"
-" • Overwrite the file (discarding any changes made outside of Folio)\n"
-" • Cancel the operation and manually resolve the issue\n"
-"\n"
-"Note: Canceling the save if you have already moved to a new note/notebook will discard your changes."
-msgstr ""
-
-#: src/ui/strings.vala:56
-msgid "Reload"
-msgstr ""
-
-#: src/ui/strings.vala:57
-msgid "Overwrite"
-msgstr ""
-
-#: src/ui/strings.vala:59
-msgid ""
-"The file has changed on disk by another application.\n"
-"\n"
-"You may do one of the following:\n"
-"\n"
-" • Reload the file (discarding any changes you have made in Folio)\n"
-" • Overwrite the file (discarding any changes made outside of Folio)"
-msgstr ""
-
-#: src/ui/strings.vala:61
-msgid "Note %i"
-msgstr ""
-
-#: data/app.gschema.xml:46 src/ui/preferences/preferences.blp:213
-msgid "Trash Storage Location"
-msgstr ""
-
-#: data/app.gschema.xml:47 src/ui/preferences/preferences.blp:214
-msgid "Where the trash folder is located (requires app restart)"
-msgstr ""
-
-#: src/ui/strings.vala:46
-msgid "Pick where the trash can will be stored"
-msgstr ""
-
-#: data/app.gschema.xml:16 src/ui/preferences/preferences.blp:128
-msgid "Use Fixed Width For Notes"
-msgstr ""
-
-#: data/app.gschema.xml:17 src/ui/preferences/preferences.blp:129
-msgid "Use a fixed width for the text area of a note"
-msgstr ""
-
-#: data/app.gschema.xml:37 src/ui/preferences/preferences.blp:118
-msgid "Expands the notebook list to include the notebook name"
-msgstr ""
-
-#: data/app.gschema.xml:51 src/ui/preferences/preferences.blp:65
-msgid "Show line numbers"
-msgstr ""
-
-#: data/app.gschema.xml:52 src/ui/preferences/preferences.blp:66
-msgid "Displays line numbers at the left of the note"
-msgstr ""
-
-#: data/app.gschema.xml:56 src/ui/preferences/preferences.blp:76
-msgid "Show all notes"
-msgstr ""
-
-#: data/app.gschema.xml:57 src/ui/preferences/preferences.blp:77
-msgid "Displays the \"All Notes\" notebook at the top of the notebook list"
-msgstr ""
-
-#: data/app.gschema.xml:61 src/ui/preferences/preferences.blp:163
-msgid "Enable autosave"
-msgstr ""
-
-#: data/app.gschema.xml:62 src/ui/preferences/preferences.blp:164
-msgid "Automatically saves the current note every 30 seconds if the contents have changed (requires app restart)"
-msgstr ""
-
-#: data/app.gschema.xml:66 src/ui/preferences/preferences.blp:174
-msgid "Don't hide the Trash folder"
-msgstr ""
-
-#: data/app.gschema.xml:67
-msgid "The trash folder is set as a hidden folder by default, this option makes it visible"
-msgstr ""
-
-#: data/app.metainfo.xml.in:367
-msgid "Main Folio window in light mode"
-msgstr ""
-
-#: data/app.metainfo.xml.in:371
-msgid "Main Folio window in dark mode"
-msgstr ""
-
-#: data/app.metainfo.xml.in:375
-msgid "Folio on small/mobile screens"
-msgstr ""
-
-#: data/app.metainfo.xml.in:379
-msgid "Folio preferences screen"
-msgstr ""
-
-#: data/app.metainfo.xml.in:383
-msgid "Folio in three pane mode"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:59
-msgid "Tools"
-msgstr ""
-
-#: data/app.gschema.xml:27 src/ui/preferences/preferences.blp:88
-msgid "Displays the formatting toolbar at the bottom of the note"
-msgstr ""
-
-#: data/app.gschema.xml:32 src/ui/preferences/preferences.blp:99
-msgid "Adds a button to the markdown reference sheet on the right of the formatting toolbar"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:111
-msgid "Layout"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:139
-msgid "Fixed Width To Use For Notes"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:140
-msgid "Sets the fixed width size of a note in px"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:157
-msgid "Files"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:175
-msgid "The trash folder is set as a hidden folder by default, this option makes it visible (requires app restart)"
-msgstr ""
-
-#: src/ui/strings.vala:51
-msgid "Unable to recognize URI"
-msgstr ""
 
 #: data/app.desktop.in:9 src/ui/strings.vala:3
 msgid "Folio"
@@ -240,21 +27,23 @@ msgstr "Prendre de nòtas"
 
 #: data/app.desktop.in:13
 msgid "Notebook;Note;Notes;Text;Markdown;Notepad;Write;School;Post-it;Sticky;"
-msgstr "Libre de nòtas;nòta;nòtas:tèxt;tèxtes;markdown;notepad;escriure;escòla;post-it;sticky;rapèl;bremba;quasernet;"
+msgstr ""
+"Libre de nòtas;nòta;nòtas:tèxt;tèxtes;markdown;notepad;escriure;escòla;post-"
+"it;sticky;rapèl;bremba;quasernet;"
 
 #: data/app.desktop.in:22 src/ui/popup/shortcut_window.blp:17
-#: src/ui/strings.vala:8 src/ui/window/window.blp:47
-#: src/ui/window/window.blp:124
+#: src/ui/strings.vala:8 src/ui/window/window.blp:54
+#: src/ui/window/window.blp:131
 msgid "New Note"
 msgstr "Nòta novèla"
 
 #: data/app.desktop.in:26 src/ui/popup/shortcut_window.blp:37
-#: src/ui/strings.vala:14 src/ui/window/window.blp:149
+#: src/ui/strings.vala:14 src/ui/window/window.blp:189
 msgid "New Notebook"
 msgstr "Novèl libre de nòtas"
 
-#: data/app.desktop.in:30 src/ui/edit_view/toolbar/toolbar.blp:90
-#: src/ui/strings.vala:39 src/ui/window/window.blp:245
+#: data/app.desktop.in:30 src/ui/edit_view/toolbar/toolbar.blp:92
+#: src/ui/strings.vala:39 src/ui/window/window.blp:291
 msgid "Markdown Cheatsheet"
 msgstr "Fuèlh de tust Markdown"
 
@@ -262,25 +51,148 @@ msgstr "Fuèlh de tust Markdown"
 msgid "Preferences"
 msgstr "Preferéncias"
 
-#: data/app.gschema.xml:6 src/ui/preferences/preferences.blp:18
+#: data/app.gschema.xml:6 src/ui/preferences/preferences.blp:45
 msgid "Note Font"
 msgstr "Polissa de caractèrs de las nòtas"
 
-#: data/app.gschema.xml:7 src/ui/preferences/preferences.blp:19
+#: data/app.gschema.xml:7 src/ui/preferences/preferences.blp:46
 msgid "The font notes will be displayed in"
 msgstr "Las nòtas seràns afichadas dins aquesta polissa"
 
-#: data/app.gschema.xml:11 src/ui/preferences/preferences.blp:31
+#: data/app.gschema.xml:11 src/ui/preferences/preferences.blp:58
 msgid "Monospace Font"
 msgstr "Polissa de chassa fixa"
 
-#: data/app.gschema.xml:12 src/ui/preferences/preferences.blp:32
+#: data/app.gschema.xml:12 src/ui/preferences/preferences.blp:59
 msgid "The font code will be displayed in"
 msgstr "Lo còdi serà afichat dins aquesta polissa"
 
-#: data/app.gschema.xml:21 src/ui/preferences/preferences.blp:46
+#: data/app.gschema.xml:16 src/ui/preferences/preferences.blp:150
+msgid "Use Fixed Width For Notes"
+msgstr ""
+
+#: data/app.gschema.xml:17 src/ui/preferences/preferences.blp:151
+msgid "Use a fixed width for the text area of a note"
+msgstr ""
+
+#: data/app.gschema.xml:21 src/ui/preferences/preferences.blp:18
 msgid "OLED Mode"
 msgstr "Mòde OLED"
+
+#: data/app.gschema.xml:22 src/ui/preferences/preferences.blp:19
+msgid "Makes the dark theme pitch black"
+msgstr "Fa venir lo tèma escur negre"
+
+#: data/app.gschema.xml:26 src/ui/preferences/preferences.blp:109
+msgid "Enable Toolbar"
+msgstr "Activar la barra d’aisinas"
+
+#: data/app.gschema.xml:27 src/ui/preferences/preferences.blp:110
+msgid "Displays the formatting toolbar at the bottom of the note"
+msgstr ""
+
+#: data/app.gschema.xml:31 src/ui/preferences/preferences.blp:120
+msgid "Enable Cheatsheet"
+msgstr ""
+
+#: data/app.gschema.xml:32 src/ui/preferences/preferences.blp:121
+msgid ""
+"Adds a button to the markdown reference sheet on the right of the formatting "
+"toolbar"
+msgstr ""
+
+#: data/app.gschema.xml:36 src/ui/preferences/preferences.blp:139
+msgid "3-Pane Layout"
+msgstr "Disposicion en 3 panèls"
+
+#: data/app.gschema.xml:37 src/ui/preferences/preferences.blp:140
+msgid "Expands the notebook list to include the notebook name"
+msgstr ""
+
+#: data/app.gschema.xml:41 src/ui/preferences/preferences.blp:207
+msgid "Notes Storage Location"
+msgstr "Emplaçament de salvagarda de las nòtas"
+
+#: data/app.gschema.xml:42 src/ui/preferences/preferences.blp:208
+msgid "Where the notebooks are stored (requires app restart)"
+msgstr ""
+"Ont son gardadas los libres de nòtas (requerís una reaviada de l’aplicacion)"
+
+#: data/app.gschema.xml:46 src/ui/preferences/preferences.blp:235
+msgid "Trash Storage Location"
+msgstr ""
+
+#: data/app.gschema.xml:47 src/ui/preferences/preferences.blp:236
+msgid "Where the trash folder is located (requires app restart)"
+msgstr ""
+
+#: data/app.gschema.xml:51 src/ui/preferences/preferences.blp:87
+msgid "Show line numbers"
+msgstr ""
+
+#: data/app.gschema.xml:52 src/ui/preferences/preferences.blp:88
+msgid "Displays line numbers at the left of the note"
+msgstr ""
+
+#: data/app.gschema.xml:56 src/ui/preferences/preferences.blp:98
+msgid "Show all notes"
+msgstr ""
+
+#: data/app.gschema.xml:57 src/ui/preferences/preferences.blp:99
+msgid "Displays the \"All Notes\" notebook at the top of the notebook list"
+msgstr ""
+
+#: data/app.gschema.xml:61 src/ui/preferences/preferences.blp:185
+msgid "Enable autosave"
+msgstr ""
+
+#: data/app.gschema.xml:62 src/ui/preferences/preferences.blp:186
+msgid ""
+"Automatically saves the current note every 30 seconds if the contents have "
+"changed (requires app restart)"
+msgstr ""
+
+#: data/app.gschema.xml:66 src/ui/preferences/preferences.blp:196
+msgid "Don't hide the Trash folder"
+msgstr ""
+
+#: data/app.gschema.xml:67
+msgid ""
+"The trash folder is set as a hidden folder by default, this option makes it "
+"visible"
+msgstr ""
+
+#: data/app.gschema.xml:71
+msgid "Note sort order"
+msgstr ""
+
+#: data/app.gschema.xml:72
+msgid "The sort order of the note list"
+msgstr ""
+
+#: data/app.gschema.xml:76
+msgid "Notebook sort order"
+msgstr ""
+
+#: data/app.gschema.xml:77
+msgid "The sort order of the notebook list"
+msgstr ""
+
+#: data/app.gschema.xml:81
+msgid "URL detection level"
+msgstr ""
+
+#: data/app.gschema.xml:82
+msgid "How agressive to look for URLs in markdown text"
+msgstr ""
+
+#: data/app.gschema.xml:86
+msgid "Line spacing"
+msgstr ""
+
+#: data/app.gschema.xml:87 src/ui/preferences/preferences.blp:74
+msgid "The line spacing for the note text"
+msgstr ""
 
 #: data/app.metainfo.xml.in:5
 msgid "Take notes in Markdown"
@@ -314,103 +226,116 @@ msgstr ""
 msgid "Trash can"
 msgstr "Bordilhièr"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:23
-#: src/ui/edit_view/toolbar/toolbar.blp:131
+#: data/app.metainfo.xml.in:393
+msgid "Main Folio window in light mode"
+msgstr ""
+
+#: data/app.metainfo.xml.in:397
+msgid "Main Folio window in dark mode"
+msgstr ""
+
+#: data/app.metainfo.xml.in:401
+msgid "Folio on small/mobile screens"
+msgstr ""
+
+#: data/app.metainfo.xml.in:405
+msgid "Folio preferences screen"
+msgstr ""
+
+#: data/app.metainfo.xml.in:409
+msgid "Folio in three pane mode"
+msgstr ""
+
+#: src/ui/edit_view/toolbar/toolbar.blp:6
 #: src/ui/widgets/markdown/heading_popover.blp:48
 msgid "Plain Text"
 msgstr "Tèxte brut"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:24
-#: src/ui/edit_view/toolbar/toolbar.blp:132
+#: src/ui/edit_view/toolbar/toolbar.blp:7
 #: src/ui/widgets/markdown/heading_popover.blp:12
 msgid "Heading 1"
 msgstr "Títol 1"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:25
-#: src/ui/edit_view/toolbar/toolbar.blp:133
+#: src/ui/edit_view/toolbar/toolbar.blp:8
 #: src/ui/widgets/markdown/heading_popover.blp:18
 msgid "Heading 2"
 msgstr "Títol 2"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:26
-#: src/ui/edit_view/toolbar/toolbar.blp:134
+#: src/ui/edit_view/toolbar/toolbar.blp:9
 #: src/ui/widgets/markdown/heading_popover.blp:24
 msgid "Heading 3"
 msgstr "Títol 3"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:27
-#: src/ui/edit_view/toolbar/toolbar.blp:135
+#: src/ui/edit_view/toolbar/toolbar.blp:10
 #: src/ui/widgets/markdown/heading_popover.blp:30
 msgid "Heading 4"
 msgstr "Títol 4"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:28
-#: src/ui/edit_view/toolbar/toolbar.blp:136
+#: src/ui/edit_view/toolbar/toolbar.blp:11
 #: src/ui/widgets/markdown/heading_popover.blp:36
 msgid "Heading 5"
 msgstr "Títol 5"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:29
-#: src/ui/edit_view/toolbar/toolbar.blp:137
+#: src/ui/edit_view/toolbar/toolbar.blp:12
 #: src/ui/widgets/markdown/heading_popover.blp:42
 msgid "Heading 6"
 msgstr "Títol 6"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:39
-#: src/ui/edit_view/toolbar/toolbar.blp:104
-#: src/ui/edit_view/toolbar/toolbar.blp:148
-#: src/ui/edit_view/toolbar/toolbar.blp:201 src/ui/popup/shortcut_window.blp:72
+#: src/ui/edit_view/toolbar/toolbar.blp:41
+#: src/ui/edit_view/toolbar/toolbar.blp:107
+#: src/ui/edit_view/toolbar/toolbar.blp:142
+#: src/ui/edit_view/toolbar/toolbar.blp:195 src/ui/popup/shortcut_window.blp:72
 msgid "Bold"
 msgstr "Gras"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:45
-#: src/ui/edit_view/toolbar/toolbar.blp:111
-#: src/ui/edit_view/toolbar/toolbar.blp:155
-#: src/ui/edit_view/toolbar/toolbar.blp:202 src/ui/popup/shortcut_window.blp:77
+#: src/ui/edit_view/toolbar/toolbar.blp:47
+#: src/ui/edit_view/toolbar/toolbar.blp:114
+#: src/ui/edit_view/toolbar/toolbar.blp:149
+#: src/ui/edit_view/toolbar/toolbar.blp:196 src/ui/popup/shortcut_window.blp:77
 msgid "Italic"
 msgstr "Italica"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:51
-#: src/ui/edit_view/toolbar/toolbar.blp:162
-#: src/ui/edit_view/toolbar/toolbar.blp:203 src/ui/popup/shortcut_window.blp:82
+#: src/ui/edit_view/toolbar/toolbar.blp:53
+#: src/ui/edit_view/toolbar/toolbar.blp:156
+#: src/ui/edit_view/toolbar/toolbar.blp:197 src/ui/popup/shortcut_window.blp:82
 msgid "Strikethrough"
 msgstr "Raiat"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:57
-#: src/ui/edit_view/toolbar/toolbar.blp:169
-#: src/ui/edit_view/toolbar/toolbar.blp:204 src/ui/popup/shortcut_window.blp:87
+#: src/ui/edit_view/toolbar/toolbar.blp:59
+#: src/ui/edit_view/toolbar/toolbar.blp:163
+#: src/ui/edit_view/toolbar/toolbar.blp:198 src/ui/popup/shortcut_window.blp:87
 msgid "Highlight"
 msgstr "Suslinhar"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:67
-#: src/ui/edit_view/toolbar/toolbar.blp:193 src/ui/popup/shortcut_window.blp:92
+#: src/ui/edit_view/toolbar/toolbar.blp:69
+#: src/ui/edit_view/toolbar/toolbar.blp:187 src/ui/popup/shortcut_window.blp:92
 msgid "Insert Link"
 msgstr "Inserir un ligam"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:73
-#: src/ui/edit_view/toolbar/toolbar.blp:194
+#: src/ui/edit_view/toolbar/toolbar.blp:75
+#: src/ui/edit_view/toolbar/toolbar.blp:188
 msgid "Insert Code"
 msgstr "Inserir de còdi"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:79
-#: src/ui/edit_view/toolbar/toolbar.blp:195
+#: src/ui/edit_view/toolbar/toolbar.blp:81
+#: src/ui/edit_view/toolbar/toolbar.blp:189
 msgid "Insert Horizontal Rule"
 msgstr "Inserir barra orizontala"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:118
+#: src/ui/edit_view/toolbar/toolbar.blp:121
 msgid "Format"
 msgstr "Format"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:181
+#: src/ui/edit_view/toolbar/toolbar.blp:175
 msgid "Insert"
 msgstr "Inserir"
 
-#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:34
+#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:18
 #: src/ui/strings.vala:44 src/ui/strings.vala:58
 msgid "Cancel"
 msgstr "Anullar"
 
-#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:39
+#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:23
 msgid "Confirm"
 msgstr "Confirmar"
 
@@ -454,37 +379,85 @@ msgstr "Formatatge"
 msgid "Navigation"
 msgstr "Navigacion"
 
-#: src/ui/popup/shortcut_window.blp:102 src/ui/window/window.blp:216
+#: src/ui/popup/shortcut_window.blp:102 src/ui/window/window.blp:268
 msgid "Toggle Sidebar"
 msgstr "Afichar o amagar lo panèl lateral"
 
-#: src/ui/popup/shortcut_window.blp:107 src/ui/window/window.blp:63
+#: src/ui/popup/shortcut_window.blp:107 src/ui/window/window.blp:70
 msgid "Search Notes"
 msgstr "Cercar de nòtas"
 
-#: data/app.gschema.xml:22 src/ui/preferences/preferences.blp:47
-msgid "Makes the dark theme pitch black"
-msgstr "Fa venir lo tèma escur negre"
-
-#: data/app.gschema.xml:26 src/ui/preferences/preferences.blp:87
-msgid "Enable Toolbar"
-msgstr "Activar la barra d’aisinas"
-
-#: data/app.gschema.xml:31 src/ui/preferences/preferences.blp:98
-msgid "Enable Cheatsheet"
+#: src/ui/popup/shortcut_window.blp:114
+msgid "Display"
 msgstr ""
 
-#: data/app.gschema.xml:36 src/ui/preferences/preferences.blp:117
-msgid "3-Pane Layout"
-msgstr "Disposicion en 3 panèls"
+#: src/ui/popup/shortcut_window.blp:117
+msgid "Full Screen"
+msgstr ""
 
-#: data/app.gschema.xml:41 src/ui/preferences/preferences.blp:185
-msgid "Notes Storage Location"
-msgstr "Emplaçament de salvagarda de las nòtas"
+#: src/ui/popup/shortcut_window.blp:122
+msgid "Zoom In"
+msgstr ""
 
-#: data/app.gschema.xml:42 src/ui/preferences/preferences.blp:186
-msgid "Where the notebooks are stored (requires app restart)"
-msgstr "Ont son gardadas los libres de nòtas (requerís una reaviada de l’aplicacion)"
+#: src/ui/popup/shortcut_window.blp:127
+msgid "Zoom Out"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:31
+#, fuzzy
+msgid "Markdown URL Detection"
+msgstr "Fuèlh de tust Markdown"
+
+#: src/ui/preferences/preferences.blp:32
+msgid ""
+"Determines the level of detection of URLs in\n"
+"free form text is used:\n"
+" - Aggressive tries to find all URLs\n"
+" - Strict requires a protocol identifier (ie http://)\n"
+" - Disabled turns detection off."
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:39
+msgid "Fonts"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:73
+msgid "Line Spacing"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:81
+msgid "Tools"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:133
+msgid "Layout"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:161
+msgid "Fixed Width To Use For Notes"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:162
+msgid "Sets the fixed width size of a note in px"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:167
+msgid "Sort Order For Notebooks"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:172
+msgid "Sort Order For Notes"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:179
+msgid "Files"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:197
+msgid ""
+"The trash folder is set as a hidden folder by default, this option makes it "
+"visible (requires app restart)"
+msgstr ""
 
 #: src/ui/strings.vala:4 src/ui/window/notebooks_bar/notebooks_bar.blp:129
 #: src/ui/window/notebooks_bar/notebooks_bar.blp:171
@@ -492,6 +465,7 @@ msgid "Trash"
 msgstr "Bordilhièr"
 
 #: src/ui/strings.vala:5
+#, c-format
 msgid "%d Notes"
 msgstr "%d nòtas"
 
@@ -499,7 +473,7 @@ msgstr "%d nòtas"
 msgid "Are you sure you want to delete everything in the trash?"
 msgstr "Volètz vertadièrament tot suprimir ?"
 
-#: src/ui/strings.vala:7 src/ui/window/window.blp:54
+#: src/ui/strings.vala:7 src/ui/window/window.blp:61
 msgid "Empty Trash"
 msgstr "Voidar lo bordilhièr"
 
@@ -536,10 +510,12 @@ msgid "Move"
 msgstr "Desplaçar"
 
 #: src/ui/strings.vala:18
+#, c-format
 msgid "Note “%s” already exists in notebook “%s”"
 msgstr "La nòta « %s » existís ja dins lo libre de nòtas « %s »"
 
 #: src/ui/strings.vala:19
+#, c-format
 msgid "Are you sure you want to delete the note “%s”?"
 msgstr "Volètz vertadièrament suprimir la nòta « %s » ?"
 
@@ -548,6 +524,7 @@ msgid "Delete Note"
 msgstr "Suprimir la nòta"
 
 #: src/ui/strings.vala:21
+#, c-format
 msgid "Are you sure you want to delete the notebook “%s”?"
 msgstr "Volètz vertadièrament suprimir lo libre de nòtas « %s » ?"
 
@@ -556,34 +533,42 @@ msgid "Delete Notebook"
 msgstr "Suprimir libre de nòtas"
 
 #: src/ui/strings.vala:24
-msgid "Note name shouldn’t contain “.” or “/”"
+#, fuzzy
+msgid "Note names cannot contain a “/”"
 msgstr "Lo nom de la nòta pòt pas conténer « . » p « / »"
 
 #: src/ui/strings.vala:25
-msgid "Note name shouldn’t be blank"
+#, fuzzy
+msgid "Note names cannot be blank"
 msgstr "Lo nom de la nòta pòt pas èsser void"
 
 #: src/ui/strings.vala:26
+#, c-format
 msgid "Note “%s” already exists"
 msgstr "La nòta « %s » existís ja"
 
 #: src/ui/strings.vala:27
-msgid "Couldn’t create note"
+#, fuzzy
+msgid "Could not create note"
 msgstr "Creacion impossibla de la nòta"
 
 #: src/ui/strings.vala:28
-msgid "Couldn’t change note"
+#, fuzzy
+msgid "Could not change note"
 msgstr "Modificacion impossibla de la nòta"
 
 #: src/ui/strings.vala:29
-msgid "Couldn’t delete note"
+#, fuzzy
+msgid "Could not delete note"
 msgstr "Supression impossibla de la nòta"
 
 #: src/ui/strings.vala:30
-msgid "Couldn’t restore note"
+#, fuzzy
+msgid "Could not restore note"
 msgstr "Restauracion impossibla de la nòta"
 
 #: src/ui/strings.vala:31
+#, c-format
 msgid "Saved “%s” to “%s”"
 msgstr "« %s » enregistrat dins « %s »"
 
@@ -592,27 +577,33 @@ msgid "Unknown error"
 msgstr "Error desconeguda"
 
 #: src/ui/strings.vala:33
-msgid "Notebook name shouldn’t contain “.” or “/”"
+#, fuzzy
+msgid "Notebook names cannot contain a “/”"
 msgstr "Lo nom del libre de nòtas pòt pas conténer « . » p « / »"
 
 #: src/ui/strings.vala:34
-msgid "Notebook name shouldn’t be blank"
+#, fuzzy
+msgid "Notebook names cannot be blank"
 msgstr "Lo nom del libre de nòtas pòt pas èsser void"
 
 #: src/ui/strings.vala:35
+#, c-format
 msgid "Notebook “%s” already exists"
 msgstr "Lo libre de nòtas « %s » existís ja"
 
 #: src/ui/strings.vala:36
-msgid "Couldn’t create notebook"
+#, fuzzy
+msgid "Could not create notebook"
 msgstr "Creacion impossibla del libre de nòta"
 
 #: src/ui/strings.vala:37
-msgid "Couldn’t change notebook"
+#, fuzzy
+msgid "Could not change notebook"
 msgstr "Modificacion impossibla del libre de nòta"
 
 #: src/ui/strings.vala:38
-msgid "Couldn’t delete notebook"
+#, fuzzy
+msgid "Could not delete notebook"
 msgstr "Supression impossibla del libre de nòta"
 
 #: src/ui/strings.vala:40
@@ -624,7 +615,7 @@ msgid "Rename"
 msgstr "Renomenar"
 
 #: src/ui/strings.vala:42
-msgid "Couldn’t find an app to handle file URIs"
+msgid "Could not find an app to handle file URIs"
 msgstr ""
 
 #: src/ui/strings.vala:43
@@ -634,6 +625,10 @@ msgstr "Aplicar"
 #: src/ui/strings.vala:45
 msgid "Pick where the notebooks will be stored"
 msgstr "Causissètz ont los libres de nòtas seràn gardats"
+
+#: src/ui/strings.vala:46
+msgid "Pick where the trash can will be stored"
+msgstr ""
 
 #: src/ui/strings.vala:47 src/ui/window/notebooks_bar/notebooks_bar.blp:59
 #: src/ui/window/notebooks_bar/notebooks_bar.blp:101
@@ -646,6 +641,110 @@ msgstr ""
 
 #: src/ui/strings.vala:50
 msgid "Extension"
+msgstr ""
+
+#: src/ui/strings.vala:51
+msgid "Unable to recognize URI"
+msgstr ""
+
+#: src/ui/strings.vala:52
+msgid "Pick primary font for notes"
+msgstr ""
+
+#: src/ui/strings.vala:53
+msgid "Pick monospace font for code"
+msgstr ""
+
+#: src/ui/strings.vala:54
+msgid "File Changed On Disk"
+msgstr ""
+
+#: src/ui/strings.vala:55
+msgid ""
+"The file has changed on disk since it was last saved/loaded by Folio.\n"
+"\n"
+"You may do one of the following:\n"
+"\n"
+" • Reload the file (discarding any changes you have made in Folio)\n"
+" • Overwrite the file (discarding any changes made outside of Folio)\n"
+" • Cancel the operation and manually resolve the issue\n"
+"\n"
+"Note: Canceling the save if you have already moved to a new note/notebook "
+"will discard your changes."
+msgstr ""
+
+#: src/ui/strings.vala:56
+msgid "Reload"
+msgstr ""
+
+#: src/ui/strings.vala:57
+msgid "Overwrite"
+msgstr ""
+
+#: src/ui/strings.vala:59
+msgid ""
+"The file has changed on disk by another application.\n"
+"\n"
+"You may do one of the following:\n"
+"\n"
+" • Reload the file (discarding any changes you have made in Folio)\n"
+" • Overwrite the file (discarding any changes made outside of Folio)"
+msgstr ""
+
+#: src/ui/strings.vala:61
+#, c-format
+msgid "Note %i"
+msgstr ""
+
+#: src/ui/strings.vala:62
+msgid "Modified Time - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:63
+msgid "Modified Time - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:64
+msgid "Alphabetical - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:65
+msgid "Alphabetical - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:66
+msgid "Natural - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:67
+msgid "Natural - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:68
+#, c-format
+msgid "Unable to launch external application for file %s."
+msgstr ""
+
+#: src/ui/strings.vala:69
+msgid "Aggressive"
+msgstr ""
+
+#: src/ui/strings.vala:70
+msgid "Strict"
+msgstr ""
+
+#: src/ui/strings.vala:71
+msgid "Disabled"
+msgstr ""
+
+#: src/ui/strings.vala:72
+#, fuzzy, c-format
+msgid "“%s” moved to trash"
+msgstr "Desplaçar al bordilhièr"
+
+#: src/ui/strings.vala:73
+#, c-format
+msgid "“%s” restored"
 msgstr ""
 
 #: src/ui/widgets/theme_selector/theme_selector.blp:15
@@ -677,40 +776,45 @@ msgid "_Keyboard Shortcuts"
 msgstr "_Acorchis de clavièr"
 
 #: src/ui/window/app_menu/app_menu.blp:43
-msgid "_About"
+#, fuzzy
+msgid "_About Folio"
 msgstr "_A prepaus"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:54
-msgid "Notebook Name"
-msgstr "Nom del libre de nòtas"
-
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:66
-msgid "Duplicate notebook names are not allowed!"
-msgstr ""
-
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:82
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:6
 msgid "First Characters"
 msgstr "Primièr caractèr"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:83
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:7
 msgid "Initials"
 msgstr "Inicialas"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:84
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:8
 msgid "Initials: camelCase"
 msgstr "Inicialas : camelCase"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:85
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:9
 msgid "Initials: snake_case"
 msgstr "Inicialas : snake_case"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:86
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:10
 msgid "Icon"
 msgstr "Icòna"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:116
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:11
+msgid "Custom"
+msgstr ""
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:16
 msgid "Notebook Color"
 msgstr "Color del libre de nòtas"
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:58
+msgid "Notebook Name"
+msgstr "Nom del libre de nòtas"
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:70
+msgid "Duplicate notebook names are not allowed!"
+msgstr ""
 
 #: src/ui/window/notebooks_bar/notebook_create_popup.blp:126
 msgid "Create Notebook"
@@ -728,11 +832,11 @@ msgstr "Tot desplaçar al bordilhièr"
 msgid "Notebooks"
 msgstr ""
 
-#: src/ui/window/sidebar/note_create_popup.blp:37
+#: src/ui/window/sidebar/note_create_popup.blp:25
 msgid "Note Name"
 msgstr "Nom de la nòta"
 
-#: src/ui/window/sidebar/note_create_popup.blp:45
+#: src/ui/window/sidebar/note_create_popup.blp:33
 msgid "Create Note"
 msgstr "Crear nòta"
 
@@ -756,30 +860,37 @@ msgstr "Desplaçar al bordilhièr"
 msgid "Open Containing Folder"
 msgstr "Dobrir lo dossièr contenent"
 
-#: src/ui/window/window.blp:118
+#: src/ui/window/window.blp:123
 msgid "Get started writing"
 msgstr "Començar d’escriure"
 
-#: src/ui/window/window.blp:143
+#: src/ui/window/window.blp:152
+msgid "Open file in external application"
+msgstr ""
+
+#: src/ui/window/window.blp:160
+msgid "Open file"
+msgstr ""
+
+#: src/ui/window/window.blp:181
 msgid "Create a notebook"
 msgstr "Crear un libre de nòtas"
 
-#: src/ui/window/window.blp:168
+#: src/ui/window/window.blp:210
 msgid "Trash is empty"
 msgstr "Lo bordilhièr es void"
 
-#: src/ui/window/window.blp:224
-msgid "Back"
-msgstr "Tornar"
-
-#: src/ui/window/window.blp:239
+#: src/ui/window/window.blp:285
 msgid "Open in Notebook"
 msgstr "Dobrir dins lo libre de nòtas"
 
-#: src/ui/window/window.blp:264
+#: src/ui/window/window.blp:312
 msgid "_Rename Note"
 msgstr "_Renomenar nòta"
 
-#: src/ui/window/window.blp:270
+#: src/ui/window/window.blp:319
 msgid "_Export Note"
 msgstr "_Exportar nòta"
+
+#~ msgid "Back"
+#~ msgstr "Tornar"

--- a/po/pl.po
+++ b/po/pl.po
@@ -2,229 +2,17 @@
 # This file is distributed under the same license as the Folio package.
 msgid ""
 msgstr ""
+"Project-Id-Version: Folio\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-10-12 16:53+0200\n"
 "PO-Revision-Date: 2024-03-02 16:59:32+0000\n"
+"Language: pl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n == 1) ? 0 : ((n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % 100 > 14)) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n == 1) ? 0 : ((n % 10 >= 2 && n % 10 <= 4 "
+"&& (n % 100 < 12 || n % 100 > 14)) ? 1 : 2);\n"
 "X-Generator: GlotPress/4.0.0\n"
-"Language: pl\n"
-"Project-Id-Version: Folio\n"
-
-#: data/app.gschema.xml:76
-msgid "Notebook sort order"
-msgstr ""
-
-#: data/app.gschema.xml:77
-msgid "The sort order of the notebook list"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:145
-msgid "Sort Order For Notebooks"
-msgstr ""
-
-#: data/app.gschema.xml:71
-msgid "Note sort order"
-msgstr ""
-
-#: data/app.gschema.xml:72
-msgid "The sort order of the note list"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:150
-msgid "Sort Order For Notes"
-msgstr ""
-
-#: src/ui/strings.vala:62
-msgid "Modified Time - Ascending"
-msgstr ""
-
-#: src/ui/strings.vala:63
-msgid "Modified Time - Descending"
-msgstr ""
-
-#: src/ui/strings.vala:64
-msgid "Alphabetical - Ascending"
-msgstr ""
-
-#: src/ui/strings.vala:65
-msgid "Alphabetical - Descending"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:114
-msgid "Display"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:117
-msgid "Full Screen"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:122
-msgid "Zoom In"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:127
-msgid "Zoom Out"
-msgstr ""
-
-#: src/ui/strings.vala:52
-msgid "Pick primary font for notes"
-msgstr ""
-
-#: src/ui/strings.vala:53
-msgid "Pick monospace font for code"
-msgstr ""
-
-#: src/ui/strings.vala:54
-msgid "File Changed On Disk"
-msgstr ""
-
-#: src/ui/strings.vala:55
-msgid ""
-"The file has changed on disk since it was last saved/loaded by Folio.\n"
-"\n"
-"You may do one of the following:\n"
-"\n"
-" • Reload the file (discarding any changes you have made in Folio)\n"
-" • Overwrite the file (discarding any changes made outside of Folio)\n"
-" • Cancel the operation and manually resolve the issue\n"
-"\n"
-"Note: Canceling the save if you have already moved to a new note/notebook will discard your changes."
-msgstr ""
-
-#: src/ui/strings.vala:56
-msgid "Reload"
-msgstr ""
-
-#: src/ui/strings.vala:57
-msgid "Overwrite"
-msgstr ""
-
-#: src/ui/strings.vala:59
-msgid ""
-"The file has changed on disk by another application.\n"
-"\n"
-"You may do one of the following:\n"
-"\n"
-" • Reload the file (discarding any changes you have made in Folio)\n"
-" • Overwrite the file (discarding any changes made outside of Folio)"
-msgstr ""
-
-#: src/ui/strings.vala:61
-msgid "Note %i"
-msgstr ""
-
-#: data/app.gschema.xml:46 src/ui/preferences/preferences.blp:213
-msgid "Trash Storage Location"
-msgstr ""
-
-#: data/app.gschema.xml:47 src/ui/preferences/preferences.blp:214
-msgid "Where the trash folder is located (requires app restart)"
-msgstr ""
-
-#: src/ui/strings.vala:46
-msgid "Pick where the trash can will be stored"
-msgstr ""
-
-#: data/app.gschema.xml:16 src/ui/preferences/preferences.blp:128
-msgid "Use Fixed Width For Notes"
-msgstr ""
-
-#: data/app.gschema.xml:17 src/ui/preferences/preferences.blp:129
-msgid "Use a fixed width for the text area of a note"
-msgstr ""
-
-#: data/app.gschema.xml:37 src/ui/preferences/preferences.blp:118
-msgid "Expands the notebook list to include the notebook name"
-msgstr ""
-
-#: data/app.gschema.xml:51 src/ui/preferences/preferences.blp:65
-msgid "Show line numbers"
-msgstr ""
-
-#: data/app.gschema.xml:52 src/ui/preferences/preferences.blp:66
-msgid "Displays line numbers at the left of the note"
-msgstr ""
-
-#: data/app.gschema.xml:56 src/ui/preferences/preferences.blp:76
-msgid "Show all notes"
-msgstr ""
-
-#: data/app.gschema.xml:57 src/ui/preferences/preferences.blp:77
-msgid "Displays the \"All Notes\" notebook at the top of the notebook list"
-msgstr ""
-
-#: data/app.gschema.xml:61 src/ui/preferences/preferences.blp:163
-msgid "Enable autosave"
-msgstr ""
-
-#: data/app.gschema.xml:62 src/ui/preferences/preferences.blp:164
-msgid "Automatically saves the current note every 30 seconds if the contents have changed (requires app restart)"
-msgstr ""
-
-#: data/app.gschema.xml:66 src/ui/preferences/preferences.blp:174
-msgid "Don't hide the Trash folder"
-msgstr ""
-
-#: data/app.gschema.xml:67
-msgid "The trash folder is set as a hidden folder by default, this option makes it visible"
-msgstr ""
-
-#: data/app.metainfo.xml.in:367
-msgid "Main Folio window in light mode"
-msgstr ""
-
-#: data/app.metainfo.xml.in:371
-msgid "Main Folio window in dark mode"
-msgstr ""
-
-#: data/app.metainfo.xml.in:375
-msgid "Folio on small/mobile screens"
-msgstr ""
-
-#: data/app.metainfo.xml.in:379
-msgid "Folio preferences screen"
-msgstr ""
-
-#: data/app.metainfo.xml.in:383
-msgid "Folio in three pane mode"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:59
-msgid "Tools"
-msgstr ""
-
-#: data/app.gschema.xml:27 src/ui/preferences/preferences.blp:88
-msgid "Displays the formatting toolbar at the bottom of the note"
-msgstr ""
-
-#: data/app.gschema.xml:32 src/ui/preferences/preferences.blp:99
-msgid "Adds a button to the markdown reference sheet on the right of the formatting toolbar"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:111
-msgid "Layout"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:139
-msgid "Fixed Width To Use For Notes"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:140
-msgid "Sets the fixed width size of a note in px"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:157
-msgid "Files"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:175
-msgid "The trash folder is set as a hidden folder by default, this option makes it visible (requires app restart)"
-msgstr ""
-
-#: src/ui/strings.vala:51
-msgid "Unable to recognize URI"
-msgstr ""
 
 #: data/app.desktop.in:9 src/ui/strings.vala:3
 msgid "Folio"
@@ -240,21 +28,22 @@ msgstr "Rób notatki"
 
 #: data/app.desktop.in:13
 msgid "Notebook;Note;Notes;Text;Markdown;Notepad;Write;School;Post-it;Sticky;"
-msgstr "Zeszyt;Notatka;Notatki;Tekst;Markdown;Notatnik;Pisać;Szkoła;Samoprzylepna;"
+msgstr ""
+"Zeszyt;Notatka;Notatki;Tekst;Markdown;Notatnik;Pisać;Szkoła;Samoprzylepna;"
 
 #: data/app.desktop.in:22 src/ui/popup/shortcut_window.blp:17
-#: src/ui/strings.vala:8 src/ui/window/window.blp:47
-#: src/ui/window/window.blp:124
+#: src/ui/strings.vala:8 src/ui/window/window.blp:54
+#: src/ui/window/window.blp:131
 msgid "New Note"
 msgstr "Nowa notatka"
 
 #: data/app.desktop.in:26 src/ui/popup/shortcut_window.blp:37
-#: src/ui/strings.vala:14 src/ui/window/window.blp:149
+#: src/ui/strings.vala:14 src/ui/window/window.blp:189
 msgid "New Notebook"
 msgstr "Nowy zeszyt"
 
-#: data/app.desktop.in:30 src/ui/edit_view/toolbar/toolbar.blp:90
-#: src/ui/strings.vala:39 src/ui/window/window.blp:245
+#: data/app.desktop.in:30 src/ui/edit_view/toolbar/toolbar.blp:92
+#: src/ui/strings.vala:39 src/ui/window/window.blp:291
 msgid "Markdown Cheatsheet"
 msgstr "Ściągawka Markdown"
 
@@ -262,25 +51,147 @@ msgstr "Ściągawka Markdown"
 msgid "Preferences"
 msgstr "Ustawienia"
 
-#: data/app.gschema.xml:6 src/ui/preferences/preferences.blp:18
+#: data/app.gschema.xml:6 src/ui/preferences/preferences.blp:45
 msgid "Note Font"
 msgstr "Czcionka Notatek"
 
-#: data/app.gschema.xml:7 src/ui/preferences/preferences.blp:19
+#: data/app.gschema.xml:7 src/ui/preferences/preferences.blp:46
 msgid "The font notes will be displayed in"
 msgstr "Czcionka używana w notatkach"
 
-#: data/app.gschema.xml:11 src/ui/preferences/preferences.blp:31
+#: data/app.gschema.xml:11 src/ui/preferences/preferences.blp:58
 msgid "Monospace Font"
 msgstr "Czcionka Monospace"
 
-#: data/app.gschema.xml:12 src/ui/preferences/preferences.blp:32
+#: data/app.gschema.xml:12 src/ui/preferences/preferences.blp:59
 msgid "The font code will be displayed in"
 msgstr "Czcionka używana dla kodu"
 
-#: data/app.gschema.xml:21 src/ui/preferences/preferences.blp:46
+#: data/app.gschema.xml:16 src/ui/preferences/preferences.blp:150
+msgid "Use Fixed Width For Notes"
+msgstr ""
+
+#: data/app.gschema.xml:17 src/ui/preferences/preferences.blp:151
+msgid "Use a fixed width for the text area of a note"
+msgstr ""
+
+#: data/app.gschema.xml:21 src/ui/preferences/preferences.blp:18
 msgid "OLED Mode"
 msgstr "Tryb OLED"
+
+#: data/app.gschema.xml:22 src/ui/preferences/preferences.blp:19
+msgid "Makes the dark theme pitch black"
+msgstr "Sprawia, że ​​ciemny motyw jest całkowicie czarny"
+
+#: data/app.gschema.xml:26 src/ui/preferences/preferences.blp:109
+msgid "Enable Toolbar"
+msgstr "Włącz Pasek Narzędzi"
+
+#: data/app.gschema.xml:27 src/ui/preferences/preferences.blp:110
+msgid "Displays the formatting toolbar at the bottom of the note"
+msgstr ""
+
+#: data/app.gschema.xml:31 src/ui/preferences/preferences.blp:120
+msgid "Enable Cheatsheet"
+msgstr ""
+
+#: data/app.gschema.xml:32 src/ui/preferences/preferences.blp:121
+msgid ""
+"Adds a button to the markdown reference sheet on the right of the formatting "
+"toolbar"
+msgstr ""
+
+#: data/app.gschema.xml:36 src/ui/preferences/preferences.blp:139
+msgid "3-Pane Layout"
+msgstr "3-Kolumnowy Interfejs"
+
+#: data/app.gschema.xml:37 src/ui/preferences/preferences.blp:140
+msgid "Expands the notebook list to include the notebook name"
+msgstr ""
+
+#: data/app.gschema.xml:41 src/ui/preferences/preferences.blp:207
+msgid "Notes Storage Location"
+msgstr "Miejsce przechowywania notatek"
+
+#: data/app.gschema.xml:42 src/ui/preferences/preferences.blp:208
+msgid "Where the notebooks are stored (requires app restart)"
+msgstr "Folder, w którym przechowywane są zeszyty (wymaga restartu aplikacji)"
+
+#: data/app.gschema.xml:46 src/ui/preferences/preferences.blp:235
+msgid "Trash Storage Location"
+msgstr ""
+
+#: data/app.gschema.xml:47 src/ui/preferences/preferences.blp:236
+msgid "Where the trash folder is located (requires app restart)"
+msgstr ""
+
+#: data/app.gschema.xml:51 src/ui/preferences/preferences.blp:87
+msgid "Show line numbers"
+msgstr ""
+
+#: data/app.gschema.xml:52 src/ui/preferences/preferences.blp:88
+msgid "Displays line numbers at the left of the note"
+msgstr ""
+
+#: data/app.gschema.xml:56 src/ui/preferences/preferences.blp:98
+msgid "Show all notes"
+msgstr ""
+
+#: data/app.gschema.xml:57 src/ui/preferences/preferences.blp:99
+msgid "Displays the \"All Notes\" notebook at the top of the notebook list"
+msgstr ""
+
+#: data/app.gschema.xml:61 src/ui/preferences/preferences.blp:185
+msgid "Enable autosave"
+msgstr ""
+
+#: data/app.gschema.xml:62 src/ui/preferences/preferences.blp:186
+msgid ""
+"Automatically saves the current note every 30 seconds if the contents have "
+"changed (requires app restart)"
+msgstr ""
+
+#: data/app.gschema.xml:66 src/ui/preferences/preferences.blp:196
+msgid "Don't hide the Trash folder"
+msgstr ""
+
+#: data/app.gschema.xml:67
+msgid ""
+"The trash folder is set as a hidden folder by default, this option makes it "
+"visible"
+msgstr ""
+
+#: data/app.gschema.xml:71
+msgid "Note sort order"
+msgstr ""
+
+#: data/app.gschema.xml:72
+msgid "The sort order of the note list"
+msgstr ""
+
+#: data/app.gschema.xml:76
+msgid "Notebook sort order"
+msgstr ""
+
+#: data/app.gschema.xml:77
+msgid "The sort order of the notebook list"
+msgstr ""
+
+#: data/app.gschema.xml:81
+msgid "URL detection level"
+msgstr ""
+
+#: data/app.gschema.xml:82
+msgid "How agressive to look for URLs in markdown text"
+msgstr ""
+
+#: data/app.gschema.xml:86
+msgid "Line spacing"
+msgstr ""
+
+#: data/app.gschema.xml:87 src/ui/preferences/preferences.blp:74
+msgid "The line spacing for the note text"
+msgstr ""
 
 #: data/app.metainfo.xml.in:5
 msgid "Take notes in Markdown"
@@ -314,103 +225,116 @@ msgstr ""
 msgid "Trash can"
 msgstr "Kosz na śmieci"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:23
-#: src/ui/edit_view/toolbar/toolbar.blp:131
+#: data/app.metainfo.xml.in:393
+msgid "Main Folio window in light mode"
+msgstr ""
+
+#: data/app.metainfo.xml.in:397
+msgid "Main Folio window in dark mode"
+msgstr ""
+
+#: data/app.metainfo.xml.in:401
+msgid "Folio on small/mobile screens"
+msgstr ""
+
+#: data/app.metainfo.xml.in:405
+msgid "Folio preferences screen"
+msgstr ""
+
+#: data/app.metainfo.xml.in:409
+msgid "Folio in three pane mode"
+msgstr ""
+
+#: src/ui/edit_view/toolbar/toolbar.blp:6
 #: src/ui/widgets/markdown/heading_popover.blp:48
 msgid "Plain Text"
 msgstr "Czysty tekst"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:24
-#: src/ui/edit_view/toolbar/toolbar.blp:132
+#: src/ui/edit_view/toolbar/toolbar.blp:7
 #: src/ui/widgets/markdown/heading_popover.blp:12
 msgid "Heading 1"
 msgstr "Nagłówek 1"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:25
-#: src/ui/edit_view/toolbar/toolbar.blp:133
+#: src/ui/edit_view/toolbar/toolbar.blp:8
 #: src/ui/widgets/markdown/heading_popover.blp:18
 msgid "Heading 2"
 msgstr "Nagłówek 2"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:26
-#: src/ui/edit_view/toolbar/toolbar.blp:134
+#: src/ui/edit_view/toolbar/toolbar.blp:9
 #: src/ui/widgets/markdown/heading_popover.blp:24
 msgid "Heading 3"
 msgstr "Nagłówek 3"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:27
-#: src/ui/edit_view/toolbar/toolbar.blp:135
+#: src/ui/edit_view/toolbar/toolbar.blp:10
 #: src/ui/widgets/markdown/heading_popover.blp:30
 msgid "Heading 4"
 msgstr "Nagłówek 4"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:28
-#: src/ui/edit_view/toolbar/toolbar.blp:136
+#: src/ui/edit_view/toolbar/toolbar.blp:11
 #: src/ui/widgets/markdown/heading_popover.blp:36
 msgid "Heading 5"
 msgstr "Nagłówek 5"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:29
-#: src/ui/edit_view/toolbar/toolbar.blp:137
+#: src/ui/edit_view/toolbar/toolbar.blp:12
 #: src/ui/widgets/markdown/heading_popover.blp:42
 msgid "Heading 6"
 msgstr "Nagłówek 6"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:39
-#: src/ui/edit_view/toolbar/toolbar.blp:104
-#: src/ui/edit_view/toolbar/toolbar.blp:148
-#: src/ui/edit_view/toolbar/toolbar.blp:201 src/ui/popup/shortcut_window.blp:72
+#: src/ui/edit_view/toolbar/toolbar.blp:41
+#: src/ui/edit_view/toolbar/toolbar.blp:107
+#: src/ui/edit_view/toolbar/toolbar.blp:142
+#: src/ui/edit_view/toolbar/toolbar.blp:195 src/ui/popup/shortcut_window.blp:72
 msgid "Bold"
 msgstr "Pogrubienie"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:45
-#: src/ui/edit_view/toolbar/toolbar.blp:111
-#: src/ui/edit_view/toolbar/toolbar.blp:155
-#: src/ui/edit_view/toolbar/toolbar.blp:202 src/ui/popup/shortcut_window.blp:77
+#: src/ui/edit_view/toolbar/toolbar.blp:47
+#: src/ui/edit_view/toolbar/toolbar.blp:114
+#: src/ui/edit_view/toolbar/toolbar.blp:149
+#: src/ui/edit_view/toolbar/toolbar.blp:196 src/ui/popup/shortcut_window.blp:77
 msgid "Italic"
 msgstr "Kursywa"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:51
-#: src/ui/edit_view/toolbar/toolbar.blp:162
-#: src/ui/edit_view/toolbar/toolbar.blp:203 src/ui/popup/shortcut_window.blp:82
+#: src/ui/edit_view/toolbar/toolbar.blp:53
+#: src/ui/edit_view/toolbar/toolbar.blp:156
+#: src/ui/edit_view/toolbar/toolbar.blp:197 src/ui/popup/shortcut_window.blp:82
 msgid "Strikethrough"
 msgstr "Przekreślenie"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:57
-#: src/ui/edit_view/toolbar/toolbar.blp:169
-#: src/ui/edit_view/toolbar/toolbar.blp:204 src/ui/popup/shortcut_window.blp:87
+#: src/ui/edit_view/toolbar/toolbar.blp:59
+#: src/ui/edit_view/toolbar/toolbar.blp:163
+#: src/ui/edit_view/toolbar/toolbar.blp:198 src/ui/popup/shortcut_window.blp:87
 msgid "Highlight"
 msgstr "Zakreślenie"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:67
-#: src/ui/edit_view/toolbar/toolbar.blp:193 src/ui/popup/shortcut_window.blp:92
+#: src/ui/edit_view/toolbar/toolbar.blp:69
+#: src/ui/edit_view/toolbar/toolbar.blp:187 src/ui/popup/shortcut_window.blp:92
 msgid "Insert Link"
 msgstr "Wstaw link"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:73
-#: src/ui/edit_view/toolbar/toolbar.blp:194
+#: src/ui/edit_view/toolbar/toolbar.blp:75
+#: src/ui/edit_view/toolbar/toolbar.blp:188
 msgid "Insert Code"
 msgstr "Wstaw kod"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:79
-#: src/ui/edit_view/toolbar/toolbar.blp:195
+#: src/ui/edit_view/toolbar/toolbar.blp:81
+#: src/ui/edit_view/toolbar/toolbar.blp:189
 msgid "Insert Horizontal Rule"
 msgstr "Wstaw linię poziomą"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:118
+#: src/ui/edit_view/toolbar/toolbar.blp:121
 msgid "Format"
 msgstr "Formatowanie"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:181
+#: src/ui/edit_view/toolbar/toolbar.blp:175
 msgid "Insert"
 msgstr "Wstaw"
 
-#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:34
+#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:18
 #: src/ui/strings.vala:44 src/ui/strings.vala:58
 msgid "Cancel"
 msgstr "Anuluj"
 
-#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:39
+#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:23
 msgid "Confirm"
 msgstr "Potwierdź"
 
@@ -454,37 +378,85 @@ msgstr "Formatowanie"
 msgid "Navigation"
 msgstr "Nawigacja"
 
-#: src/ui/popup/shortcut_window.blp:102 src/ui/window/window.blp:216
+#: src/ui/popup/shortcut_window.blp:102 src/ui/window/window.blp:268
 msgid "Toggle Sidebar"
 msgstr "Przełącz panel boczny"
 
-#: src/ui/popup/shortcut_window.blp:107 src/ui/window/window.blp:63
+#: src/ui/popup/shortcut_window.blp:107 src/ui/window/window.blp:70
 msgid "Search Notes"
 msgstr "Wyszukaj notatki"
 
-#: data/app.gschema.xml:22 src/ui/preferences/preferences.blp:47
-msgid "Makes the dark theme pitch black"
-msgstr "Sprawia, że ​​ciemny motyw jest całkowicie czarny"
-
-#: data/app.gschema.xml:26 src/ui/preferences/preferences.blp:87
-msgid "Enable Toolbar"
-msgstr "Włącz Pasek Narzędzi"
-
-#: data/app.gschema.xml:31 src/ui/preferences/preferences.blp:98
-msgid "Enable Cheatsheet"
+#: src/ui/popup/shortcut_window.blp:114
+msgid "Display"
 msgstr ""
 
-#: data/app.gschema.xml:36 src/ui/preferences/preferences.blp:117
-msgid "3-Pane Layout"
-msgstr "3-Kolumnowy Interfejs"
+#: src/ui/popup/shortcut_window.blp:117
+msgid "Full Screen"
+msgstr ""
 
-#: data/app.gschema.xml:41 src/ui/preferences/preferences.blp:185
-msgid "Notes Storage Location"
-msgstr "Miejsce przechowywania notatek"
+#: src/ui/popup/shortcut_window.blp:122
+msgid "Zoom In"
+msgstr ""
 
-#: data/app.gschema.xml:42 src/ui/preferences/preferences.blp:186
-msgid "Where the notebooks are stored (requires app restart)"
-msgstr "Folder, w którym przechowywane są zeszyty (wymaga restartu aplikacji)"
+#: src/ui/popup/shortcut_window.blp:127
+msgid "Zoom Out"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:31
+#, fuzzy
+msgid "Markdown URL Detection"
+msgstr "Ściągawka Markdown"
+
+#: src/ui/preferences/preferences.blp:32
+msgid ""
+"Determines the level of detection of URLs in\n"
+"free form text is used:\n"
+" - Aggressive tries to find all URLs\n"
+" - Strict requires a protocol identifier (ie http://)\n"
+" - Disabled turns detection off."
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:39
+msgid "Fonts"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:73
+msgid "Line Spacing"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:81
+msgid "Tools"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:133
+msgid "Layout"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:161
+msgid "Fixed Width To Use For Notes"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:162
+msgid "Sets the fixed width size of a note in px"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:167
+msgid "Sort Order For Notebooks"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:172
+msgid "Sort Order For Notes"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:179
+msgid "Files"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:197
+msgid ""
+"The trash folder is set as a hidden folder by default, this option makes it "
+"visible (requires app restart)"
+msgstr ""
 
 #: src/ui/strings.vala:4 src/ui/window/notebooks_bar/notebooks_bar.blp:129
 #: src/ui/window/notebooks_bar/notebooks_bar.blp:171
@@ -492,6 +464,7 @@ msgid "Trash"
 msgstr "Śmieci"
 
 #: src/ui/strings.vala:5
+#, c-format
 msgid "%d Notes"
 msgstr "%d Notatek"
 
@@ -499,7 +472,7 @@ msgstr "%d Notatek"
 msgid "Are you sure you want to delete everything in the trash?"
 msgstr "Jesteś pewien, że chcesz permanentnie usunąć całą zawartość kosza?"
 
-#: src/ui/strings.vala:7 src/ui/window/window.blp:54
+#: src/ui/strings.vala:7 src/ui/window/window.blp:61
 msgid "Empty Trash"
 msgstr "Opróżnij kosz"
 
@@ -536,10 +509,12 @@ msgid "Move"
 msgstr "Przenieś"
 
 #: src/ui/strings.vala:18
+#, c-format
 msgid "Note “%s” already exists in notebook “%s”"
 msgstr "Notatka o nazwie “%s” już istnieje w zeszycie “%s”"
 
 #: src/ui/strings.vala:19
+#, c-format
 msgid "Are you sure you want to delete the note “%s”?"
 msgstr "Jesteś pewien, że chcesz usunąć notatkę o nazwie “%s”?"
 
@@ -548,6 +523,7 @@ msgid "Delete Note"
 msgstr "Usuń notatkę"
 
 #: src/ui/strings.vala:21
+#, c-format
 msgid "Are you sure you want to delete the notebook “%s”?"
 msgstr "Jesteś pewien, że chcesz usunąć zeszyt o nazwie “%s”?"
 
@@ -556,34 +532,42 @@ msgid "Delete Notebook"
 msgstr "Usuń zeszyt"
 
 #: src/ui/strings.vala:24
-msgid "Note name shouldn’t contain “.” or “/”"
+#, fuzzy
+msgid "Note names cannot contain a “/”"
 msgstr "Nazwa notatki nie powinna zawierać takich znaków jak “.” lub “/”"
 
 #: src/ui/strings.vala:25
-msgid "Note name shouldn’t be blank"
+#, fuzzy
+msgid "Note names cannot be blank"
 msgstr "Nazwa notatki nie powinna być pusta"
 
 #: src/ui/strings.vala:26
+#, c-format
 msgid "Note “%s” already exists"
 msgstr "Notatka “%s” już istnieje"
 
 #: src/ui/strings.vala:27
-msgid "Couldn’t create note"
+#, fuzzy
+msgid "Could not create note"
 msgstr "Nie udało się utworzyć notatki"
 
 #: src/ui/strings.vala:28
-msgid "Couldn’t change note"
+#, fuzzy
+msgid "Could not change note"
 msgstr "Nie udało się zmienić notatki"
 
 #: src/ui/strings.vala:29
-msgid "Couldn’t delete note"
+#, fuzzy
+msgid "Could not delete note"
 msgstr "Nie udało się usunąć notatki"
 
 #: src/ui/strings.vala:30
-msgid "Couldn’t restore note"
+#, fuzzy
+msgid "Could not restore note"
 msgstr "Nie udało się przywrócić notatki"
 
 #: src/ui/strings.vala:31
+#, c-format
 msgid "Saved “%s” to “%s”"
 msgstr "Zapisano “%s” w “%s”"
 
@@ -592,27 +576,33 @@ msgid "Unknown error"
 msgstr "Nieznany błąd"
 
 #: src/ui/strings.vala:33
-msgid "Notebook name shouldn’t contain “.” or “/”"
+#, fuzzy
+msgid "Notebook names cannot contain a “/”"
 msgstr "Nazwa zeszytu nie powinna zawierać takich znaków jak “.” lub “/”"
 
 #: src/ui/strings.vala:34
-msgid "Notebook name shouldn’t be blank"
+#, fuzzy
+msgid "Notebook names cannot be blank"
 msgstr "Nazwa zeszytu nie powinna być pusta"
 
 #: src/ui/strings.vala:35
+#, c-format
 msgid "Notebook “%s” already exists"
 msgstr "Zeszyt “%s” już istnieje"
 
 #: src/ui/strings.vala:36
-msgid "Couldn’t create notebook"
+#, fuzzy
+msgid "Could not create notebook"
 msgstr "Nie udało się stworzyć zeszytu"
 
 #: src/ui/strings.vala:37
-msgid "Couldn’t change notebook"
+#, fuzzy
+msgid "Could not change notebook"
 msgstr "Nie udało się zmienić zeszytu"
 
 #: src/ui/strings.vala:38
-msgid "Couldn’t delete notebook"
+#, fuzzy
+msgid "Could not delete notebook"
 msgstr "Nie udało się usunąć zeszytu"
 
 #: src/ui/strings.vala:40
@@ -624,7 +614,7 @@ msgid "Rename"
 msgstr "Zmień nazwę"
 
 #: src/ui/strings.vala:42
-msgid "Couldn’t find an app to handle file URIs"
+msgid "Could not find an app to handle file URIs"
 msgstr ""
 
 #: src/ui/strings.vala:43
@@ -634,6 +624,10 @@ msgstr "Zastosuj"
 #: src/ui/strings.vala:45
 msgid "Pick where the notebooks will be stored"
 msgstr "Wybierz miejsce przechowywania zeszytów"
+
+#: src/ui/strings.vala:46
+msgid "Pick where the trash can will be stored"
+msgstr ""
 
 #: src/ui/strings.vala:47 src/ui/window/notebooks_bar/notebooks_bar.blp:59
 #: src/ui/window/notebooks_bar/notebooks_bar.blp:101
@@ -646,6 +640,110 @@ msgstr ""
 
 #: src/ui/strings.vala:50
 msgid "Extension"
+msgstr ""
+
+#: src/ui/strings.vala:51
+msgid "Unable to recognize URI"
+msgstr ""
+
+#: src/ui/strings.vala:52
+msgid "Pick primary font for notes"
+msgstr ""
+
+#: src/ui/strings.vala:53
+msgid "Pick monospace font for code"
+msgstr ""
+
+#: src/ui/strings.vala:54
+msgid "File Changed On Disk"
+msgstr ""
+
+#: src/ui/strings.vala:55
+msgid ""
+"The file has changed on disk since it was last saved/loaded by Folio.\n"
+"\n"
+"You may do one of the following:\n"
+"\n"
+" • Reload the file (discarding any changes you have made in Folio)\n"
+" • Overwrite the file (discarding any changes made outside of Folio)\n"
+" • Cancel the operation and manually resolve the issue\n"
+"\n"
+"Note: Canceling the save if you have already moved to a new note/notebook "
+"will discard your changes."
+msgstr ""
+
+#: src/ui/strings.vala:56
+msgid "Reload"
+msgstr ""
+
+#: src/ui/strings.vala:57
+msgid "Overwrite"
+msgstr ""
+
+#: src/ui/strings.vala:59
+msgid ""
+"The file has changed on disk by another application.\n"
+"\n"
+"You may do one of the following:\n"
+"\n"
+" • Reload the file (discarding any changes you have made in Folio)\n"
+" • Overwrite the file (discarding any changes made outside of Folio)"
+msgstr ""
+
+#: src/ui/strings.vala:61
+#, c-format
+msgid "Note %i"
+msgstr ""
+
+#: src/ui/strings.vala:62
+msgid "Modified Time - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:63
+msgid "Modified Time - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:64
+msgid "Alphabetical - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:65
+msgid "Alphabetical - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:66
+msgid "Natural - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:67
+msgid "Natural - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:68
+#, c-format
+msgid "Unable to launch external application for file %s."
+msgstr ""
+
+#: src/ui/strings.vala:69
+msgid "Aggressive"
+msgstr ""
+
+#: src/ui/strings.vala:70
+msgid "Strict"
+msgstr ""
+
+#: src/ui/strings.vala:71
+msgid "Disabled"
+msgstr ""
+
+#: src/ui/strings.vala:72
+#, fuzzy, c-format
+msgid "“%s” moved to trash"
+msgstr "Przenieś do Kosza"
+
+#: src/ui/strings.vala:73
+#, c-format
+msgid "“%s” restored"
 msgstr ""
 
 #: src/ui/widgets/theme_selector/theme_selector.blp:15
@@ -677,40 +775,45 @@ msgid "_Keyboard Shortcuts"
 msgstr "_Skróty klawiszowe"
 
 #: src/ui/window/app_menu/app_menu.blp:43
-msgid "_About"
+#, fuzzy
+msgid "_About Folio"
 msgstr "_O programie"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:54
-msgid "Notebook Name"
-msgstr "Nazwa zeszytu"
-
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:66
-msgid "Duplicate notebook names are not allowed!"
-msgstr ""
-
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:82
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:6
 msgid "First Characters"
 msgstr "Pierwsze litery"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:83
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:7
 msgid "Initials"
 msgstr "Inicjały"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:84
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:8
 msgid "Initials: camelCase"
 msgstr "Inicjały: camelCase"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:85
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:9
 msgid "Initials: snake_case"
 msgstr "Inicjały: snake_case"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:86
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:10
 msgid "Icon"
 msgstr "Ikona"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:116
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:11
+msgid "Custom"
+msgstr ""
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:16
 msgid "Notebook Color"
 msgstr "Kolor zeszytu"
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:58
+msgid "Notebook Name"
+msgstr "Nazwa zeszytu"
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:70
+msgid "Duplicate notebook names are not allowed!"
+msgstr ""
 
 #: src/ui/window/notebooks_bar/notebook_create_popup.blp:126
 msgid "Create Notebook"
@@ -728,11 +831,11 @@ msgstr "Przenieś wszystko do Kosza"
 msgid "Notebooks"
 msgstr ""
 
-#: src/ui/window/sidebar/note_create_popup.blp:37
+#: src/ui/window/sidebar/note_create_popup.blp:25
 msgid "Note Name"
 msgstr "Nazwa notatki"
 
-#: src/ui/window/sidebar/note_create_popup.blp:45
+#: src/ui/window/sidebar/note_create_popup.blp:33
 msgid "Create Note"
 msgstr "Utwórz notatkę"
 
@@ -756,30 +859,37 @@ msgstr "Przenieś do Kosza"
 msgid "Open Containing Folder"
 msgstr "Pokaż plik w folderze"
 
-#: src/ui/window/window.blp:118
+#: src/ui/window/window.blp:123
 msgid "Get started writing"
 msgstr "Zacznij pisać"
 
-#: src/ui/window/window.blp:143
+#: src/ui/window/window.blp:152
+msgid "Open file in external application"
+msgstr ""
+
+#: src/ui/window/window.blp:160
+msgid "Open file"
+msgstr ""
+
+#: src/ui/window/window.blp:181
 msgid "Create a notebook"
 msgstr "Utwórz zeszyt"
 
-#: src/ui/window/window.blp:168
+#: src/ui/window/window.blp:210
 msgid "Trash is empty"
 msgstr "Kosz jest pusty"
 
-#: src/ui/window/window.blp:224
-msgid "Back"
-msgstr "Powrót"
-
-#: src/ui/window/window.blp:239
+#: src/ui/window/window.blp:285
 msgid "Open in Notebook"
 msgstr "Otwórz w zeszycie"
 
-#: src/ui/window/window.blp:264
+#: src/ui/window/window.blp:312
 msgid "_Rename Note"
 msgstr "_Zmień nazwę notatki"
 
-#: src/ui/window/window.blp:270
+#: src/ui/window/window.blp:319
 msgid "_Export Note"
 msgstr "_Eksportuj notatkę"
+
+#~ msgid "Back"
+#~ msgstr "Powrót"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -2,244 +2,16 @@
 # This file is distributed under the same license as the Folio package.
 msgid ""
 msgstr ""
+"Project-Id-Version: Folio\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-10-12 16:53+0200\n"
 "PO-Revision-Date: 2024-04-04 03:06:46+0000\n"
+"Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: GlotPress/4.0.0\n"
-"Language: pt_BR\n"
-"Project-Id-Version: Folio\n"
-
-#: data/app.gschema.xml:76
-msgid "Notebook sort order"
-msgstr "Ordem de classificação dos cadernos"
-
-#: data/app.gschema.xml:77
-msgid "The sort order of the notebook list"
-msgstr "A ordem de classificação da lista de cadernos"
-
-#: src/ui/preferences/preferences.blp:145
-msgid "Sort Order For Notebooks"
-msgstr "Ordem de classificação para os cadernos"
-
-#: data/app.gschema.xml:71
-msgid "Note sort order"
-msgstr "Ordem de classificação das notas"
-
-#: data/app.gschema.xml:72
-msgid "The sort order of the note list"
-msgstr "A ordem de classificação da lista de notas"
-
-#: src/ui/preferences/preferences.blp:150
-msgid "Sort Order For Notes"
-msgstr "Ordem de classificação para as notas"
-
-#: src/ui/strings.vala:62
-msgid "Modified Time - Ascending"
-msgstr "Hora de alteração - Ascendente"
-
-#: src/ui/strings.vala:63
-msgid "Modified Time - Descending"
-msgstr "Hora de alteração - Descendente"
-
-#: src/ui/strings.vala:64
-msgid "Alphabetical - Ascending"
-msgstr "Alfabética - Ascendente"
-
-#: src/ui/strings.vala:65
-msgid "Alphabetical - Descending"
-msgstr "Alfabética - Descendente"
-
-#: src/ui/popup/shortcut_window.blp:114
-msgid "Display"
-msgstr "Exibição"
-
-#: src/ui/popup/shortcut_window.blp:117
-msgid "Full Screen"
-msgstr "Tela inteira"
-
-#: src/ui/popup/shortcut_window.blp:122
-msgid "Zoom In"
-msgstr "Ampliar"
-
-#: src/ui/popup/shortcut_window.blp:127
-msgid "Zoom Out"
-msgstr "Reduzir"
-
-#: src/ui/strings.vala:52
-msgid "Pick primary font for notes"
-msgstr "Escolher fonte principal para as notas"
-
-#: src/ui/strings.vala:53
-msgid "Pick monospace font for code"
-msgstr "Escolher fonte monoespaçada para código"
-
-#: src/ui/strings.vala:54
-msgid "File Changed On Disk"
-msgstr "Arquivo alterado no disco"
-
-#: src/ui/strings.vala:55
-msgid ""
-"The file has changed on disk since it was last saved/loaded by Folio.\n"
-"\n"
-"You may do one of the following:\n"
-"\n"
-" • Reload the file (discarding any changes you have made in Folio)\n"
-" • Overwrite the file (discarding any changes made outside of Folio)\n"
-" • Cancel the operation and manually resolve the issue\n"
-"\n"
-"Note: Canceling the save if you have already moved to a new note/notebook will discard your changes."
-msgstr ""
-"O arquivo foi alterado no disco desde a última vez em que foi salvo/carregado pelo Folio.\n"
-"\n"
-"Você pode escolher uma das seguintes opções:\n"
-"\n"
-" • Recarregar o arquivo (descartando quaisquer alterações feitas no Folio)\n"
-" • Sobrescrever o arquivo (descartando quaisquer alterações feitas fora do Folio)\n"
-" • Cancelar a operação e resolver o problema manualmente\n"
-"\n"
-"Nota: Cancelar o salvamento se você já tiver mudado para uma nova nota ou caderno descartará suas alterações."
-
-#: src/ui/strings.vala:56
-msgid "Reload"
-msgstr "Recarregar"
-
-#: src/ui/strings.vala:57
-msgid "Overwrite"
-msgstr "Sobrescrever"
-
-#: src/ui/strings.vala:59
-msgid ""
-"The file has changed on disk by another application.\n"
-"\n"
-"You may do one of the following:\n"
-"\n"
-" • Reload the file (discarding any changes you have made in Folio)\n"
-" • Overwrite the file (discarding any changes made outside of Folio)"
-msgstr ""
-"O arquivo foi alterado no disco por outro aplicativo.\n"
-"\n"
-"Você pode escolher uma das seguintes opções:\n"
-"\n"
-" • Recarregar o arquivo (descartando quaisquer alterações feitas no Folio)\n"
-" • Sobrescrever o arquivo (descartando quaisquer alterações feitas fora do Folio)"
-
-#: src/ui/strings.vala:61
-msgid "Note %i"
-msgstr "Nota %i"
-
-#: data/app.gschema.xml:46 src/ui/preferences/preferences.blp:213
-msgid "Trash Storage Location"
-msgstr "Local de armazenamento da lixeira"
-
-#: data/app.gschema.xml:47 src/ui/preferences/preferences.blp:214
-msgid "Where the trash folder is located (requires app restart)"
-msgstr "Onde a pasta da lixeira está localizada (requer reinício do aplicativo)"
-
-#: src/ui/strings.vala:46
-msgid "Pick where the trash can will be stored"
-msgstr "Escolha onde a lixeira será armazenada"
-
-#: data/app.gschema.xml:16 src/ui/preferences/preferences.blp:128
-msgid "Use Fixed Width For Notes"
-msgstr "Usar largura fixa para as notas"
-
-#: data/app.gschema.xml:17 src/ui/preferences/preferences.blp:129
-msgid "Use a fixed width for the text area of a note"
-msgstr "Usar uma largura fixa para a área de texto de uma nota"
-
-#: data/app.gschema.xml:37 src/ui/preferences/preferences.blp:118
-msgid "Expands the notebook list to include the notebook name"
-msgstr "Expande a lista de cadernos para incluir o nome dos cadernos"
-
-#: data/app.gschema.xml:51 src/ui/preferences/preferences.blp:65
-msgid "Show line numbers"
-msgstr "Mostrar números de linha"
-
-#: data/app.gschema.xml:52 src/ui/preferences/preferences.blp:66
-msgid "Displays line numbers at the left of the note"
-msgstr "Mostra números de linha à esquerda da nota"
-
-#: data/app.gschema.xml:56 src/ui/preferences/preferences.blp:76
-msgid "Show all notes"
-msgstr "Mostrar todas as notas"
-
-#: data/app.gschema.xml:57 src/ui/preferences/preferences.blp:77
-msgid "Displays the \"All Notes\" notebook at the top of the notebook list"
-msgstr "Mostra o caderno \"Todas as notas\" no topo da lista de cadernos"
-
-#: data/app.gschema.xml:61 src/ui/preferences/preferences.blp:163
-msgid "Enable autosave"
-msgstr "Ativar salvamento automático"
-
-#: data/app.gschema.xml:62 src/ui/preferences/preferences.blp:164
-msgid "Automatically saves the current note every 30 seconds if the contents have changed (requires app restart)"
-msgstr "Salva automaticamente a nota atual a cada 30 segundos, se o conteúdo tiver sido alterado (requer reinício do aplicativo)"
-
-#: data/app.gschema.xml:66 src/ui/preferences/preferences.blp:174
-msgid "Don't hide the Trash folder"
-msgstr "Não ocultar a pasta da lixeira"
-
-#: data/app.gschema.xml:67
-msgid "The trash folder is set as a hidden folder by default, this option makes it visible"
-msgstr "A pasta da lixeira é ocultada por padrão; esta opção a torna visível"
-
-#: data/app.metainfo.xml.in:367
-msgid "Main Folio window in light mode"
-msgstr "Janela principal do Folio no tema clato"
-
-#: data/app.metainfo.xml.in:371
-msgid "Main Folio window in dark mode"
-msgstr "Janela principal do Folio no tema escuro"
-
-#: data/app.metainfo.xml.in:375
-msgid "Folio on small/mobile screens"
-msgstr "Folio em telas pequenas/de dispositivos móveis"
-
-#: data/app.metainfo.xml.in:379
-msgid "Folio preferences screen"
-msgstr "Tela de preferências do Folio"
-
-#: data/app.metainfo.xml.in:383
-msgid "Folio in three pane mode"
-msgstr "Folio no modo de três painéis"
-
-#: src/ui/preferences/preferences.blp:59
-msgid "Tools"
-msgstr "Ferramentas"
-
-#: data/app.gschema.xml:27 src/ui/preferences/preferences.blp:88
-msgid "Displays the formatting toolbar at the bottom of the note"
-msgstr "Mostra a barra de ferramentas de formatação na parte de baixo da nota"
-
-#: data/app.gschema.xml:32 src/ui/preferences/preferences.blp:99
-msgid "Adds a button to the markdown reference sheet on the right of the formatting toolbar"
-msgstr "Adiciona um botão à direita da barra de ferramentas de formatação para a folha de referência de Markdown"
-
-#: src/ui/preferences/preferences.blp:111
-msgid "Layout"
-msgstr "Layout"
-
-#: src/ui/preferences/preferences.blp:139
-msgid "Fixed Width To Use For Notes"
-msgstr "Largura fixa a ser usada para as notas"
-
-#: src/ui/preferences/preferences.blp:140
-msgid "Sets the fixed width size of a note in px"
-msgstr "Determina o tamanho da largura fixa de uma nota em pixels (px)"
-
-#: src/ui/preferences/preferences.blp:157
-msgid "Files"
-msgstr "Arquivos"
-
-#: src/ui/preferences/preferences.blp:175
-msgid "The trash folder is set as a hidden folder by default, this option makes it visible (requires app restart)"
-msgstr "A pasta da lixeira é ocultada por padrão; esta opção a torna visível (requer reinício do aplicativo)"
-
-#: src/ui/strings.vala:51
-msgid "Unable to recognize URI"
-msgstr "Não foi possível reconhecer a URI"
 
 #: data/app.desktop.in:9 src/ui/strings.vala:3
 msgid "Folio"
@@ -255,21 +27,23 @@ msgstr "Tome notas"
 
 #: data/app.desktop.in:13
 msgid "Notebook;Note;Notes;Text;Markdown;Notepad;Write;School;Post-it;Sticky;"
-msgstr "Caderno;Nota;Notas;Texto;Markdown;Bloco de Notas;Escrever;Escreva;Escola;Post-it;Lembrete;Adesivo;Cole;"
+msgstr ""
+"Caderno;Nota;Notas;Texto;Markdown;Bloco de Notas;Escrever;Escreva;Escola;"
+"Post-it;Lembrete;Adesivo;Cole;"
 
 #: data/app.desktop.in:22 src/ui/popup/shortcut_window.blp:17
-#: src/ui/strings.vala:8 src/ui/window/window.blp:47
-#: src/ui/window/window.blp:124
+#: src/ui/strings.vala:8 src/ui/window/window.blp:54
+#: src/ui/window/window.blp:131
 msgid "New Note"
 msgstr "Nova nota"
 
 #: data/app.desktop.in:26 src/ui/popup/shortcut_window.blp:37
-#: src/ui/strings.vala:14 src/ui/window/window.blp:149
+#: src/ui/strings.vala:14 src/ui/window/window.blp:189
 msgid "New Notebook"
 msgstr "Novo caderno"
 
-#: data/app.desktop.in:30 src/ui/edit_view/toolbar/toolbar.blp:90
-#: src/ui/strings.vala:39 src/ui/window/window.blp:245
+#: data/app.desktop.in:30 src/ui/edit_view/toolbar/toolbar.blp:92
+#: src/ui/strings.vala:39 src/ui/window/window.blp:291
 msgid "Markdown Cheatsheet"
 msgstr "Dicas de Markdown"
 
@@ -277,25 +51,152 @@ msgstr "Dicas de Markdown"
 msgid "Preferences"
 msgstr "Preferências"
 
-#: data/app.gschema.xml:6 src/ui/preferences/preferences.blp:18
+#: data/app.gschema.xml:6 src/ui/preferences/preferences.blp:45
 msgid "Note Font"
 msgstr "Fonte das notas"
 
-#: data/app.gschema.xml:7 src/ui/preferences/preferences.blp:19
+#: data/app.gschema.xml:7 src/ui/preferences/preferences.blp:46
 msgid "The font notes will be displayed in"
 msgstr "Fonte na qual as notas serão exibidas"
 
-#: data/app.gschema.xml:11 src/ui/preferences/preferences.blp:31
+#: data/app.gschema.xml:11 src/ui/preferences/preferences.blp:58
 msgid "Monospace Font"
 msgstr "Fonte monoespaçada"
 
-#: data/app.gschema.xml:12 src/ui/preferences/preferences.blp:32
+#: data/app.gschema.xml:12 src/ui/preferences/preferences.blp:59
 msgid "The font code will be displayed in"
 msgstr "Fonte na qual trechos de código serão exibidos"
 
-#: data/app.gschema.xml:21 src/ui/preferences/preferences.blp:46
+#: data/app.gschema.xml:16 src/ui/preferences/preferences.blp:150
+msgid "Use Fixed Width For Notes"
+msgstr "Usar largura fixa para as notas"
+
+#: data/app.gschema.xml:17 src/ui/preferences/preferences.blp:151
+msgid "Use a fixed width for the text area of a note"
+msgstr "Usar uma largura fixa para a área de texto de uma nota"
+
+#: data/app.gschema.xml:21 src/ui/preferences/preferences.blp:18
 msgid "OLED Mode"
 msgstr "Modo OLED"
+
+#: data/app.gschema.xml:22 src/ui/preferences/preferences.blp:19
+msgid "Makes the dark theme pitch black"
+msgstr "Torna o tema escuro totalmente preto"
+
+#: data/app.gschema.xml:26 src/ui/preferences/preferences.blp:109
+msgid "Enable Toolbar"
+msgstr "Ativar barra de ferramentas"
+
+#: data/app.gschema.xml:27 src/ui/preferences/preferences.blp:110
+msgid "Displays the formatting toolbar at the bottom of the note"
+msgstr "Mostra a barra de ferramentas de formatação na parte de baixo da nota"
+
+#: data/app.gschema.xml:31 src/ui/preferences/preferences.blp:120
+msgid "Enable Cheatsheet"
+msgstr "Ativar dicas de Markdown"
+
+#: data/app.gschema.xml:32 src/ui/preferences/preferences.blp:121
+msgid ""
+"Adds a button to the markdown reference sheet on the right of the formatting "
+"toolbar"
+msgstr ""
+"Adiciona um botão à direita da barra de ferramentas de formatação para a "
+"folha de referência de Markdown"
+
+#: data/app.gschema.xml:36 src/ui/preferences/preferences.blp:139
+msgid "3-Pane Layout"
+msgstr "Layout de 3 painéis"
+
+#: data/app.gschema.xml:37 src/ui/preferences/preferences.blp:140
+msgid "Expands the notebook list to include the notebook name"
+msgstr "Expande a lista de cadernos para incluir o nome dos cadernos"
+
+#: data/app.gschema.xml:41 src/ui/preferences/preferences.blp:207
+msgid "Notes Storage Location"
+msgstr "Local de armazenamento das notas"
+
+#: data/app.gschema.xml:42 src/ui/preferences/preferences.blp:208
+msgid "Where the notebooks are stored (requires app restart)"
+msgstr "Onde os cadernos são armazenados (requer reinício do aplicativo)"
+
+#: data/app.gschema.xml:46 src/ui/preferences/preferences.blp:235
+msgid "Trash Storage Location"
+msgstr "Local de armazenamento da lixeira"
+
+#: data/app.gschema.xml:47 src/ui/preferences/preferences.blp:236
+msgid "Where the trash folder is located (requires app restart)"
+msgstr ""
+"Onde a pasta da lixeira está localizada (requer reinício do aplicativo)"
+
+#: data/app.gschema.xml:51 src/ui/preferences/preferences.blp:87
+msgid "Show line numbers"
+msgstr "Mostrar números de linha"
+
+#: data/app.gschema.xml:52 src/ui/preferences/preferences.blp:88
+msgid "Displays line numbers at the left of the note"
+msgstr "Mostra números de linha à esquerda da nota"
+
+#: data/app.gschema.xml:56 src/ui/preferences/preferences.blp:98
+msgid "Show all notes"
+msgstr "Mostrar todas as notas"
+
+#: data/app.gschema.xml:57 src/ui/preferences/preferences.blp:99
+msgid "Displays the \"All Notes\" notebook at the top of the notebook list"
+msgstr "Mostra o caderno \"Todas as notas\" no topo da lista de cadernos"
+
+#: data/app.gschema.xml:61 src/ui/preferences/preferences.blp:185
+msgid "Enable autosave"
+msgstr "Ativar salvamento automático"
+
+#: data/app.gschema.xml:62 src/ui/preferences/preferences.blp:186
+msgid ""
+"Automatically saves the current note every 30 seconds if the contents have "
+"changed (requires app restart)"
+msgstr ""
+"Salva automaticamente a nota atual a cada 30 segundos, se o conteúdo tiver "
+"sido alterado (requer reinício do aplicativo)"
+
+#: data/app.gschema.xml:66 src/ui/preferences/preferences.blp:196
+msgid "Don't hide the Trash folder"
+msgstr "Não ocultar a pasta da lixeira"
+
+#: data/app.gschema.xml:67
+msgid ""
+"The trash folder is set as a hidden folder by default, this option makes it "
+"visible"
+msgstr "A pasta da lixeira é ocultada por padrão; esta opção a torna visível"
+
+#: data/app.gschema.xml:71
+msgid "Note sort order"
+msgstr "Ordem de classificação das notas"
+
+#: data/app.gschema.xml:72
+msgid "The sort order of the note list"
+msgstr "A ordem de classificação da lista de notas"
+
+#: data/app.gschema.xml:76
+msgid "Notebook sort order"
+msgstr "Ordem de classificação dos cadernos"
+
+#: data/app.gschema.xml:77
+msgid "The sort order of the notebook list"
+msgstr "A ordem de classificação da lista de cadernos"
+
+#: data/app.gschema.xml:81
+msgid "URL detection level"
+msgstr ""
+
+#: data/app.gschema.xml:82
+msgid "How agressive to look for URLs in markdown text"
+msgstr ""
+
+#: data/app.gschema.xml:86
+msgid "Line spacing"
+msgstr ""
+
+#: data/app.gschema.xml:87 src/ui/preferences/preferences.blp:74
+msgid "The line spacing for the note text"
+msgstr ""
 
 #: data/app.metainfo.xml.in:5
 msgid "Take notes in Markdown"
@@ -329,103 +230,116 @@ msgstr "Tematização do aplicativo com base na cor de cada caderno"
 msgid "Trash can"
 msgstr "Lixeira"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:23
-#: src/ui/edit_view/toolbar/toolbar.blp:131
+#: data/app.metainfo.xml.in:393
+msgid "Main Folio window in light mode"
+msgstr "Janela principal do Folio no tema clato"
+
+#: data/app.metainfo.xml.in:397
+msgid "Main Folio window in dark mode"
+msgstr "Janela principal do Folio no tema escuro"
+
+#: data/app.metainfo.xml.in:401
+msgid "Folio on small/mobile screens"
+msgstr "Folio em telas pequenas/de dispositivos móveis"
+
+#: data/app.metainfo.xml.in:405
+msgid "Folio preferences screen"
+msgstr "Tela de preferências do Folio"
+
+#: data/app.metainfo.xml.in:409
+msgid "Folio in three pane mode"
+msgstr "Folio no modo de três painéis"
+
+#: src/ui/edit_view/toolbar/toolbar.blp:6
 #: src/ui/widgets/markdown/heading_popover.blp:48
 msgid "Plain Text"
 msgstr "Texto puro"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:24
-#: src/ui/edit_view/toolbar/toolbar.blp:132
+#: src/ui/edit_view/toolbar/toolbar.blp:7
 #: src/ui/widgets/markdown/heading_popover.blp:12
 msgid "Heading 1"
 msgstr "Título 1"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:25
-#: src/ui/edit_view/toolbar/toolbar.blp:133
+#: src/ui/edit_view/toolbar/toolbar.blp:8
 #: src/ui/widgets/markdown/heading_popover.blp:18
 msgid "Heading 2"
 msgstr "Título 2"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:26
-#: src/ui/edit_view/toolbar/toolbar.blp:134
+#: src/ui/edit_view/toolbar/toolbar.blp:9
 #: src/ui/widgets/markdown/heading_popover.blp:24
 msgid "Heading 3"
 msgstr "Título 3"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:27
-#: src/ui/edit_view/toolbar/toolbar.blp:135
+#: src/ui/edit_view/toolbar/toolbar.blp:10
 #: src/ui/widgets/markdown/heading_popover.blp:30
 msgid "Heading 4"
 msgstr "Título 4"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:28
-#: src/ui/edit_view/toolbar/toolbar.blp:136
+#: src/ui/edit_view/toolbar/toolbar.blp:11
 #: src/ui/widgets/markdown/heading_popover.blp:36
 msgid "Heading 5"
 msgstr "Título 5"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:29
-#: src/ui/edit_view/toolbar/toolbar.blp:137
+#: src/ui/edit_view/toolbar/toolbar.blp:12
 #: src/ui/widgets/markdown/heading_popover.blp:42
 msgid "Heading 6"
 msgstr "Título 6"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:39
-#: src/ui/edit_view/toolbar/toolbar.blp:104
-#: src/ui/edit_view/toolbar/toolbar.blp:148
-#: src/ui/edit_view/toolbar/toolbar.blp:201 src/ui/popup/shortcut_window.blp:72
+#: src/ui/edit_view/toolbar/toolbar.blp:41
+#: src/ui/edit_view/toolbar/toolbar.blp:107
+#: src/ui/edit_view/toolbar/toolbar.blp:142
+#: src/ui/edit_view/toolbar/toolbar.blp:195 src/ui/popup/shortcut_window.blp:72
 msgid "Bold"
 msgstr "Negrito"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:45
-#: src/ui/edit_view/toolbar/toolbar.blp:111
-#: src/ui/edit_view/toolbar/toolbar.blp:155
-#: src/ui/edit_view/toolbar/toolbar.blp:202 src/ui/popup/shortcut_window.blp:77
+#: src/ui/edit_view/toolbar/toolbar.blp:47
+#: src/ui/edit_view/toolbar/toolbar.blp:114
+#: src/ui/edit_view/toolbar/toolbar.blp:149
+#: src/ui/edit_view/toolbar/toolbar.blp:196 src/ui/popup/shortcut_window.blp:77
 msgid "Italic"
 msgstr "Itálico"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:51
-#: src/ui/edit_view/toolbar/toolbar.blp:162
-#: src/ui/edit_view/toolbar/toolbar.blp:203 src/ui/popup/shortcut_window.blp:82
+#: src/ui/edit_view/toolbar/toolbar.blp:53
+#: src/ui/edit_view/toolbar/toolbar.blp:156
+#: src/ui/edit_view/toolbar/toolbar.blp:197 src/ui/popup/shortcut_window.blp:82
 msgid "Strikethrough"
 msgstr "Tachado"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:57
-#: src/ui/edit_view/toolbar/toolbar.blp:169
-#: src/ui/edit_view/toolbar/toolbar.blp:204 src/ui/popup/shortcut_window.blp:87
+#: src/ui/edit_view/toolbar/toolbar.blp:59
+#: src/ui/edit_view/toolbar/toolbar.blp:163
+#: src/ui/edit_view/toolbar/toolbar.blp:198 src/ui/popup/shortcut_window.blp:87
 msgid "Highlight"
 msgstr "Destacado"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:67
-#: src/ui/edit_view/toolbar/toolbar.blp:193 src/ui/popup/shortcut_window.blp:92
+#: src/ui/edit_view/toolbar/toolbar.blp:69
+#: src/ui/edit_view/toolbar/toolbar.blp:187 src/ui/popup/shortcut_window.blp:92
 msgid "Insert Link"
 msgstr "Inserir link"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:73
-#: src/ui/edit_view/toolbar/toolbar.blp:194
+#: src/ui/edit_view/toolbar/toolbar.blp:75
+#: src/ui/edit_view/toolbar/toolbar.blp:188
 msgid "Insert Code"
 msgstr "Inserir código"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:79
-#: src/ui/edit_view/toolbar/toolbar.blp:195
+#: src/ui/edit_view/toolbar/toolbar.blp:81
+#: src/ui/edit_view/toolbar/toolbar.blp:189
 msgid "Insert Horizontal Rule"
 msgstr "Inserir linha horizontal"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:118
+#: src/ui/edit_view/toolbar/toolbar.blp:121
 msgid "Format"
 msgstr "Formatar"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:181
+#: src/ui/edit_view/toolbar/toolbar.blp:175
 msgid "Insert"
 msgstr "Inserir"
 
-#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:34
+#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:18
 #: src/ui/strings.vala:44 src/ui/strings.vala:58
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:39
+#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:23
 msgid "Confirm"
 msgstr "Confirmar"
 
@@ -469,37 +383,87 @@ msgstr "Formatação"
 msgid "Navigation"
 msgstr "Navegação"
 
-#: src/ui/popup/shortcut_window.blp:102 src/ui/window/window.blp:216
+#: src/ui/popup/shortcut_window.blp:102 src/ui/window/window.blp:268
 msgid "Toggle Sidebar"
 msgstr "Mostrar/Ocultar barra lateral"
 
-#: src/ui/popup/shortcut_window.blp:107 src/ui/window/window.blp:63
+#: src/ui/popup/shortcut_window.blp:107 src/ui/window/window.blp:70
 msgid "Search Notes"
 msgstr "Buscar nas notas"
 
-#: data/app.gschema.xml:22 src/ui/preferences/preferences.blp:47
-msgid "Makes the dark theme pitch black"
-msgstr "Torna o tema escuro totalmente preto"
+#: src/ui/popup/shortcut_window.blp:114
+msgid "Display"
+msgstr "Exibição"
 
-#: data/app.gschema.xml:26 src/ui/preferences/preferences.blp:87
-msgid "Enable Toolbar"
-msgstr "Ativar barra de ferramentas"
+#: src/ui/popup/shortcut_window.blp:117
+msgid "Full Screen"
+msgstr "Tela inteira"
 
-#: data/app.gschema.xml:31 src/ui/preferences/preferences.blp:98
-msgid "Enable Cheatsheet"
-msgstr "Ativar dicas de Markdown"
+#: src/ui/popup/shortcut_window.blp:122
+msgid "Zoom In"
+msgstr "Ampliar"
 
-#: data/app.gschema.xml:36 src/ui/preferences/preferences.blp:117
-msgid "3-Pane Layout"
-msgstr "Layout de 3 painéis"
+#: src/ui/popup/shortcut_window.blp:127
+msgid "Zoom Out"
+msgstr "Reduzir"
 
-#: data/app.gschema.xml:41 src/ui/preferences/preferences.blp:185
-msgid "Notes Storage Location"
-msgstr "Local de armazenamento das notas"
+#: src/ui/preferences/preferences.blp:31
+#, fuzzy
+msgid "Markdown URL Detection"
+msgstr "Dicas de Markdown"
 
-#: data/app.gschema.xml:42 src/ui/preferences/preferences.blp:186
-msgid "Where the notebooks are stored (requires app restart)"
-msgstr "Onde os cadernos são armazenados (requer reinício do aplicativo)"
+#: src/ui/preferences/preferences.blp:32
+msgid ""
+"Determines the level of detection of URLs in\n"
+"free form text is used:\n"
+" - Aggressive tries to find all URLs\n"
+" - Strict requires a protocol identifier (ie http://)\n"
+" - Disabled turns detection off."
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:39
+msgid "Fonts"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:73
+msgid "Line Spacing"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:81
+msgid "Tools"
+msgstr "Ferramentas"
+
+#: src/ui/preferences/preferences.blp:133
+msgid "Layout"
+msgstr "Layout"
+
+#: src/ui/preferences/preferences.blp:161
+msgid "Fixed Width To Use For Notes"
+msgstr "Largura fixa a ser usada para as notas"
+
+#: src/ui/preferences/preferences.blp:162
+msgid "Sets the fixed width size of a note in px"
+msgstr "Determina o tamanho da largura fixa de uma nota em pixels (px)"
+
+#: src/ui/preferences/preferences.blp:167
+msgid "Sort Order For Notebooks"
+msgstr "Ordem de classificação para os cadernos"
+
+#: src/ui/preferences/preferences.blp:172
+msgid "Sort Order For Notes"
+msgstr "Ordem de classificação para as notas"
+
+#: src/ui/preferences/preferences.blp:179
+msgid "Files"
+msgstr "Arquivos"
+
+#: src/ui/preferences/preferences.blp:197
+msgid ""
+"The trash folder is set as a hidden folder by default, this option makes it "
+"visible (requires app restart)"
+msgstr ""
+"A pasta da lixeira é ocultada por padrão; esta opção a torna visível (requer "
+"reinício do aplicativo)"
 
 #: src/ui/strings.vala:4 src/ui/window/notebooks_bar/notebooks_bar.blp:129
 #: src/ui/window/notebooks_bar/notebooks_bar.blp:171
@@ -507,6 +471,7 @@ msgid "Trash"
 msgstr "Lixeira"
 
 #: src/ui/strings.vala:5
+#, c-format
 msgid "%d Notes"
 msgstr "%d notas"
 
@@ -514,7 +479,7 @@ msgstr "%d notas"
 msgid "Are you sure you want to delete everything in the trash?"
 msgstr "Tem certeza de que deseja apagar tudo da Lixeira?"
 
-#: src/ui/strings.vala:7 src/ui/window/window.blp:54
+#: src/ui/strings.vala:7 src/ui/window/window.blp:61
 msgid "Empty Trash"
 msgstr "Esvaziar lixeira"
 
@@ -551,10 +516,12 @@ msgid "Move"
 msgstr "Mover"
 
 #: src/ui/strings.vala:18
+#, c-format
 msgid "Note “%s” already exists in notebook “%s”"
 msgstr "A nota “%s” já existe no caderno “%s”"
 
 #: src/ui/strings.vala:19
+#, c-format
 msgid "Are you sure you want to delete the note “%s”?"
 msgstr "Tem certeza de que deseja apagar a nota “%s”?"
 
@@ -563,6 +530,7 @@ msgid "Delete Note"
 msgstr "Apagar nota"
 
 #: src/ui/strings.vala:21
+#, c-format
 msgid "Are you sure you want to delete the notebook “%s”?"
 msgstr "Tem certeza de que deseja apagar o caderno “%s”?"
 
@@ -571,34 +539,42 @@ msgid "Delete Notebook"
 msgstr "Apagar caderno"
 
 #: src/ui/strings.vala:24
-msgid "Note name shouldn’t contain “.” or “/”"
+#, fuzzy
+msgid "Note names cannot contain a “/”"
 msgstr "O nome da nota não deve conter “.” ou “/”"
 
 #: src/ui/strings.vala:25
-msgid "Note name shouldn’t be blank"
+#, fuzzy
+msgid "Note names cannot be blank"
 msgstr "O nome da nota não deve ficar em branco"
 
 #: src/ui/strings.vala:26
+#, c-format
 msgid "Note “%s” already exists"
 msgstr "A nota “%s” já existe"
 
 #: src/ui/strings.vala:27
-msgid "Couldn’t create note"
+#, fuzzy
+msgid "Could not create note"
 msgstr "Não foi possível criar a nota"
 
 #: src/ui/strings.vala:28
-msgid "Couldn’t change note"
+#, fuzzy
+msgid "Could not change note"
 msgstr "Não foi possível alterar a nota"
 
 #: src/ui/strings.vala:29
-msgid "Couldn’t delete note"
+#, fuzzy
+msgid "Could not delete note"
 msgstr "Não foi possível apagar a nota"
 
 #: src/ui/strings.vala:30
-msgid "Couldn’t restore note"
+#, fuzzy
+msgid "Could not restore note"
 msgstr "Não foi possível restaurar a nota"
 
 #: src/ui/strings.vala:31
+#, c-format
 msgid "Saved “%s” to “%s”"
 msgstr "“%s” salvo em “%s”"
 
@@ -607,27 +583,33 @@ msgid "Unknown error"
 msgstr "Erro desconhecido"
 
 #: src/ui/strings.vala:33
-msgid "Notebook name shouldn’t contain “.” or “/”"
+#, fuzzy
+msgid "Notebook names cannot contain a “/”"
 msgstr "O nome do caderno não deve conter “.” ou “/”"
 
 #: src/ui/strings.vala:34
-msgid "Notebook name shouldn’t be blank"
+#, fuzzy
+msgid "Notebook names cannot be blank"
 msgstr "O nome do caderno não deve ficar em branco"
 
 #: src/ui/strings.vala:35
+#, c-format
 msgid "Notebook “%s” already exists"
 msgstr "O caderno “%s” já existe"
 
 #: src/ui/strings.vala:36
-msgid "Couldn’t create notebook"
+#, fuzzy
+msgid "Could not create notebook"
 msgstr "Não foi possível criar o caderno"
 
 #: src/ui/strings.vala:37
-msgid "Couldn’t change notebook"
+#, fuzzy
+msgid "Could not change notebook"
 msgstr "Não foi possível alterar o caderno"
 
 #: src/ui/strings.vala:38
-msgid "Couldn’t delete notebook"
+#, fuzzy
+msgid "Could not delete notebook"
 msgstr "Não foi possível excluir o caderno"
 
 #: src/ui/strings.vala:40
@@ -639,8 +621,10 @@ msgid "Rename"
 msgstr "Renomear"
 
 #: src/ui/strings.vala:42
-msgid "Couldn’t find an app to handle file URIs"
-msgstr "Não foi possível encontrar um aplicativo para lidar com URIs de arquivo"
+#, fuzzy
+msgid "Could not find an app to handle file URIs"
+msgstr ""
+"Não foi possível encontrar um aplicativo para lidar com URIs de arquivo"
 
 #: src/ui/strings.vala:43
 msgid "Apply"
@@ -649,6 +633,10 @@ msgstr "Aplicar"
 #: src/ui/strings.vala:45
 msgid "Pick where the notebooks will be stored"
 msgstr "Escolha onde os cadernos serão armazenados"
+
+#: src/ui/strings.vala:46
+msgid "Pick where the trash can will be stored"
+msgstr "Escolha onde a lixeira será armazenada"
 
 #: src/ui/strings.vala:47 src/ui/window/notebooks_bar/notebooks_bar.blp:59
 #: src/ui/window/notebooks_bar/notebooks_bar.blp:101
@@ -662,6 +650,131 @@ msgstr "Modificado pela última vez"
 #: src/ui/strings.vala:50
 msgid "Extension"
 msgstr "Extensão"
+
+#: src/ui/strings.vala:51
+msgid "Unable to recognize URI"
+msgstr "Não foi possível reconhecer a URI"
+
+#: src/ui/strings.vala:52
+msgid "Pick primary font for notes"
+msgstr "Escolher fonte principal para as notas"
+
+#: src/ui/strings.vala:53
+msgid "Pick monospace font for code"
+msgstr "Escolher fonte monoespaçada para código"
+
+#: src/ui/strings.vala:54
+msgid "File Changed On Disk"
+msgstr "Arquivo alterado no disco"
+
+#: src/ui/strings.vala:55
+msgid ""
+"The file has changed on disk since it was last saved/loaded by Folio.\n"
+"\n"
+"You may do one of the following:\n"
+"\n"
+" • Reload the file (discarding any changes you have made in Folio)\n"
+" • Overwrite the file (discarding any changes made outside of Folio)\n"
+" • Cancel the operation and manually resolve the issue\n"
+"\n"
+"Note: Canceling the save if you have already moved to a new note/notebook "
+"will discard your changes."
+msgstr ""
+"O arquivo foi alterado no disco desde a última vez em que foi salvo/"
+"carregado pelo Folio.\n"
+"\n"
+"Você pode escolher uma das seguintes opções:\n"
+"\n"
+" • Recarregar o arquivo (descartando quaisquer alterações feitas no Folio)\n"
+" • Sobrescrever o arquivo (descartando quaisquer alterações feitas fora do "
+"Folio)\n"
+" • Cancelar a operação e resolver o problema manualmente\n"
+"\n"
+"Nota: Cancelar o salvamento se você já tiver mudado para uma nova nota ou "
+"caderno descartará suas alterações."
+
+#: src/ui/strings.vala:56
+msgid "Reload"
+msgstr "Recarregar"
+
+#: src/ui/strings.vala:57
+msgid "Overwrite"
+msgstr "Sobrescrever"
+
+#: src/ui/strings.vala:59
+msgid ""
+"The file has changed on disk by another application.\n"
+"\n"
+"You may do one of the following:\n"
+"\n"
+" • Reload the file (discarding any changes you have made in Folio)\n"
+" • Overwrite the file (discarding any changes made outside of Folio)"
+msgstr ""
+"O arquivo foi alterado no disco por outro aplicativo.\n"
+"\n"
+"Você pode escolher uma das seguintes opções:\n"
+"\n"
+" • Recarregar o arquivo (descartando quaisquer alterações feitas no Folio)\n"
+" • Sobrescrever o arquivo (descartando quaisquer alterações feitas fora do "
+"Folio)"
+
+#: src/ui/strings.vala:61
+#, c-format
+msgid "Note %i"
+msgstr "Nota %i"
+
+#: src/ui/strings.vala:62
+msgid "Modified Time - Ascending"
+msgstr "Hora de alteração - Ascendente"
+
+#: src/ui/strings.vala:63
+msgid "Modified Time - Descending"
+msgstr "Hora de alteração - Descendente"
+
+#: src/ui/strings.vala:64
+msgid "Alphabetical - Ascending"
+msgstr "Alfabética - Ascendente"
+
+#: src/ui/strings.vala:65
+msgid "Alphabetical - Descending"
+msgstr "Alfabética - Descendente"
+
+#: src/ui/strings.vala:66
+#, fuzzy
+msgid "Natural - Ascending"
+msgstr "Alfabética - Ascendente"
+
+#: src/ui/strings.vala:67
+#, fuzzy
+msgid "Natural - Descending"
+msgstr "Alfabética - Descendente"
+
+#: src/ui/strings.vala:68
+#, c-format
+msgid "Unable to launch external application for file %s."
+msgstr ""
+
+#: src/ui/strings.vala:69
+msgid "Aggressive"
+msgstr ""
+
+#: src/ui/strings.vala:70
+msgid "Strict"
+msgstr ""
+
+#: src/ui/strings.vala:71
+msgid "Disabled"
+msgstr ""
+
+#: src/ui/strings.vala:72
+#, fuzzy, c-format
+msgid "“%s” moved to trash"
+msgstr "Mover para a lixeira"
+
+#: src/ui/strings.vala:73
+#, c-format
+msgid "“%s” restored"
+msgstr ""
 
 #: src/ui/widgets/theme_selector/theme_selector.blp:15
 msgid "Follow system style"
@@ -692,40 +805,45 @@ msgid "_Keyboard Shortcuts"
 msgstr "_Teclas de atalho"
 
 #: src/ui/window/app_menu/app_menu.blp:43
-msgid "_About"
+#, fuzzy
+msgid "_About Folio"
 msgstr "_Sobre o Paper"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:54
-msgid "Notebook Name"
-msgstr "Nome do caderno"
-
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:66
-msgid "Duplicate notebook names are not allowed!"
-msgstr "Nomes duplicados de cadernos não são permitidos!"
-
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:82
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:6
 msgid "First Characters"
 msgstr "Primeiros Caracteres"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:83
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:7
 msgid "Initials"
 msgstr "Iniciais"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:84
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:8
 msgid "Initials: camelCase"
 msgstr "Iniciais: camelCase"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:85
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:9
 msgid "Initials: snake_case"
 msgstr "Iniciais: snake_case"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:86
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:10
 msgid "Icon"
 msgstr "Ícone"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:116
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:11
+msgid "Custom"
+msgstr ""
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:16
 msgid "Notebook Color"
 msgstr "Cor do caderno"
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:58
+msgid "Notebook Name"
+msgstr "Nome do caderno"
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:70
+msgid "Duplicate notebook names are not allowed!"
+msgstr "Nomes duplicados de cadernos não são permitidos!"
 
 #: src/ui/window/notebooks_bar/notebook_create_popup.blp:126
 msgid "Create Notebook"
@@ -743,11 +861,11 @@ msgstr "Mover tudo para a lixeira"
 msgid "Notebooks"
 msgstr "Cadernos"
 
-#: src/ui/window/sidebar/note_create_popup.blp:37
+#: src/ui/window/sidebar/note_create_popup.blp:25
 msgid "Note Name"
 msgstr "Nome da nota"
 
-#: src/ui/window/sidebar/note_create_popup.blp:45
+#: src/ui/window/sidebar/note_create_popup.blp:33
 msgid "Create Note"
 msgstr "Criar nota"
 
@@ -771,30 +889,37 @@ msgstr "Mover para a lixeira"
 msgid "Open Containing Folder"
 msgstr "Abrir diretório de armazenamento"
 
-#: src/ui/window/window.blp:118
+#: src/ui/window/window.blp:123
 msgid "Get started writing"
 msgstr "Comece a escrever"
 
-#: src/ui/window/window.blp:143
+#: src/ui/window/window.blp:152
+msgid "Open file in external application"
+msgstr ""
+
+#: src/ui/window/window.blp:160
+msgid "Open file"
+msgstr ""
+
+#: src/ui/window/window.blp:181
 msgid "Create a notebook"
 msgstr "Crie um caderno"
 
-#: src/ui/window/window.blp:168
+#: src/ui/window/window.blp:210
 msgid "Trash is empty"
 msgstr "A lixeira está vazia"
 
-#: src/ui/window/window.blp:224
-msgid "Back"
-msgstr "Voltar"
-
-#: src/ui/window/window.blp:239
+#: src/ui/window/window.blp:285
 msgid "Open in Notebook"
 msgstr "Abrir no caderno"
 
-#: src/ui/window/window.blp:264
+#: src/ui/window/window.blp:312
 msgid "_Rename Note"
 msgstr "_Renomear nota"
 
-#: src/ui/window/window.blp:270
+#: src/ui/window/window.blp:319
 msgid "_Export Note"
 msgstr "_Exportar nota"
+
+#~ msgid "Back"
+#~ msgstr "Voltar"

--- a/po/ru.po
+++ b/po/ru.po
@@ -2,229 +2,17 @@
 # This file is distributed under the same license as the Folio package.
 msgid ""
 msgstr ""
+"Project-Id-Version: Folio\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-10-12 16:53+0200\n"
 "PO-Revision-Date: 2024-03-02 17:00:09+0000\n"
+"Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n % 10 == 1 && n % 100 != 11) ? 0 : ((n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % 100 > 14)) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n % 10 == 1 && n % 100 != 11) ? 0 : ((n % "
+"10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % 100 > 14)) ? 1 : 2);\n"
 "X-Generator: GlotPress/4.0.0\n"
-"Language: ru\n"
-"Project-Id-Version: Folio\n"
-
-#: data/app.gschema.xml:76
-msgid "Notebook sort order"
-msgstr ""
-
-#: data/app.gschema.xml:77
-msgid "The sort order of the notebook list"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:145
-msgid "Sort Order For Notebooks"
-msgstr ""
-
-#: data/app.gschema.xml:71
-msgid "Note sort order"
-msgstr ""
-
-#: data/app.gschema.xml:72
-msgid "The sort order of the note list"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:150
-msgid "Sort Order For Notes"
-msgstr ""
-
-#: src/ui/strings.vala:62
-msgid "Modified Time - Ascending"
-msgstr ""
-
-#: src/ui/strings.vala:63
-msgid "Modified Time - Descending"
-msgstr ""
-
-#: src/ui/strings.vala:64
-msgid "Alphabetical - Ascending"
-msgstr ""
-
-#: src/ui/strings.vala:65
-msgid "Alphabetical - Descending"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:114
-msgid "Display"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:117
-msgid "Full Screen"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:122
-msgid "Zoom In"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:127
-msgid "Zoom Out"
-msgstr ""
-
-#: src/ui/strings.vala:52
-msgid "Pick primary font for notes"
-msgstr ""
-
-#: src/ui/strings.vala:53
-msgid "Pick monospace font for code"
-msgstr ""
-
-#: src/ui/strings.vala:54
-msgid "File Changed On Disk"
-msgstr ""
-
-#: src/ui/strings.vala:55
-msgid ""
-"The file has changed on disk since it was last saved/loaded by Folio.\n"
-"\n"
-"You may do one of the following:\n"
-"\n"
-" • Reload the file (discarding any changes you have made in Folio)\n"
-" • Overwrite the file (discarding any changes made outside of Folio)\n"
-" • Cancel the operation and manually resolve the issue\n"
-"\n"
-"Note: Canceling the save if you have already moved to a new note/notebook will discard your changes."
-msgstr ""
-
-#: src/ui/strings.vala:56
-msgid "Reload"
-msgstr ""
-
-#: src/ui/strings.vala:57
-msgid "Overwrite"
-msgstr ""
-
-#: src/ui/strings.vala:59
-msgid ""
-"The file has changed on disk by another application.\n"
-"\n"
-"You may do one of the following:\n"
-"\n"
-" • Reload the file (discarding any changes you have made in Folio)\n"
-" • Overwrite the file (discarding any changes made outside of Folio)"
-msgstr ""
-
-#: src/ui/strings.vala:61
-msgid "Note %i"
-msgstr ""
-
-#: data/app.gschema.xml:46 src/ui/preferences/preferences.blp:213
-msgid "Trash Storage Location"
-msgstr ""
-
-#: data/app.gschema.xml:47 src/ui/preferences/preferences.blp:214
-msgid "Where the trash folder is located (requires app restart)"
-msgstr ""
-
-#: src/ui/strings.vala:46
-msgid "Pick where the trash can will be stored"
-msgstr ""
-
-#: data/app.gschema.xml:16 src/ui/preferences/preferences.blp:128
-msgid "Use Fixed Width For Notes"
-msgstr ""
-
-#: data/app.gschema.xml:17 src/ui/preferences/preferences.blp:129
-msgid "Use a fixed width for the text area of a note"
-msgstr ""
-
-#: data/app.gschema.xml:37 src/ui/preferences/preferences.blp:118
-msgid "Expands the notebook list to include the notebook name"
-msgstr ""
-
-#: data/app.gschema.xml:51 src/ui/preferences/preferences.blp:65
-msgid "Show line numbers"
-msgstr ""
-
-#: data/app.gschema.xml:52 src/ui/preferences/preferences.blp:66
-msgid "Displays line numbers at the left of the note"
-msgstr ""
-
-#: data/app.gschema.xml:56 src/ui/preferences/preferences.blp:76
-msgid "Show all notes"
-msgstr ""
-
-#: data/app.gschema.xml:57 src/ui/preferences/preferences.blp:77
-msgid "Displays the \"All Notes\" notebook at the top of the notebook list"
-msgstr ""
-
-#: data/app.gschema.xml:61 src/ui/preferences/preferences.blp:163
-msgid "Enable autosave"
-msgstr ""
-
-#: data/app.gschema.xml:62 src/ui/preferences/preferences.blp:164
-msgid "Automatically saves the current note every 30 seconds if the contents have changed (requires app restart)"
-msgstr ""
-
-#: data/app.gschema.xml:66 src/ui/preferences/preferences.blp:174
-msgid "Don't hide the Trash folder"
-msgstr ""
-
-#: data/app.gschema.xml:67
-msgid "The trash folder is set as a hidden folder by default, this option makes it visible"
-msgstr ""
-
-#: data/app.metainfo.xml.in:367
-msgid "Main Folio window in light mode"
-msgstr ""
-
-#: data/app.metainfo.xml.in:371
-msgid "Main Folio window in dark mode"
-msgstr ""
-
-#: data/app.metainfo.xml.in:375
-msgid "Folio on small/mobile screens"
-msgstr ""
-
-#: data/app.metainfo.xml.in:379
-msgid "Folio preferences screen"
-msgstr ""
-
-#: data/app.metainfo.xml.in:383
-msgid "Folio in three pane mode"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:59
-msgid "Tools"
-msgstr ""
-
-#: data/app.gschema.xml:27 src/ui/preferences/preferences.blp:88
-msgid "Displays the formatting toolbar at the bottom of the note"
-msgstr ""
-
-#: data/app.gschema.xml:32 src/ui/preferences/preferences.blp:99
-msgid "Adds a button to the markdown reference sheet on the right of the formatting toolbar"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:111
-msgid "Layout"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:139
-msgid "Fixed Width To Use For Notes"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:140
-msgid "Sets the fixed width size of a note in px"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:157
-msgid "Files"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:175
-msgid "The trash folder is set as a hidden folder by default, this option makes it visible (requires app restart)"
-msgstr ""
-
-#: src/ui/strings.vala:51
-msgid "Unable to recognize URI"
-msgstr ""
 
 #: data/app.desktop.in:9 src/ui/strings.vala:3
 msgid "Folio"
@@ -243,18 +31,18 @@ msgid "Notebook;Note;Notes;Text;Markdown;Notepad;Write;School;Post-it;Sticky;"
 msgstr "Блокнот;Заметка;Заметки;Текст;Markdown;Писать;Школа;Пости-это;"
 
 #: data/app.desktop.in:22 src/ui/popup/shortcut_window.blp:17
-#: src/ui/strings.vala:8 src/ui/window/window.blp:47
-#: src/ui/window/window.blp:124
+#: src/ui/strings.vala:8 src/ui/window/window.blp:54
+#: src/ui/window/window.blp:131
 msgid "New Note"
 msgstr "Новая заметка"
 
 #: data/app.desktop.in:26 src/ui/popup/shortcut_window.blp:37
-#: src/ui/strings.vala:14 src/ui/window/window.blp:149
+#: src/ui/strings.vala:14 src/ui/window/window.blp:189
 msgid "New Notebook"
 msgstr "Новый блокнот"
 
-#: data/app.desktop.in:30 src/ui/edit_view/toolbar/toolbar.blp:90
-#: src/ui/strings.vala:39 src/ui/window/window.blp:245
+#: data/app.desktop.in:30 src/ui/edit_view/toolbar/toolbar.blp:92
+#: src/ui/strings.vala:39 src/ui/window/window.blp:291
 msgid "Markdown Cheatsheet"
 msgstr "Шпаргалка Markdown"
 
@@ -262,25 +50,147 @@ msgstr "Шпаргалка Markdown"
 msgid "Preferences"
 msgstr "Параметры"
 
-#: data/app.gschema.xml:6 src/ui/preferences/preferences.blp:18
+#: data/app.gschema.xml:6 src/ui/preferences/preferences.blp:45
 msgid "Note Font"
 msgstr "Шрифт заметок"
 
-#: data/app.gschema.xml:7 src/ui/preferences/preferences.blp:19
+#: data/app.gschema.xml:7 src/ui/preferences/preferences.blp:46
 msgid "The font notes will be displayed in"
 msgstr "Шрифт, которым будут отображатся заметки"
 
-#: data/app.gschema.xml:11 src/ui/preferences/preferences.blp:31
+#: data/app.gschema.xml:11 src/ui/preferences/preferences.blp:58
 msgid "Monospace Font"
 msgstr "Шрифт кода"
 
-#: data/app.gschema.xml:12 src/ui/preferences/preferences.blp:32
+#: data/app.gschema.xml:12 src/ui/preferences/preferences.blp:59
 msgid "The font code will be displayed in"
 msgstr "Шрифт, которым будет отображатся код"
 
-#: data/app.gschema.xml:21 src/ui/preferences/preferences.blp:46
+#: data/app.gschema.xml:16 src/ui/preferences/preferences.blp:150
+msgid "Use Fixed Width For Notes"
+msgstr ""
+
+#: data/app.gschema.xml:17 src/ui/preferences/preferences.blp:151
+msgid "Use a fixed width for the text area of a note"
+msgstr ""
+
+#: data/app.gschema.xml:21 src/ui/preferences/preferences.blp:18
 msgid "OLED Mode"
 msgstr "Режим OLED"
+
+#: data/app.gschema.xml:22 src/ui/preferences/preferences.blp:19
+msgid "Makes the dark theme pitch black"
+msgstr "Делает тёмную тему чёрной как смоль"
+
+#: data/app.gschema.xml:26 src/ui/preferences/preferences.blp:109
+msgid "Enable Toolbar"
+msgstr "Включить панель инструментов"
+
+#: data/app.gschema.xml:27 src/ui/preferences/preferences.blp:110
+msgid "Displays the formatting toolbar at the bottom of the note"
+msgstr ""
+
+#: data/app.gschema.xml:31 src/ui/preferences/preferences.blp:120
+msgid "Enable Cheatsheet"
+msgstr ""
+
+#: data/app.gschema.xml:32 src/ui/preferences/preferences.blp:121
+msgid ""
+"Adds a button to the markdown reference sheet on the right of the formatting "
+"toolbar"
+msgstr ""
+
+#: data/app.gschema.xml:36 src/ui/preferences/preferences.blp:139
+msgid "3-Pane Layout"
+msgstr "3-панельное расположение"
+
+#: data/app.gschema.xml:37 src/ui/preferences/preferences.blp:140
+msgid "Expands the notebook list to include the notebook name"
+msgstr ""
+
+#: data/app.gschema.xml:41 src/ui/preferences/preferences.blp:207
+msgid "Notes Storage Location"
+msgstr "Место хранения заметок"
+
+#: data/app.gschema.xml:42 src/ui/preferences/preferences.blp:208
+msgid "Where the notebooks are stored (requires app restart)"
+msgstr "То, где хранятся блокноты (требует перезапуск приложения)"
+
+#: data/app.gschema.xml:46 src/ui/preferences/preferences.blp:235
+msgid "Trash Storage Location"
+msgstr ""
+
+#: data/app.gschema.xml:47 src/ui/preferences/preferences.blp:236
+msgid "Where the trash folder is located (requires app restart)"
+msgstr ""
+
+#: data/app.gschema.xml:51 src/ui/preferences/preferences.blp:87
+msgid "Show line numbers"
+msgstr ""
+
+#: data/app.gschema.xml:52 src/ui/preferences/preferences.blp:88
+msgid "Displays line numbers at the left of the note"
+msgstr ""
+
+#: data/app.gschema.xml:56 src/ui/preferences/preferences.blp:98
+msgid "Show all notes"
+msgstr ""
+
+#: data/app.gschema.xml:57 src/ui/preferences/preferences.blp:99
+msgid "Displays the \"All Notes\" notebook at the top of the notebook list"
+msgstr ""
+
+#: data/app.gschema.xml:61 src/ui/preferences/preferences.blp:185
+msgid "Enable autosave"
+msgstr ""
+
+#: data/app.gschema.xml:62 src/ui/preferences/preferences.blp:186
+msgid ""
+"Automatically saves the current note every 30 seconds if the contents have "
+"changed (requires app restart)"
+msgstr ""
+
+#: data/app.gschema.xml:66 src/ui/preferences/preferences.blp:196
+msgid "Don't hide the Trash folder"
+msgstr ""
+
+#: data/app.gschema.xml:67
+msgid ""
+"The trash folder is set as a hidden folder by default, this option makes it "
+"visible"
+msgstr ""
+
+#: data/app.gschema.xml:71
+msgid "Note sort order"
+msgstr ""
+
+#: data/app.gschema.xml:72
+msgid "The sort order of the note list"
+msgstr ""
+
+#: data/app.gschema.xml:76
+msgid "Notebook sort order"
+msgstr ""
+
+#: data/app.gschema.xml:77
+msgid "The sort order of the notebook list"
+msgstr ""
+
+#: data/app.gschema.xml:81
+msgid "URL detection level"
+msgstr ""
+
+#: data/app.gschema.xml:82
+msgid "How agressive to look for URLs in markdown text"
+msgstr ""
+
+#: data/app.gschema.xml:86
+msgid "Line spacing"
+msgstr ""
+
+#: data/app.gschema.xml:87 src/ui/preferences/preferences.blp:74
+msgid "The line spacing for the note text"
+msgstr ""
 
 #: data/app.metainfo.xml.in:5
 msgid "Take notes in Markdown"
@@ -314,103 +224,116 @@ msgstr ""
 msgid "Trash can"
 msgstr "Мусорная корзина"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:23
-#: src/ui/edit_view/toolbar/toolbar.blp:131
+#: data/app.metainfo.xml.in:393
+msgid "Main Folio window in light mode"
+msgstr ""
+
+#: data/app.metainfo.xml.in:397
+msgid "Main Folio window in dark mode"
+msgstr ""
+
+#: data/app.metainfo.xml.in:401
+msgid "Folio on small/mobile screens"
+msgstr ""
+
+#: data/app.metainfo.xml.in:405
+msgid "Folio preferences screen"
+msgstr ""
+
+#: data/app.metainfo.xml.in:409
+msgid "Folio in three pane mode"
+msgstr ""
+
+#: src/ui/edit_view/toolbar/toolbar.blp:6
 #: src/ui/widgets/markdown/heading_popover.blp:48
 msgid "Plain Text"
 msgstr "Простой текст"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:24
-#: src/ui/edit_view/toolbar/toolbar.blp:132
+#: src/ui/edit_view/toolbar/toolbar.blp:7
 #: src/ui/widgets/markdown/heading_popover.blp:12
 msgid "Heading 1"
 msgstr "Заголовок 1"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:25
-#: src/ui/edit_view/toolbar/toolbar.blp:133
+#: src/ui/edit_view/toolbar/toolbar.blp:8
 #: src/ui/widgets/markdown/heading_popover.blp:18
 msgid "Heading 2"
 msgstr "Заголовок 2"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:26
-#: src/ui/edit_view/toolbar/toolbar.blp:134
+#: src/ui/edit_view/toolbar/toolbar.blp:9
 #: src/ui/widgets/markdown/heading_popover.blp:24
 msgid "Heading 3"
 msgstr "Заголовок 3"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:27
-#: src/ui/edit_view/toolbar/toolbar.blp:135
+#: src/ui/edit_view/toolbar/toolbar.blp:10
 #: src/ui/widgets/markdown/heading_popover.blp:30
 msgid "Heading 4"
 msgstr "Заголовок 4"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:28
-#: src/ui/edit_view/toolbar/toolbar.blp:136
+#: src/ui/edit_view/toolbar/toolbar.blp:11
 #: src/ui/widgets/markdown/heading_popover.blp:36
 msgid "Heading 5"
 msgstr "Заголовок 5"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:29
-#: src/ui/edit_view/toolbar/toolbar.blp:137
+#: src/ui/edit_view/toolbar/toolbar.blp:12
 #: src/ui/widgets/markdown/heading_popover.blp:42
 msgid "Heading 6"
 msgstr "Заголовок 6"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:39
-#: src/ui/edit_view/toolbar/toolbar.blp:104
-#: src/ui/edit_view/toolbar/toolbar.blp:148
-#: src/ui/edit_view/toolbar/toolbar.blp:201 src/ui/popup/shortcut_window.blp:72
+#: src/ui/edit_view/toolbar/toolbar.blp:41
+#: src/ui/edit_view/toolbar/toolbar.blp:107
+#: src/ui/edit_view/toolbar/toolbar.blp:142
+#: src/ui/edit_view/toolbar/toolbar.blp:195 src/ui/popup/shortcut_window.blp:72
 msgid "Bold"
 msgstr "Жирный"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:45
-#: src/ui/edit_view/toolbar/toolbar.blp:111
-#: src/ui/edit_view/toolbar/toolbar.blp:155
-#: src/ui/edit_view/toolbar/toolbar.blp:202 src/ui/popup/shortcut_window.blp:77
+#: src/ui/edit_view/toolbar/toolbar.blp:47
+#: src/ui/edit_view/toolbar/toolbar.blp:114
+#: src/ui/edit_view/toolbar/toolbar.blp:149
+#: src/ui/edit_view/toolbar/toolbar.blp:196 src/ui/popup/shortcut_window.blp:77
 msgid "Italic"
 msgstr "Курсив"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:51
-#: src/ui/edit_view/toolbar/toolbar.blp:162
-#: src/ui/edit_view/toolbar/toolbar.blp:203 src/ui/popup/shortcut_window.blp:82
+#: src/ui/edit_view/toolbar/toolbar.blp:53
+#: src/ui/edit_view/toolbar/toolbar.blp:156
+#: src/ui/edit_view/toolbar/toolbar.blp:197 src/ui/popup/shortcut_window.blp:82
 msgid "Strikethrough"
 msgstr "Зачеркнутый"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:57
-#: src/ui/edit_view/toolbar/toolbar.blp:169
-#: src/ui/edit_view/toolbar/toolbar.blp:204 src/ui/popup/shortcut_window.blp:87
+#: src/ui/edit_view/toolbar/toolbar.blp:59
+#: src/ui/edit_view/toolbar/toolbar.blp:163
+#: src/ui/edit_view/toolbar/toolbar.blp:198 src/ui/popup/shortcut_window.blp:87
 msgid "Highlight"
 msgstr "Выделение"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:67
-#: src/ui/edit_view/toolbar/toolbar.blp:193 src/ui/popup/shortcut_window.blp:92
+#: src/ui/edit_view/toolbar/toolbar.blp:69
+#: src/ui/edit_view/toolbar/toolbar.blp:187 src/ui/popup/shortcut_window.blp:92
 msgid "Insert Link"
 msgstr "Вставить ссылку"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:73
-#: src/ui/edit_view/toolbar/toolbar.blp:194
+#: src/ui/edit_view/toolbar/toolbar.blp:75
+#: src/ui/edit_view/toolbar/toolbar.blp:188
 msgid "Insert Code"
 msgstr "Вставить код"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:79
-#: src/ui/edit_view/toolbar/toolbar.blp:195
+#: src/ui/edit_view/toolbar/toolbar.blp:81
+#: src/ui/edit_view/toolbar/toolbar.blp:189
 msgid "Insert Horizontal Rule"
 msgstr "Вставить горизонтальное разделение"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:118
+#: src/ui/edit_view/toolbar/toolbar.blp:121
 msgid "Format"
 msgstr "Форматирование"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:181
+#: src/ui/edit_view/toolbar/toolbar.blp:175
 msgid "Insert"
 msgstr "Вставить"
 
-#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:34
+#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:18
 #: src/ui/strings.vala:44 src/ui/strings.vala:58
 msgid "Cancel"
 msgstr "Отмена"
 
-#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:39
+#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:23
 msgid "Confirm"
 msgstr "Подтвердить"
 
@@ -454,37 +377,85 @@ msgstr "Форматирование"
 msgid "Navigation"
 msgstr "Навигация"
 
-#: src/ui/popup/shortcut_window.blp:102 src/ui/window/window.blp:216
+#: src/ui/popup/shortcut_window.blp:102 src/ui/window/window.blp:268
 msgid "Toggle Sidebar"
 msgstr "Переключить боковую панель"
 
-#: src/ui/popup/shortcut_window.blp:107 src/ui/window/window.blp:63
+#: src/ui/popup/shortcut_window.blp:107 src/ui/window/window.blp:70
 msgid "Search Notes"
 msgstr "Поиск заметок"
 
-#: data/app.gschema.xml:22 src/ui/preferences/preferences.blp:47
-msgid "Makes the dark theme pitch black"
-msgstr "Делает тёмную тему чёрной как смоль"
-
-#: data/app.gschema.xml:26 src/ui/preferences/preferences.blp:87
-msgid "Enable Toolbar"
-msgstr "Включить панель инструментов"
-
-#: data/app.gschema.xml:31 src/ui/preferences/preferences.blp:98
-msgid "Enable Cheatsheet"
+#: src/ui/popup/shortcut_window.blp:114
+msgid "Display"
 msgstr ""
 
-#: data/app.gschema.xml:36 src/ui/preferences/preferences.blp:117
-msgid "3-Pane Layout"
-msgstr "3-панельное расположение"
+#: src/ui/popup/shortcut_window.blp:117
+msgid "Full Screen"
+msgstr ""
 
-#: data/app.gschema.xml:41 src/ui/preferences/preferences.blp:185
-msgid "Notes Storage Location"
-msgstr "Место хранения заметок"
+#: src/ui/popup/shortcut_window.blp:122
+msgid "Zoom In"
+msgstr ""
 
-#: data/app.gschema.xml:42 src/ui/preferences/preferences.blp:186
-msgid "Where the notebooks are stored (requires app restart)"
-msgstr "То, где хранятся блокноты (требует перезапуск приложения)"
+#: src/ui/popup/shortcut_window.blp:127
+msgid "Zoom Out"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:31
+#, fuzzy
+msgid "Markdown URL Detection"
+msgstr "Шпаргалка Markdown"
+
+#: src/ui/preferences/preferences.blp:32
+msgid ""
+"Determines the level of detection of URLs in\n"
+"free form text is used:\n"
+" - Aggressive tries to find all URLs\n"
+" - Strict requires a protocol identifier (ie http://)\n"
+" - Disabled turns detection off."
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:39
+msgid "Fonts"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:73
+msgid "Line Spacing"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:81
+msgid "Tools"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:133
+msgid "Layout"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:161
+msgid "Fixed Width To Use For Notes"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:162
+msgid "Sets the fixed width size of a note in px"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:167
+msgid "Sort Order For Notebooks"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:172
+msgid "Sort Order For Notes"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:179
+msgid "Files"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:197
+msgid ""
+"The trash folder is set as a hidden folder by default, this option makes it "
+"visible (requires app restart)"
+msgstr ""
 
 #: src/ui/strings.vala:4 src/ui/window/notebooks_bar/notebooks_bar.blp:129
 #: src/ui/window/notebooks_bar/notebooks_bar.blp:171
@@ -492,6 +463,7 @@ msgid "Trash"
 msgstr "Корзина"
 
 #: src/ui/strings.vala:5
+#, c-format
 msgid "%d Notes"
 msgstr "%d Заметки"
 
@@ -499,7 +471,7 @@ msgstr "%d Заметки"
 msgid "Are you sure you want to delete everything in the trash?"
 msgstr "Вы уверены что хотите удалить всё из корзины?"
 
-#: src/ui/strings.vala:7 src/ui/window/window.blp:54
+#: src/ui/strings.vala:7 src/ui/window/window.blp:61
 msgid "Empty Trash"
 msgstr "Очистить Корзину"
 
@@ -536,10 +508,12 @@ msgid "Move"
 msgstr "Переместить"
 
 #: src/ui/strings.vala:18
+#, c-format
 msgid "Note “%s” already exists in notebook “%s”"
 msgstr "Заметка “%s” уже существует в блокноте “%s”"
 
 #: src/ui/strings.vala:19
+#, c-format
 msgid "Are you sure you want to delete the note “%s”?"
 msgstr "Вы уверены что хотите удалить заметку “%s”?"
 
@@ -548,6 +522,7 @@ msgid "Delete Note"
 msgstr "Удалить заметку"
 
 #: src/ui/strings.vala:21
+#, c-format
 msgid "Are you sure you want to delete the notebook “%s”?"
 msgstr "Вы уверены что хотите удалить блокнот “%s”?"
 
@@ -556,34 +531,42 @@ msgid "Delete Notebook"
 msgstr "Удалить блокнот"
 
 #: src/ui/strings.vala:24
-msgid "Note name shouldn’t contain “.” or “/”"
+#, fuzzy
+msgid "Note names cannot contain a “/”"
 msgstr "Помните что имя не должно содержать “.” или “/”"
 
 #: src/ui/strings.vala:25
-msgid "Note name shouldn’t be blank"
+#, fuzzy
+msgid "Note names cannot be blank"
 msgstr "Помните что имя не должно быть пустым"
 
 #: src/ui/strings.vala:26
+#, c-format
 msgid "Note “%s” already exists"
 msgstr "Заметка “%s” уже существует"
 
 #: src/ui/strings.vala:27
-msgid "Couldn’t create note"
+#, fuzzy
+msgid "Could not create note"
 msgstr "Не удалось создать заметку"
 
 #: src/ui/strings.vala:28
-msgid "Couldn’t change note"
+#, fuzzy
+msgid "Could not change note"
 msgstr "Не удалось изменить заметку"
 
 #: src/ui/strings.vala:29
-msgid "Couldn’t delete note"
+#, fuzzy
+msgid "Could not delete note"
 msgstr "Не удалось удалить заметку"
 
 #: src/ui/strings.vala:30
-msgid "Couldn’t restore note"
+#, fuzzy
+msgid "Could not restore note"
 msgstr "Не удалось восстановить заметку"
 
 #: src/ui/strings.vala:31
+#, c-format
 msgid "Saved “%s” to “%s”"
 msgstr "Сохранено “%s” в “%s”"
 
@@ -592,27 +575,33 @@ msgid "Unknown error"
 msgstr "Неизвестная ошибка"
 
 #: src/ui/strings.vala:33
-msgid "Notebook name shouldn’t contain “.” or “/”"
+#, fuzzy
+msgid "Notebook names cannot contain a “/”"
 msgstr "Имя блокнота не должно содержать “.” или “/”"
 
 #: src/ui/strings.vala:34
-msgid "Notebook name shouldn’t be blank"
+#, fuzzy
+msgid "Notebook names cannot be blank"
 msgstr "Имя блокнота не должно быть пустым"
 
 #: src/ui/strings.vala:35
+#, c-format
 msgid "Notebook “%s” already exists"
 msgstr "Блокнот “%s” уже существует"
 
 #: src/ui/strings.vala:36
-msgid "Couldn’t create notebook"
+#, fuzzy
+msgid "Could not create notebook"
 msgstr "Не удалось создать блокнот"
 
 #: src/ui/strings.vala:37
-msgid "Couldn’t change notebook"
+#, fuzzy
+msgid "Could not change notebook"
 msgstr "Не удалось изменить блокнот"
 
 #: src/ui/strings.vala:38
-msgid "Couldn’t delete notebook"
+#, fuzzy
+msgid "Could not delete notebook"
 msgstr "Не удалось удалить блокнот"
 
 #: src/ui/strings.vala:40
@@ -624,7 +613,7 @@ msgid "Rename"
 msgstr "Переименовать"
 
 #: src/ui/strings.vala:42
-msgid "Couldn’t find an app to handle file URIs"
+msgid "Could not find an app to handle file URIs"
 msgstr ""
 
 #: src/ui/strings.vala:43
@@ -634,6 +623,10 @@ msgstr "Применить"
 #: src/ui/strings.vala:45
 msgid "Pick where the notebooks will be stored"
 msgstr "Выберите где будут хранится блокноты"
+
+#: src/ui/strings.vala:46
+msgid "Pick where the trash can will be stored"
+msgstr ""
 
 #: src/ui/strings.vala:47 src/ui/window/notebooks_bar/notebooks_bar.blp:59
 #: src/ui/window/notebooks_bar/notebooks_bar.blp:101
@@ -646,6 +639,110 @@ msgstr ""
 
 #: src/ui/strings.vala:50
 msgid "Extension"
+msgstr ""
+
+#: src/ui/strings.vala:51
+msgid "Unable to recognize URI"
+msgstr ""
+
+#: src/ui/strings.vala:52
+msgid "Pick primary font for notes"
+msgstr ""
+
+#: src/ui/strings.vala:53
+msgid "Pick monospace font for code"
+msgstr ""
+
+#: src/ui/strings.vala:54
+msgid "File Changed On Disk"
+msgstr ""
+
+#: src/ui/strings.vala:55
+msgid ""
+"The file has changed on disk since it was last saved/loaded by Folio.\n"
+"\n"
+"You may do one of the following:\n"
+"\n"
+" • Reload the file (discarding any changes you have made in Folio)\n"
+" • Overwrite the file (discarding any changes made outside of Folio)\n"
+" • Cancel the operation and manually resolve the issue\n"
+"\n"
+"Note: Canceling the save if you have already moved to a new note/notebook "
+"will discard your changes."
+msgstr ""
+
+#: src/ui/strings.vala:56
+msgid "Reload"
+msgstr ""
+
+#: src/ui/strings.vala:57
+msgid "Overwrite"
+msgstr ""
+
+#: src/ui/strings.vala:59
+msgid ""
+"The file has changed on disk by another application.\n"
+"\n"
+"You may do one of the following:\n"
+"\n"
+" • Reload the file (discarding any changes you have made in Folio)\n"
+" • Overwrite the file (discarding any changes made outside of Folio)"
+msgstr ""
+
+#: src/ui/strings.vala:61
+#, c-format
+msgid "Note %i"
+msgstr ""
+
+#: src/ui/strings.vala:62
+msgid "Modified Time - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:63
+msgid "Modified Time - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:64
+msgid "Alphabetical - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:65
+msgid "Alphabetical - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:66
+msgid "Natural - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:67
+msgid "Natural - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:68
+#, c-format
+msgid "Unable to launch external application for file %s."
+msgstr ""
+
+#: src/ui/strings.vala:69
+msgid "Aggressive"
+msgstr ""
+
+#: src/ui/strings.vala:70
+msgid "Strict"
+msgstr ""
+
+#: src/ui/strings.vala:71
+msgid "Disabled"
+msgstr ""
+
+#: src/ui/strings.vala:72
+#, fuzzy, c-format
+msgid "“%s” moved to trash"
+msgstr "Переместить в корзину"
+
+#: src/ui/strings.vala:73
+#, c-format
+msgid "“%s” restored"
 msgstr ""
 
 #: src/ui/widgets/theme_selector/theme_selector.blp:15
@@ -677,40 +774,45 @@ msgid "_Keyboard Shortcuts"
 msgstr "_Комбинации клавиш"
 
 #: src/ui/window/app_menu/app_menu.blp:43
-msgid "_About"
+#, fuzzy
+msgid "_About Folio"
 msgstr "_О Paper"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:54
-msgid "Notebook Name"
-msgstr "Имя блокнота"
-
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:66
-msgid "Duplicate notebook names are not allowed!"
-msgstr ""
-
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:82
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:6
 msgid "First Characters"
 msgstr "Первые буквы"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:83
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:7
 msgid "Initials"
 msgstr "Инициалы"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:84
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:8
 msgid "Initials: camelCase"
 msgstr "Инициалы: camelCase"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:85
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:9
 msgid "Initials: snake_case"
 msgstr "Инициалы: snake_case"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:86
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:10
 msgid "Icon"
 msgstr "Значок"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:116
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:11
+msgid "Custom"
+msgstr ""
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:16
 msgid "Notebook Color"
 msgstr "Цвет блокнота"
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:58
+msgid "Notebook Name"
+msgstr "Имя блокнота"
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:70
+msgid "Duplicate notebook names are not allowed!"
+msgstr ""
 
 #: src/ui/window/notebooks_bar/notebook_create_popup.blp:126
 msgid "Create Notebook"
@@ -728,11 +830,11 @@ msgstr "Переместить всё в корзину"
 msgid "Notebooks"
 msgstr ""
 
-#: src/ui/window/sidebar/note_create_popup.blp:37
+#: src/ui/window/sidebar/note_create_popup.blp:25
 msgid "Note Name"
 msgstr "Имя заметки"
 
-#: src/ui/window/sidebar/note_create_popup.blp:45
+#: src/ui/window/sidebar/note_create_popup.blp:33
 msgid "Create Note"
 msgstr "Создать заметку"
 
@@ -756,30 +858,37 @@ msgstr "Переместить в корзину"
 msgid "Open Containing Folder"
 msgstr "Открыть содержащую папку"
 
-#: src/ui/window/window.blp:118
+#: src/ui/window/window.blp:123
 msgid "Get started writing"
 msgstr "Начать писать"
 
-#: src/ui/window/window.blp:143
+#: src/ui/window/window.blp:152
+msgid "Open file in external application"
+msgstr ""
+
+#: src/ui/window/window.blp:160
+msgid "Open file"
+msgstr ""
+
+#: src/ui/window/window.blp:181
 msgid "Create a notebook"
 msgstr "Создать блокнот"
 
-#: src/ui/window/window.blp:168
+#: src/ui/window/window.blp:210
 msgid "Trash is empty"
 msgstr "Корзина пуста"
 
-#: src/ui/window/window.blp:224
-msgid "Back"
-msgstr "Назад"
-
-#: src/ui/window/window.blp:239
+#: src/ui/window/window.blp:285
 msgid "Open in Notebook"
 msgstr "Открыть в блокноте"
 
-#: src/ui/window/window.blp:264
+#: src/ui/window/window.blp:312
 msgid "_Rename Note"
 msgstr "_Переименовать заметку"
 
-#: src/ui/window/window.blp:270
+#: src/ui/window/window.blp:319
 msgid "_Export Note"
 msgstr "_Экспортировать заметку"
+
+#~ msgid "Back"
+#~ msgstr "Назад"

--- a/po/sr.po
+++ b/po/sr.po
@@ -2,229 +2,17 @@
 # This file is distributed under the same license as the Folio package.
 msgid ""
 msgstr ""
+"Project-Id-Version: Folio\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-10-12 16:53+0200\n"
 "PO-Revision-Date: 2024-03-02 17:00:32+0000\n"
+"Language: sr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n % 10 == 1 && n % 100 != 11) ? 0 : ((n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % 100 > 14)) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n % 10 == 1 && n % 100 != 11) ? 0 : ((n % "
+"10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % 100 > 14)) ? 1 : 2);\n"
 "X-Generator: GlotPress/4.0.0\n"
-"Language: sr\n"
-"Project-Id-Version: Folio\n"
-
-#: data/app.gschema.xml:76
-msgid "Notebook sort order"
-msgstr ""
-
-#: data/app.gschema.xml:77
-msgid "The sort order of the notebook list"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:145
-msgid "Sort Order For Notebooks"
-msgstr ""
-
-#: data/app.gschema.xml:71
-msgid "Note sort order"
-msgstr ""
-
-#: data/app.gschema.xml:72
-msgid "The sort order of the note list"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:150
-msgid "Sort Order For Notes"
-msgstr ""
-
-#: src/ui/strings.vala:62
-msgid "Modified Time - Ascending"
-msgstr ""
-
-#: src/ui/strings.vala:63
-msgid "Modified Time - Descending"
-msgstr ""
-
-#: src/ui/strings.vala:64
-msgid "Alphabetical - Ascending"
-msgstr ""
-
-#: src/ui/strings.vala:65
-msgid "Alphabetical - Descending"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:114
-msgid "Display"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:117
-msgid "Full Screen"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:122
-msgid "Zoom In"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:127
-msgid "Zoom Out"
-msgstr ""
-
-#: src/ui/strings.vala:52
-msgid "Pick primary font for notes"
-msgstr ""
-
-#: src/ui/strings.vala:53
-msgid "Pick monospace font for code"
-msgstr ""
-
-#: src/ui/strings.vala:54
-msgid "File Changed On Disk"
-msgstr ""
-
-#: src/ui/strings.vala:55
-msgid ""
-"The file has changed on disk since it was last saved/loaded by Folio.\n"
-"\n"
-"You may do one of the following:\n"
-"\n"
-" • Reload the file (discarding any changes you have made in Folio)\n"
-" • Overwrite the file (discarding any changes made outside of Folio)\n"
-" • Cancel the operation and manually resolve the issue\n"
-"\n"
-"Note: Canceling the save if you have already moved to a new note/notebook will discard your changes."
-msgstr ""
-
-#: src/ui/strings.vala:56
-msgid "Reload"
-msgstr ""
-
-#: src/ui/strings.vala:57
-msgid "Overwrite"
-msgstr ""
-
-#: src/ui/strings.vala:59
-msgid ""
-"The file has changed on disk by another application.\n"
-"\n"
-"You may do one of the following:\n"
-"\n"
-" • Reload the file (discarding any changes you have made in Folio)\n"
-" • Overwrite the file (discarding any changes made outside of Folio)"
-msgstr ""
-
-#: src/ui/strings.vala:61
-msgid "Note %i"
-msgstr ""
-
-#: data/app.gschema.xml:46 src/ui/preferences/preferences.blp:213
-msgid "Trash Storage Location"
-msgstr ""
-
-#: data/app.gschema.xml:47 src/ui/preferences/preferences.blp:214
-msgid "Where the trash folder is located (requires app restart)"
-msgstr ""
-
-#: src/ui/strings.vala:46
-msgid "Pick where the trash can will be stored"
-msgstr ""
-
-#: data/app.gschema.xml:16 src/ui/preferences/preferences.blp:128
-msgid "Use Fixed Width For Notes"
-msgstr ""
-
-#: data/app.gschema.xml:17 src/ui/preferences/preferences.blp:129
-msgid "Use a fixed width for the text area of a note"
-msgstr ""
-
-#: data/app.gschema.xml:37 src/ui/preferences/preferences.blp:118
-msgid "Expands the notebook list to include the notebook name"
-msgstr ""
-
-#: data/app.gschema.xml:51 src/ui/preferences/preferences.blp:65
-msgid "Show line numbers"
-msgstr ""
-
-#: data/app.gschema.xml:52 src/ui/preferences/preferences.blp:66
-msgid "Displays line numbers at the left of the note"
-msgstr ""
-
-#: data/app.gschema.xml:56 src/ui/preferences/preferences.blp:76
-msgid "Show all notes"
-msgstr ""
-
-#: data/app.gschema.xml:57 src/ui/preferences/preferences.blp:77
-msgid "Displays the \"All Notes\" notebook at the top of the notebook list"
-msgstr ""
-
-#: data/app.gschema.xml:61 src/ui/preferences/preferences.blp:163
-msgid "Enable autosave"
-msgstr ""
-
-#: data/app.gschema.xml:62 src/ui/preferences/preferences.blp:164
-msgid "Automatically saves the current note every 30 seconds if the contents have changed (requires app restart)"
-msgstr ""
-
-#: data/app.gschema.xml:66 src/ui/preferences/preferences.blp:174
-msgid "Don't hide the Trash folder"
-msgstr ""
-
-#: data/app.gschema.xml:67
-msgid "The trash folder is set as a hidden folder by default, this option makes it visible"
-msgstr ""
-
-#: data/app.metainfo.xml.in:367
-msgid "Main Folio window in light mode"
-msgstr ""
-
-#: data/app.metainfo.xml.in:371
-msgid "Main Folio window in dark mode"
-msgstr ""
-
-#: data/app.metainfo.xml.in:375
-msgid "Folio on small/mobile screens"
-msgstr ""
-
-#: data/app.metainfo.xml.in:379
-msgid "Folio preferences screen"
-msgstr ""
-
-#: data/app.metainfo.xml.in:383
-msgid "Folio in three pane mode"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:59
-msgid "Tools"
-msgstr ""
-
-#: data/app.gschema.xml:27 src/ui/preferences/preferences.blp:88
-msgid "Displays the formatting toolbar at the bottom of the note"
-msgstr ""
-
-#: data/app.gschema.xml:32 src/ui/preferences/preferences.blp:99
-msgid "Adds a button to the markdown reference sheet on the right of the formatting toolbar"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:111
-msgid "Layout"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:139
-msgid "Fixed Width To Use For Notes"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:140
-msgid "Sets the fixed width size of a note in px"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:157
-msgid "Files"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:175
-msgid "The trash folder is set as a hidden folder by default, this option makes it visible (requires app restart)"
-msgstr ""
-
-#: src/ui/strings.vala:51
-msgid "Unable to recognize URI"
-msgstr ""
 
 #: data/app.desktop.in:9 src/ui/strings.vala:3
 msgid "Folio"
@@ -240,21 +28,25 @@ msgstr "Стварајте белешке"
 
 #: data/app.desktop.in:13
 msgid "Notebook;Note;Notes;Text;Markdown;Notepad;Write;School;Post-it;Sticky;"
-msgstr "Notebook;Note;Notes;Text;Markdown;Notepad;Write;School;Post-it;Sticky;Бележница;Белешка;Белешке;Текст;Маркдаун;Ноутпад;Писање;Школа;Лепљиво;Beležnica;Beleška;Beleške;Tekst;Markdaun;Noutpad;Pisanje;Škola;Skola;Lepljivo;"
+msgstr ""
+"Notebook;Note;Notes;Text;Markdown;Notepad;Write;School;Post-it;Sticky;"
+"Бележница;Белешка;Белешке;Текст;Маркдаун;Ноутпад;Писање;Школа;Лепљиво;"
+"Beležnica;Beleška;Beleške;Tekst;Markdaun;Noutpad;Pisanje;Škola;Skola;"
+"Lepljivo;"
 
 #: data/app.desktop.in:22 src/ui/popup/shortcut_window.blp:17
-#: src/ui/strings.vala:8 src/ui/window/window.blp:47
-#: src/ui/window/window.blp:124
+#: src/ui/strings.vala:8 src/ui/window/window.blp:54
+#: src/ui/window/window.blp:131
 msgid "New Note"
 msgstr "Нова белешка"
 
 #: data/app.desktop.in:26 src/ui/popup/shortcut_window.blp:37
-#: src/ui/strings.vala:14 src/ui/window/window.blp:149
+#: src/ui/strings.vala:14 src/ui/window/window.blp:189
 msgid "New Notebook"
 msgstr "Нова бележница"
 
-#: data/app.desktop.in:30 src/ui/edit_view/toolbar/toolbar.blp:90
-#: src/ui/strings.vala:39 src/ui/window/window.blp:245
+#: data/app.desktop.in:30 src/ui/edit_view/toolbar/toolbar.blp:92
+#: src/ui/strings.vala:39 src/ui/window/window.blp:291
 msgid "Markdown Cheatsheet"
 msgstr "Маркдаун подсетник"
 
@@ -262,25 +54,147 @@ msgstr "Маркдаун подсетник"
 msgid "Preferences"
 msgstr "Поставке"
 
-#: data/app.gschema.xml:6 src/ui/preferences/preferences.blp:18
+#: data/app.gschema.xml:6 src/ui/preferences/preferences.blp:45
 msgid "Note Font"
 msgstr "Фонт белешке"
 
-#: data/app.gschema.xml:7 src/ui/preferences/preferences.blp:19
+#: data/app.gschema.xml:7 src/ui/preferences/preferences.blp:46
 msgid "The font notes will be displayed in"
 msgstr "Фонт за приказ белешке"
 
-#: data/app.gschema.xml:11 src/ui/preferences/preferences.blp:31
+#: data/app.gschema.xml:11 src/ui/preferences/preferences.blp:58
 msgid "Monospace Font"
 msgstr "Фонт утврђене ширине"
 
-#: data/app.gschema.xml:12 src/ui/preferences/preferences.blp:32
+#: data/app.gschema.xml:12 src/ui/preferences/preferences.blp:59
 msgid "The font code will be displayed in"
 msgstr "Фонт за приказ кода"
 
-#: data/app.gschema.xml:21 src/ui/preferences/preferences.blp:46
+#: data/app.gschema.xml:16 src/ui/preferences/preferences.blp:150
+msgid "Use Fixed Width For Notes"
+msgstr ""
+
+#: data/app.gschema.xml:17 src/ui/preferences/preferences.blp:151
+msgid "Use a fixed width for the text area of a note"
+msgstr ""
+
+#: data/app.gschema.xml:21 src/ui/preferences/preferences.blp:18
 msgid "OLED Mode"
 msgstr "ОЛЕД режим"
+
+#: data/app.gschema.xml:22 src/ui/preferences/preferences.blp:19
+msgid "Makes the dark theme pitch black"
+msgstr "Учини тамну тему веома тамном"
+
+#: data/app.gschema.xml:26 src/ui/preferences/preferences.blp:109
+msgid "Enable Toolbar"
+msgstr "Омогући алатницу"
+
+#: data/app.gschema.xml:27 src/ui/preferences/preferences.blp:110
+msgid "Displays the formatting toolbar at the bottom of the note"
+msgstr ""
+
+#: data/app.gschema.xml:31 src/ui/preferences/preferences.blp:120
+msgid "Enable Cheatsheet"
+msgstr ""
+
+#: data/app.gschema.xml:32 src/ui/preferences/preferences.blp:121
+msgid ""
+"Adds a button to the markdown reference sheet on the right of the formatting "
+"toolbar"
+msgstr ""
+
+#: data/app.gschema.xml:36 src/ui/preferences/preferences.blp:139
+msgid "3-Pane Layout"
+msgstr "Распоред са три површи"
+
+#: data/app.gschema.xml:37 src/ui/preferences/preferences.blp:140
+msgid "Expands the notebook list to include the notebook name"
+msgstr ""
+
+#: data/app.gschema.xml:41 src/ui/preferences/preferences.blp:207
+msgid "Notes Storage Location"
+msgstr "Место складиштења белешки"
+
+#: data/app.gschema.xml:42 src/ui/preferences/preferences.blp:208
+msgid "Where the notebooks are stored (requires app restart)"
+msgstr "Где се чувају бележнице (захтева поновно покретање програма)"
+
+#: data/app.gschema.xml:46 src/ui/preferences/preferences.blp:235
+msgid "Trash Storage Location"
+msgstr ""
+
+#: data/app.gschema.xml:47 src/ui/preferences/preferences.blp:236
+msgid "Where the trash folder is located (requires app restart)"
+msgstr ""
+
+#: data/app.gschema.xml:51 src/ui/preferences/preferences.blp:87
+msgid "Show line numbers"
+msgstr ""
+
+#: data/app.gschema.xml:52 src/ui/preferences/preferences.blp:88
+msgid "Displays line numbers at the left of the note"
+msgstr ""
+
+#: data/app.gschema.xml:56 src/ui/preferences/preferences.blp:98
+msgid "Show all notes"
+msgstr ""
+
+#: data/app.gschema.xml:57 src/ui/preferences/preferences.blp:99
+msgid "Displays the \"All Notes\" notebook at the top of the notebook list"
+msgstr ""
+
+#: data/app.gschema.xml:61 src/ui/preferences/preferences.blp:185
+msgid "Enable autosave"
+msgstr ""
+
+#: data/app.gschema.xml:62 src/ui/preferences/preferences.blp:186
+msgid ""
+"Automatically saves the current note every 30 seconds if the contents have "
+"changed (requires app restart)"
+msgstr ""
+
+#: data/app.gschema.xml:66 src/ui/preferences/preferences.blp:196
+msgid "Don't hide the Trash folder"
+msgstr ""
+
+#: data/app.gschema.xml:67
+msgid ""
+"The trash folder is set as a hidden folder by default, this option makes it "
+"visible"
+msgstr ""
+
+#: data/app.gschema.xml:71
+msgid "Note sort order"
+msgstr ""
+
+#: data/app.gschema.xml:72
+msgid "The sort order of the note list"
+msgstr ""
+
+#: data/app.gschema.xml:76
+msgid "Notebook sort order"
+msgstr ""
+
+#: data/app.gschema.xml:77
+msgid "The sort order of the notebook list"
+msgstr ""
+
+#: data/app.gschema.xml:81
+msgid "URL detection level"
+msgstr ""
+
+#: data/app.gschema.xml:82
+msgid "How agressive to look for URLs in markdown text"
+msgstr ""
+
+#: data/app.gschema.xml:86
+msgid "Line spacing"
+msgstr ""
+
+#: data/app.gschema.xml:87 src/ui/preferences/preferences.blp:74
+msgid "The line spacing for the note text"
+msgstr ""
 
 #: data/app.metainfo.xml.in:5
 msgid "Take notes in Markdown"
@@ -314,103 +228,116 @@ msgstr ""
 msgid "Trash can"
 msgstr "Канта за смеће"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:23
-#: src/ui/edit_view/toolbar/toolbar.blp:131
+#: data/app.metainfo.xml.in:393
+msgid "Main Folio window in light mode"
+msgstr ""
+
+#: data/app.metainfo.xml.in:397
+msgid "Main Folio window in dark mode"
+msgstr ""
+
+#: data/app.metainfo.xml.in:401
+msgid "Folio on small/mobile screens"
+msgstr ""
+
+#: data/app.metainfo.xml.in:405
+msgid "Folio preferences screen"
+msgstr ""
+
+#: data/app.metainfo.xml.in:409
+msgid "Folio in three pane mode"
+msgstr ""
+
+#: src/ui/edit_view/toolbar/toolbar.blp:6
 #: src/ui/widgets/markdown/heading_popover.blp:48
 msgid "Plain Text"
 msgstr "Обичан текст"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:24
-#: src/ui/edit_view/toolbar/toolbar.blp:132
+#: src/ui/edit_view/toolbar/toolbar.blp:7
 #: src/ui/widgets/markdown/heading_popover.blp:12
 msgid "Heading 1"
 msgstr "Заглавље 1"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:25
-#: src/ui/edit_view/toolbar/toolbar.blp:133
+#: src/ui/edit_view/toolbar/toolbar.blp:8
 #: src/ui/widgets/markdown/heading_popover.blp:18
 msgid "Heading 2"
 msgstr "Заглавље 2"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:26
-#: src/ui/edit_view/toolbar/toolbar.blp:134
+#: src/ui/edit_view/toolbar/toolbar.blp:9
 #: src/ui/widgets/markdown/heading_popover.blp:24
 msgid "Heading 3"
 msgstr "Заглавље 3"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:27
-#: src/ui/edit_view/toolbar/toolbar.blp:135
+#: src/ui/edit_view/toolbar/toolbar.blp:10
 #: src/ui/widgets/markdown/heading_popover.blp:30
 msgid "Heading 4"
 msgstr "Заглавље 4"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:28
-#: src/ui/edit_view/toolbar/toolbar.blp:136
+#: src/ui/edit_view/toolbar/toolbar.blp:11
 #: src/ui/widgets/markdown/heading_popover.blp:36
 msgid "Heading 5"
 msgstr "Заглавље 5"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:29
-#: src/ui/edit_view/toolbar/toolbar.blp:137
+#: src/ui/edit_view/toolbar/toolbar.blp:12
 #: src/ui/widgets/markdown/heading_popover.blp:42
 msgid "Heading 6"
 msgstr "Заглавље 6"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:39
-#: src/ui/edit_view/toolbar/toolbar.blp:104
-#: src/ui/edit_view/toolbar/toolbar.blp:148
-#: src/ui/edit_view/toolbar/toolbar.blp:201 src/ui/popup/shortcut_window.blp:72
+#: src/ui/edit_view/toolbar/toolbar.blp:41
+#: src/ui/edit_view/toolbar/toolbar.blp:107
+#: src/ui/edit_view/toolbar/toolbar.blp:142
+#: src/ui/edit_view/toolbar/toolbar.blp:195 src/ui/popup/shortcut_window.blp:72
 msgid "Bold"
 msgstr "Подебљано"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:45
-#: src/ui/edit_view/toolbar/toolbar.blp:111
-#: src/ui/edit_view/toolbar/toolbar.blp:155
-#: src/ui/edit_view/toolbar/toolbar.blp:202 src/ui/popup/shortcut_window.blp:77
+#: src/ui/edit_view/toolbar/toolbar.blp:47
+#: src/ui/edit_view/toolbar/toolbar.blp:114
+#: src/ui/edit_view/toolbar/toolbar.blp:149
+#: src/ui/edit_view/toolbar/toolbar.blp:196 src/ui/popup/shortcut_window.blp:77
 msgid "Italic"
 msgstr "Искошено"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:51
-#: src/ui/edit_view/toolbar/toolbar.blp:162
-#: src/ui/edit_view/toolbar/toolbar.blp:203 src/ui/popup/shortcut_window.blp:82
+#: src/ui/edit_view/toolbar/toolbar.blp:53
+#: src/ui/edit_view/toolbar/toolbar.blp:156
+#: src/ui/edit_view/toolbar/toolbar.blp:197 src/ui/popup/shortcut_window.blp:82
 msgid "Strikethrough"
 msgstr "Прецртано"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:57
-#: src/ui/edit_view/toolbar/toolbar.blp:169
-#: src/ui/edit_view/toolbar/toolbar.blp:204 src/ui/popup/shortcut_window.blp:87
+#: src/ui/edit_view/toolbar/toolbar.blp:59
+#: src/ui/edit_view/toolbar/toolbar.blp:163
+#: src/ui/edit_view/toolbar/toolbar.blp:198 src/ui/popup/shortcut_window.blp:87
 msgid "Highlight"
 msgstr "Истакнуто"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:67
-#: src/ui/edit_view/toolbar/toolbar.blp:193 src/ui/popup/shortcut_window.blp:92
+#: src/ui/edit_view/toolbar/toolbar.blp:69
+#: src/ui/edit_view/toolbar/toolbar.blp:187 src/ui/popup/shortcut_window.blp:92
 msgid "Insert Link"
 msgstr "Убаци везу"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:73
-#: src/ui/edit_view/toolbar/toolbar.blp:194
+#: src/ui/edit_view/toolbar/toolbar.blp:75
+#: src/ui/edit_view/toolbar/toolbar.blp:188
 msgid "Insert Code"
 msgstr "Убаци код"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:79
-#: src/ui/edit_view/toolbar/toolbar.blp:195
+#: src/ui/edit_view/toolbar/toolbar.blp:81
+#: src/ui/edit_view/toolbar/toolbar.blp:189
 msgid "Insert Horizontal Rule"
 msgstr "Убаци линију"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:118
+#: src/ui/edit_view/toolbar/toolbar.blp:121
 msgid "Format"
 msgstr "Облик"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:181
+#: src/ui/edit_view/toolbar/toolbar.blp:175
 msgid "Insert"
 msgstr "Убаци"
 
-#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:34
+#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:18
 #: src/ui/strings.vala:44 src/ui/strings.vala:58
 msgid "Cancel"
 msgstr "Откажи"
 
-#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:39
+#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:23
 msgid "Confirm"
 msgstr "Потврди"
 
@@ -454,37 +381,85 @@ msgstr "Форматирање"
 msgid "Navigation"
 msgstr "Навигација"
 
-#: src/ui/popup/shortcut_window.blp:102 src/ui/window/window.blp:216
+#: src/ui/popup/shortcut_window.blp:102 src/ui/window/window.blp:268
 msgid "Toggle Sidebar"
 msgstr "Окини бочну површ"
 
-#: src/ui/popup/shortcut_window.blp:107 src/ui/window/window.blp:63
+#: src/ui/popup/shortcut_window.blp:107 src/ui/window/window.blp:70
 msgid "Search Notes"
 msgstr "Претраживање белешки"
 
-#: data/app.gschema.xml:22 src/ui/preferences/preferences.blp:47
-msgid "Makes the dark theme pitch black"
-msgstr "Учини тамну тему веома тамном"
-
-#: data/app.gschema.xml:26 src/ui/preferences/preferences.blp:87
-msgid "Enable Toolbar"
-msgstr "Омогући алатницу"
-
-#: data/app.gschema.xml:31 src/ui/preferences/preferences.blp:98
-msgid "Enable Cheatsheet"
+#: src/ui/popup/shortcut_window.blp:114
+msgid "Display"
 msgstr ""
 
-#: data/app.gschema.xml:36 src/ui/preferences/preferences.blp:117
-msgid "3-Pane Layout"
-msgstr "Распоред са три површи"
+#: src/ui/popup/shortcut_window.blp:117
+msgid "Full Screen"
+msgstr ""
 
-#: data/app.gschema.xml:41 src/ui/preferences/preferences.blp:185
-msgid "Notes Storage Location"
-msgstr "Место складиштења белешки"
+#: src/ui/popup/shortcut_window.blp:122
+msgid "Zoom In"
+msgstr ""
 
-#: data/app.gschema.xml:42 src/ui/preferences/preferences.blp:186
-msgid "Where the notebooks are stored (requires app restart)"
-msgstr "Где се чувају бележнице (захтева поновно покретање програма)"
+#: src/ui/popup/shortcut_window.blp:127
+msgid "Zoom Out"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:31
+#, fuzzy
+msgid "Markdown URL Detection"
+msgstr "Маркдаун подсетник"
+
+#: src/ui/preferences/preferences.blp:32
+msgid ""
+"Determines the level of detection of URLs in\n"
+"free form text is used:\n"
+" - Aggressive tries to find all URLs\n"
+" - Strict requires a protocol identifier (ie http://)\n"
+" - Disabled turns detection off."
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:39
+msgid "Fonts"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:73
+msgid "Line Spacing"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:81
+msgid "Tools"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:133
+msgid "Layout"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:161
+msgid "Fixed Width To Use For Notes"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:162
+msgid "Sets the fixed width size of a note in px"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:167
+msgid "Sort Order For Notebooks"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:172
+msgid "Sort Order For Notes"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:179
+msgid "Files"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:197
+msgid ""
+"The trash folder is set as a hidden folder by default, this option makes it "
+"visible (requires app restart)"
+msgstr ""
 
 #: src/ui/strings.vala:4 src/ui/window/notebooks_bar/notebooks_bar.blp:129
 #: src/ui/window/notebooks_bar/notebooks_bar.blp:171
@@ -492,6 +467,7 @@ msgid "Trash"
 msgstr "Смеће"
 
 #: src/ui/strings.vala:5
+#, c-format
 msgid "%d Notes"
 msgstr "%d бележница"
 
@@ -499,7 +475,7 @@ msgstr "%d бележница"
 msgid "Are you sure you want to delete everything in the trash?"
 msgstr "Да ли сте сигурни да желите обрисати све из смећа?"
 
-#: src/ui/strings.vala:7 src/ui/window/window.blp:54
+#: src/ui/strings.vala:7 src/ui/window/window.blp:61
 msgid "Empty Trash"
 msgstr "Избаци смеће"
 
@@ -536,10 +512,12 @@ msgid "Move"
 msgstr "Премести"
 
 #: src/ui/strings.vala:18
+#, c-format
 msgid "Note “%s” already exists in notebook “%s”"
 msgstr "Белешка „%s“ већ постоји у бележници „%s“"
 
 #: src/ui/strings.vala:19
+#, c-format
 msgid "Are you sure you want to delete the note “%s”?"
 msgstr "Да ли сте сигурни да желите обрисати белешку „%s“?"
 
@@ -548,6 +526,7 @@ msgid "Delete Note"
 msgstr "Обриши белешку"
 
 #: src/ui/strings.vala:21
+#, c-format
 msgid "Are you sure you want to delete the notebook “%s”?"
 msgstr "Да ли сте сигурни да желите обрисати бележницу „%s“?Да"
 
@@ -556,34 +535,42 @@ msgid "Delete Notebook"
 msgstr "Обриши бележницу"
 
 #: src/ui/strings.vala:24
-msgid "Note name shouldn’t contain “.” or “/”"
+#, fuzzy
+msgid "Note names cannot contain a “/”"
 msgstr "Назив белешке не сме садржати „.“ или „/“"
 
 #: src/ui/strings.vala:25
-msgid "Note name shouldn’t be blank"
+#, fuzzy
+msgid "Note names cannot be blank"
 msgstr "Назив белешке "
 
 #: src/ui/strings.vala:26
+#, c-format
 msgid "Note “%s” already exists"
 msgstr "Белешка „%s“ већ постоји"
 
 #: src/ui/strings.vala:27
-msgid "Couldn’t create note"
+#, fuzzy
+msgid "Could not create note"
 msgstr "Не могу направити белешку"
 
 #: src/ui/strings.vala:28
-msgid "Couldn’t change note"
+#, fuzzy
+msgid "Could not change note"
 msgstr "Не могу променити белешку"
 
 #: src/ui/strings.vala:29
-msgid "Couldn’t delete note"
+#, fuzzy
+msgid "Could not delete note"
 msgstr "Не могу обрисати белешку"
 
 #: src/ui/strings.vala:30
-msgid "Couldn’t restore note"
+#, fuzzy
+msgid "Could not restore note"
 msgstr "Не могу повратити белешку"
 
 #: src/ui/strings.vala:31
+#, c-format
 msgid "Saved “%s” to “%s”"
 msgstr "„%s“ сачувано у „%s“"
 
@@ -592,27 +579,33 @@ msgid "Unknown error"
 msgstr "Непозната грешка"
 
 #: src/ui/strings.vala:33
-msgid "Notebook name shouldn’t contain “.” or “/”"
+#, fuzzy
+msgid "Notebook names cannot contain a “/”"
 msgstr "Назив бележнице не сме садржати „.“ или „/“"
 
 #: src/ui/strings.vala:34
-msgid "Notebook name shouldn’t be blank"
+#, fuzzy
+msgid "Notebook names cannot be blank"
 msgstr "Назив бележнице не сме бити празан"
 
 #: src/ui/strings.vala:35
+#, c-format
 msgid "Notebook “%s” already exists"
 msgstr "Бележница „%s“ већ постоји"
 
 #: src/ui/strings.vala:36
-msgid "Couldn’t create notebook"
+#, fuzzy
+msgid "Could not create notebook"
 msgstr "Не могу направити бележницу"
 
 #: src/ui/strings.vala:37
-msgid "Couldn’t change notebook"
+#, fuzzy
+msgid "Could not change notebook"
 msgstr "Не могу променити бележницу"
 
 #: src/ui/strings.vala:38
-msgid "Couldn’t delete notebook"
+#, fuzzy
+msgid "Could not delete notebook"
 msgstr "Не могу обрисати бележницу"
 
 #: src/ui/strings.vala:40
@@ -624,7 +617,7 @@ msgid "Rename"
 msgstr "Преименуј"
 
 #: src/ui/strings.vala:42
-msgid "Couldn’t find an app to handle file URIs"
+msgid "Could not find an app to handle file URIs"
 msgstr ""
 
 #: src/ui/strings.vala:43
@@ -634,6 +627,10 @@ msgstr "Примени"
 #: src/ui/strings.vala:45
 msgid "Pick where the notebooks will be stored"
 msgstr "Изабери место за складиштење белешки"
+
+#: src/ui/strings.vala:46
+msgid "Pick where the trash can will be stored"
+msgstr ""
 
 #: src/ui/strings.vala:47 src/ui/window/notebooks_bar/notebooks_bar.blp:59
 #: src/ui/window/notebooks_bar/notebooks_bar.blp:101
@@ -646,6 +643,110 @@ msgstr ""
 
 #: src/ui/strings.vala:50
 msgid "Extension"
+msgstr ""
+
+#: src/ui/strings.vala:51
+msgid "Unable to recognize URI"
+msgstr ""
+
+#: src/ui/strings.vala:52
+msgid "Pick primary font for notes"
+msgstr ""
+
+#: src/ui/strings.vala:53
+msgid "Pick monospace font for code"
+msgstr ""
+
+#: src/ui/strings.vala:54
+msgid "File Changed On Disk"
+msgstr ""
+
+#: src/ui/strings.vala:55
+msgid ""
+"The file has changed on disk since it was last saved/loaded by Folio.\n"
+"\n"
+"You may do one of the following:\n"
+"\n"
+" • Reload the file (discarding any changes you have made in Folio)\n"
+" • Overwrite the file (discarding any changes made outside of Folio)\n"
+" • Cancel the operation and manually resolve the issue\n"
+"\n"
+"Note: Canceling the save if you have already moved to a new note/notebook "
+"will discard your changes."
+msgstr ""
+
+#: src/ui/strings.vala:56
+msgid "Reload"
+msgstr ""
+
+#: src/ui/strings.vala:57
+msgid "Overwrite"
+msgstr ""
+
+#: src/ui/strings.vala:59
+msgid ""
+"The file has changed on disk by another application.\n"
+"\n"
+"You may do one of the following:\n"
+"\n"
+" • Reload the file (discarding any changes you have made in Folio)\n"
+" • Overwrite the file (discarding any changes made outside of Folio)"
+msgstr ""
+
+#: src/ui/strings.vala:61
+#, c-format
+msgid "Note %i"
+msgstr ""
+
+#: src/ui/strings.vala:62
+msgid "Modified Time - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:63
+msgid "Modified Time - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:64
+msgid "Alphabetical - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:65
+msgid "Alphabetical - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:66
+msgid "Natural - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:67
+msgid "Natural - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:68
+#, c-format
+msgid "Unable to launch external application for file %s."
+msgstr ""
+
+#: src/ui/strings.vala:69
+msgid "Aggressive"
+msgstr ""
+
+#: src/ui/strings.vala:70
+msgid "Strict"
+msgstr ""
+
+#: src/ui/strings.vala:71
+msgid "Disabled"
+msgstr ""
+
+#: src/ui/strings.vala:72
+#, fuzzy, c-format
+msgid "“%s” moved to trash"
+msgstr "Премести у смеће"
+
+#: src/ui/strings.vala:73
+#, c-format
+msgid "“%s” restored"
 msgstr ""
 
 #: src/ui/widgets/theme_selector/theme_selector.blp:15
@@ -677,40 +778,45 @@ msgid "_Keyboard Shortcuts"
 msgstr "П_речице на тастатури"
 
 #: src/ui/window/app_menu/app_menu.blp:43
-msgid "_About"
+#, fuzzy
+msgid "_About Folio"
 msgstr "_О програму"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:54
-msgid "Notebook Name"
-msgstr "Назив бележнице"
-
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:66
-msgid "Duplicate notebook names are not allowed!"
-msgstr ""
-
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:82
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:6
 msgid "First Characters"
 msgstr "Први знакови"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:83
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:7
 msgid "Initials"
 msgstr "Иницијали"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:84
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:8
 msgid "Initials: camelCase"
 msgstr "Иницијали: камилаСтил"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:85
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:9
 msgid "Initials: snake_case"
 msgstr "Иницијали: змијски_стил"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:86
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:10
 msgid "Icon"
 msgstr "Иконица"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:116
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:11
+msgid "Custom"
+msgstr ""
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:16
 msgid "Notebook Color"
 msgstr "Боја бележнице"
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:58
+msgid "Notebook Name"
+msgstr "Назив бележнице"
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:70
+msgid "Duplicate notebook names are not allowed!"
+msgstr ""
 
 #: src/ui/window/notebooks_bar/notebook_create_popup.blp:126
 msgid "Create Notebook"
@@ -728,11 +834,11 @@ msgstr "Премести све у смеће"
 msgid "Notebooks"
 msgstr ""
 
-#: src/ui/window/sidebar/note_create_popup.blp:37
+#: src/ui/window/sidebar/note_create_popup.blp:25
 msgid "Note Name"
 msgstr "Назив белешке"
 
-#: src/ui/window/sidebar/note_create_popup.blp:45
+#: src/ui/window/sidebar/note_create_popup.blp:33
 msgid "Create Note"
 msgstr "Направи белешку"
 
@@ -756,30 +862,37 @@ msgstr "Премести у смеће"
 msgid "Open Containing Folder"
 msgstr "Отвори припадајућу фасциклу"
 
-#: src/ui/window/window.blp:118
+#: src/ui/window/window.blp:123
 msgid "Get started writing"
 msgstr "Започните писање"
 
-#: src/ui/window/window.blp:143
+#: src/ui/window/window.blp:152
+msgid "Open file in external application"
+msgstr ""
+
+#: src/ui/window/window.blp:160
+msgid "Open file"
+msgstr ""
+
+#: src/ui/window/window.blp:181
 msgid "Create a notebook"
 msgstr "Направи бележницу"
 
-#: src/ui/window/window.blp:168
+#: src/ui/window/window.blp:210
 msgid "Trash is empty"
 msgstr "Нема ставки у смећу"
 
-#: src/ui/window/window.blp:224
-msgid "Back"
-msgstr "Назад"
-
-#: src/ui/window/window.blp:239
+#: src/ui/window/window.blp:285
 msgid "Open in Notebook"
 msgstr "Отвори у бележници"
 
-#: src/ui/window/window.blp:264
+#: src/ui/window/window.blp:312
 msgid "_Rename Note"
 msgstr "П_реименуј белешку"
 
-#: src/ui/window/window.blp:270
+#: src/ui/window/window.blp:319
 msgid "_Export Note"
 msgstr "Изв_ези белешку"
+
+#~ msgid "Back"
+#~ msgstr "Назад"

--- a/po/tok.po
+++ b/po/tok.po
@@ -2,229 +2,16 @@
 # This file is distributed under the same license as the Folio package.
 msgid ""
 msgstr ""
+"Project-Id-Version: Folio\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-10-12 16:53+0200\n"
 "PO-Revision-Date: 2024-03-03 00:25:55+0000\n"
+"Language: tok\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: GlotPress/4.0.0\n"
-"Language: tok\n"
-"Project-Id-Version: Folio\n"
-
-#: data/app.gschema.xml:76
-msgid "Notebook sort order"
-msgstr ""
-
-#: data/app.gschema.xml:77
-msgid "The sort order of the notebook list"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:145
-msgid "Sort Order For Notebooks"
-msgstr ""
-
-#: data/app.gschema.xml:71
-msgid "Note sort order"
-msgstr ""
-
-#: data/app.gschema.xml:72
-msgid "The sort order of the note list"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:150
-msgid "Sort Order For Notes"
-msgstr ""
-
-#: src/ui/strings.vala:62
-msgid "Modified Time - Ascending"
-msgstr ""
-
-#: src/ui/strings.vala:63
-msgid "Modified Time - Descending"
-msgstr ""
-
-#: src/ui/strings.vala:64
-msgid "Alphabetical - Ascending"
-msgstr ""
-
-#: src/ui/strings.vala:65
-msgid "Alphabetical - Descending"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:114
-msgid "Display"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:117
-msgid "Full Screen"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:122
-msgid "Zoom In"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:127
-msgid "Zoom Out"
-msgstr ""
-
-#: src/ui/strings.vala:52
-msgid "Pick primary font for notes"
-msgstr ""
-
-#: src/ui/strings.vala:53
-msgid "Pick monospace font for code"
-msgstr ""
-
-#: src/ui/strings.vala:54
-msgid "File Changed On Disk"
-msgstr ""
-
-#: src/ui/strings.vala:55
-msgid ""
-"The file has changed on disk since it was last saved/loaded by Folio.\n"
-"\n"
-"You may do one of the following:\n"
-"\n"
-" • Reload the file (discarding any changes you have made in Folio)\n"
-" • Overwrite the file (discarding any changes made outside of Folio)\n"
-" • Cancel the operation and manually resolve the issue\n"
-"\n"
-"Note: Canceling the save if you have already moved to a new note/notebook will discard your changes."
-msgstr ""
-
-#: src/ui/strings.vala:56
-msgid "Reload"
-msgstr ""
-
-#: src/ui/strings.vala:57
-msgid "Overwrite"
-msgstr ""
-
-#: src/ui/strings.vala:59
-msgid ""
-"The file has changed on disk by another application.\n"
-"\n"
-"You may do one of the following:\n"
-"\n"
-" • Reload the file (discarding any changes you have made in Folio)\n"
-" • Overwrite the file (discarding any changes made outside of Folio)"
-msgstr ""
-
-#: src/ui/strings.vala:61
-msgid "Note %i"
-msgstr ""
-
-#: data/app.gschema.xml:46 src/ui/preferences/preferences.blp:213
-msgid "Trash Storage Location"
-msgstr ""
-
-#: data/app.gschema.xml:47 src/ui/preferences/preferences.blp:214
-msgid "Where the trash folder is located (requires app restart)"
-msgstr ""
-
-#: src/ui/strings.vala:46
-msgid "Pick where the trash can will be stored"
-msgstr ""
-
-#: data/app.gschema.xml:16 src/ui/preferences/preferences.blp:128
-msgid "Use Fixed Width For Notes"
-msgstr ""
-
-#: data/app.gschema.xml:17 src/ui/preferences/preferences.blp:129
-msgid "Use a fixed width for the text area of a note"
-msgstr ""
-
-#: data/app.gschema.xml:37 src/ui/preferences/preferences.blp:118
-msgid "Expands the notebook list to include the notebook name"
-msgstr ""
-
-#: data/app.gschema.xml:51 src/ui/preferences/preferences.blp:65
-msgid "Show line numbers"
-msgstr ""
-
-#: data/app.gschema.xml:52 src/ui/preferences/preferences.blp:66
-msgid "Displays line numbers at the left of the note"
-msgstr ""
-
-#: data/app.gschema.xml:56 src/ui/preferences/preferences.blp:76
-msgid "Show all notes"
-msgstr ""
-
-#: data/app.gschema.xml:57 src/ui/preferences/preferences.blp:77
-msgid "Displays the \"All Notes\" notebook at the top of the notebook list"
-msgstr ""
-
-#: data/app.gschema.xml:61 src/ui/preferences/preferences.blp:163
-msgid "Enable autosave"
-msgstr ""
-
-#: data/app.gschema.xml:62 src/ui/preferences/preferences.blp:164
-msgid "Automatically saves the current note every 30 seconds if the contents have changed (requires app restart)"
-msgstr ""
-
-#: data/app.gschema.xml:66 src/ui/preferences/preferences.blp:174
-msgid "Don't hide the Trash folder"
-msgstr ""
-
-#: data/app.gschema.xml:67
-msgid "The trash folder is set as a hidden folder by default, this option makes it visible"
-msgstr ""
-
-#: data/app.metainfo.xml.in:367
-msgid "Main Folio window in light mode"
-msgstr ""
-
-#: data/app.metainfo.xml.in:371
-msgid "Main Folio window in dark mode"
-msgstr ""
-
-#: data/app.metainfo.xml.in:375
-msgid "Folio on small/mobile screens"
-msgstr ""
-
-#: data/app.metainfo.xml.in:379
-msgid "Folio preferences screen"
-msgstr ""
-
-#: data/app.metainfo.xml.in:383
-msgid "Folio in three pane mode"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:59
-msgid "Tools"
-msgstr ""
-
-#: data/app.gschema.xml:27 src/ui/preferences/preferences.blp:88
-msgid "Displays the formatting toolbar at the bottom of the note"
-msgstr ""
-
-#: data/app.gschema.xml:32 src/ui/preferences/preferences.blp:99
-msgid "Adds a button to the markdown reference sheet on the right of the formatting toolbar"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:111
-msgid "Layout"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:139
-msgid "Fixed Width To Use For Notes"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:140
-msgid "Sets the fixed width size of a note in px"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:157
-msgid "Files"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:175
-msgid "The trash folder is set as a hidden folder by default, this option makes it visible (requires app restart)"
-msgstr ""
-
-#: src/ui/strings.vala:51
-msgid "Unable to recognize URI"
-msgstr ""
 
 #: data/app.desktop.in:9 src/ui/strings.vala:3
 msgid "Folio"
@@ -243,18 +30,18 @@ msgid "Notebook;Note;Notes;Text;Markdown;Notepad;Write;School;Post-it;Sticky;"
 msgstr "lipu;sitelen;Markdown;Matan;sona;"
 
 #: data/app.desktop.in:22 src/ui/popup/shortcut_window.blp:17
-#: src/ui/strings.vala:8 src/ui/window/window.blp:47
-#: src/ui/window/window.blp:124
+#: src/ui/strings.vala:8 src/ui/window/window.blp:54
+#: src/ui/window/window.blp:131
 msgid "New Note"
 msgstr "sitelen sin"
 
 #: data/app.desktop.in:26 src/ui/popup/shortcut_window.blp:37
-#: src/ui/strings.vala:14 src/ui/window/window.blp:149
+#: src/ui/strings.vala:14 src/ui/window/window.blp:189
 msgid "New Notebook"
 msgstr "lipu sin"
 
-#: data/app.desktop.in:30 src/ui/edit_view/toolbar/toolbar.blp:90
-#: src/ui/strings.vala:39 src/ui/window/window.blp:245
+#: data/app.desktop.in:30 src/ui/edit_view/toolbar/toolbar.blp:92
+#: src/ui/strings.vala:39 src/ui/window/window.blp:291
 msgid "Markdown Cheatsheet"
 msgstr "lipu pi nasin Markdown"
 
@@ -262,25 +49,147 @@ msgstr "lipu pi nasin Markdown"
 msgid "Preferences"
 msgstr "nasin"
 
-#: data/app.gschema.xml:6 src/ui/preferences/preferences.blp:18
+#: data/app.gschema.xml:6 src/ui/preferences/preferences.blp:45
 msgid "Note Font"
 msgstr "sitelen pi sitelen lili"
 
-#: data/app.gschema.xml:7 src/ui/preferences/preferences.blp:19
+#: data/app.gschema.xml:7 src/ui/preferences/preferences.blp:46
 msgid "The font notes will be displayed in"
 msgstr "sitelen lili sina li kepeken ni"
 
-#: data/app.gschema.xml:11 src/ui/preferences/preferences.blp:31
+#: data/app.gschema.xml:11 src/ui/preferences/preferences.blp:58
 msgid "Monospace Font"
 msgstr "sitelen pi toki ilo"
 
-#: data/app.gschema.xml:12 src/ui/preferences/preferences.blp:32
+#: data/app.gschema.xml:12 src/ui/preferences/preferences.blp:59
 msgid "The font code will be displayed in"
 msgstr "toki ilo lon sitelen lili sina li kepeken ni"
 
-#: data/app.gschema.xml:21 src/ui/preferences/preferences.blp:46
+#: data/app.gschema.xml:16 src/ui/preferences/preferences.blp:150
+msgid "Use Fixed Width For Notes"
+msgstr ""
+
+#: data/app.gschema.xml:17 src/ui/preferences/preferences.blp:151
+msgid "Use a fixed width for the text area of a note"
+msgstr ""
+
+#: data/app.gschema.xml:21 src/ui/preferences/preferences.blp:18
 msgid "OLED Mode"
 msgstr "nasin OLED"
+
+#: data/app.gschema.xml:22 src/ui/preferences/preferences.blp:19
+msgid "Makes the dark theme pitch black"
+msgstr "pimeja li pimeja mute"
+
+#: data/app.gschema.xml:26 src/ui/preferences/preferences.blp:109
+msgid "Enable Toolbar"
+msgstr "palisa ilo"
+
+#: data/app.gschema.xml:27 src/ui/preferences/preferences.blp:110
+msgid "Displays the formatting toolbar at the bottom of the note"
+msgstr ""
+
+#: data/app.gschema.xml:31 src/ui/preferences/preferences.blp:120
+msgid "Enable Cheatsheet"
+msgstr ""
+
+#: data/app.gschema.xml:32 src/ui/preferences/preferences.blp:121
+msgid ""
+"Adds a button to the markdown reference sheet on the right of the formatting "
+"toolbar"
+msgstr ""
+
+#: data/app.gschema.xml:36 src/ui/preferences/preferences.blp:139
+msgid "3-Pane Layout"
+msgstr "nasin pi kipisi 3"
+
+#: data/app.gschema.xml:37 src/ui/preferences/preferences.blp:140
+msgid "Expands the notebook list to include the notebook name"
+msgstr ""
+
+#: data/app.gschema.xml:41 src/ui/preferences/preferences.blp:207
+msgid "Notes Storage Location"
+msgstr "kulupu lipu"
+
+#: data/app.gschema.xml:42 src/ui/preferences/preferences.blp:208
+msgid "Where the notebooks are stored (requires app restart)"
+msgstr "lipu sina li lon ni (wile kama sin)"
+
+#: data/app.gschema.xml:46 src/ui/preferences/preferences.blp:235
+msgid "Trash Storage Location"
+msgstr ""
+
+#: data/app.gschema.xml:47 src/ui/preferences/preferences.blp:236
+msgid "Where the trash folder is located (requires app restart)"
+msgstr ""
+
+#: data/app.gschema.xml:51 src/ui/preferences/preferences.blp:87
+msgid "Show line numbers"
+msgstr ""
+
+#: data/app.gschema.xml:52 src/ui/preferences/preferences.blp:88
+msgid "Displays line numbers at the left of the note"
+msgstr ""
+
+#: data/app.gschema.xml:56 src/ui/preferences/preferences.blp:98
+msgid "Show all notes"
+msgstr ""
+
+#: data/app.gschema.xml:57 src/ui/preferences/preferences.blp:99
+msgid "Displays the \"All Notes\" notebook at the top of the notebook list"
+msgstr ""
+
+#: data/app.gschema.xml:61 src/ui/preferences/preferences.blp:185
+msgid "Enable autosave"
+msgstr ""
+
+#: data/app.gschema.xml:62 src/ui/preferences/preferences.blp:186
+msgid ""
+"Automatically saves the current note every 30 seconds if the contents have "
+"changed (requires app restart)"
+msgstr ""
+
+#: data/app.gschema.xml:66 src/ui/preferences/preferences.blp:196
+msgid "Don't hide the Trash folder"
+msgstr ""
+
+#: data/app.gschema.xml:67
+msgid ""
+"The trash folder is set as a hidden folder by default, this option makes it "
+"visible"
+msgstr ""
+
+#: data/app.gschema.xml:71
+msgid "Note sort order"
+msgstr ""
+
+#: data/app.gschema.xml:72
+msgid "The sort order of the note list"
+msgstr ""
+
+#: data/app.gschema.xml:76
+msgid "Notebook sort order"
+msgstr ""
+
+#: data/app.gschema.xml:77
+msgid "The sort order of the notebook list"
+msgstr ""
+
+#: data/app.gschema.xml:81
+msgid "URL detection level"
+msgstr ""
+
+#: data/app.gschema.xml:82
+msgid "How agressive to look for URLs in markdown text"
+msgstr ""
+
+#: data/app.gschema.xml:86
+msgid "Line spacing"
+msgstr ""
+
+#: data/app.gschema.xml:87 src/ui/preferences/preferences.blp:74
+msgid "The line spacing for the note text"
+msgstr ""
 
 #: data/app.metainfo.xml.in:5
 msgid "Take notes in Markdown"
@@ -314,103 +223,116 @@ msgstr ""
 msgid "Trash can"
 msgstr "jaki poki"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:23
-#: src/ui/edit_view/toolbar/toolbar.blp:131
+#: data/app.metainfo.xml.in:393
+msgid "Main Folio window in light mode"
+msgstr ""
+
+#: data/app.metainfo.xml.in:397
+msgid "Main Folio window in dark mode"
+msgstr ""
+
+#: data/app.metainfo.xml.in:401
+msgid "Folio on small/mobile screens"
+msgstr ""
+
+#: data/app.metainfo.xml.in:405
+msgid "Folio preferences screen"
+msgstr ""
+
+#: data/app.metainfo.xml.in:409
+msgid "Folio in three pane mode"
+msgstr ""
+
+#: src/ui/edit_view/toolbar/toolbar.blp:6
 #: src/ui/widgets/markdown/heading_popover.blp:48
 msgid "Plain Text"
 msgstr "sitelen ali"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:24
-#: src/ui/edit_view/toolbar/toolbar.blp:132
+#: src/ui/edit_view/toolbar/toolbar.blp:7
 #: src/ui/widgets/markdown/heading_popover.blp:12
 msgid "Heading 1"
 msgstr "sitelen suli 1"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:25
-#: src/ui/edit_view/toolbar/toolbar.blp:133
+#: src/ui/edit_view/toolbar/toolbar.blp:8
 #: src/ui/widgets/markdown/heading_popover.blp:18
 msgid "Heading 2"
 msgstr "sitelen suli 2"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:26
-#: src/ui/edit_view/toolbar/toolbar.blp:134
+#: src/ui/edit_view/toolbar/toolbar.blp:9
 #: src/ui/widgets/markdown/heading_popover.blp:24
 msgid "Heading 3"
 msgstr "sitelen suli 3"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:27
-#: src/ui/edit_view/toolbar/toolbar.blp:135
+#: src/ui/edit_view/toolbar/toolbar.blp:10
 #: src/ui/widgets/markdown/heading_popover.blp:30
 msgid "Heading 4"
 msgstr "sitelen suli 4"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:28
-#: src/ui/edit_view/toolbar/toolbar.blp:136
+#: src/ui/edit_view/toolbar/toolbar.blp:11
 #: src/ui/widgets/markdown/heading_popover.blp:36
 msgid "Heading 5"
 msgstr "sitelen suli 5"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:29
-#: src/ui/edit_view/toolbar/toolbar.blp:137
+#: src/ui/edit_view/toolbar/toolbar.blp:12
 #: src/ui/widgets/markdown/heading_popover.blp:42
 msgid "Heading 6"
 msgstr "sitelen suli 6"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:39
-#: src/ui/edit_view/toolbar/toolbar.blp:104
-#: src/ui/edit_view/toolbar/toolbar.blp:148
-#: src/ui/edit_view/toolbar/toolbar.blp:201 src/ui/popup/shortcut_window.blp:72
+#: src/ui/edit_view/toolbar/toolbar.blp:41
+#: src/ui/edit_view/toolbar/toolbar.blp:107
+#: src/ui/edit_view/toolbar/toolbar.blp:142
+#: src/ui/edit_view/toolbar/toolbar.blp:195 src/ui/popup/shortcut_window.blp:72
 msgid "Bold"
 msgstr "sitelen wawa"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:45
-#: src/ui/edit_view/toolbar/toolbar.blp:111
-#: src/ui/edit_view/toolbar/toolbar.blp:155
-#: src/ui/edit_view/toolbar/toolbar.blp:202 src/ui/popup/shortcut_window.blp:77
+#: src/ui/edit_view/toolbar/toolbar.blp:47
+#: src/ui/edit_view/toolbar/toolbar.blp:114
+#: src/ui/edit_view/toolbar/toolbar.blp:149
+#: src/ui/edit_view/toolbar/toolbar.blp:196 src/ui/popup/shortcut_window.blp:77
 msgid "Italic"
 msgstr "sitelen linja"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:51
-#: src/ui/edit_view/toolbar/toolbar.blp:162
-#: src/ui/edit_view/toolbar/toolbar.blp:203 src/ui/popup/shortcut_window.blp:82
+#: src/ui/edit_view/toolbar/toolbar.blp:53
+#: src/ui/edit_view/toolbar/toolbar.blp:156
+#: src/ui/edit_view/toolbar/toolbar.blp:197 src/ui/popup/shortcut_window.blp:82
 msgid "Strikethrough"
 msgstr "sitelen pakala"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:57
-#: src/ui/edit_view/toolbar/toolbar.blp:169
-#: src/ui/edit_view/toolbar/toolbar.blp:204 src/ui/popup/shortcut_window.blp:87
+#: src/ui/edit_view/toolbar/toolbar.blp:59
+#: src/ui/edit_view/toolbar/toolbar.blp:163
+#: src/ui/edit_view/toolbar/toolbar.blp:198 src/ui/popup/shortcut_window.blp:87
 msgid "Highlight"
 msgstr "sitelen kule"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:67
-#: src/ui/edit_view/toolbar/toolbar.blp:193 src/ui/popup/shortcut_window.blp:92
+#: src/ui/edit_view/toolbar/toolbar.blp:69
+#: src/ui/edit_view/toolbar/toolbar.blp:187 src/ui/popup/shortcut_window.blp:92
 msgid "Insert Link"
 msgstr "pana sitelen nasin"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:73
-#: src/ui/edit_view/toolbar/toolbar.blp:194
+#: src/ui/edit_view/toolbar/toolbar.blp:75
+#: src/ui/edit_view/toolbar/toolbar.blp:188
 msgid "Insert Code"
 msgstr "pana toki ilo"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:79
-#: src/ui/edit_view/toolbar/toolbar.blp:195
+#: src/ui/edit_view/toolbar/toolbar.blp:81
+#: src/ui/edit_view/toolbar/toolbar.blp:189
 msgid "Insert Horizontal Rule"
 msgstr "pana palisa"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:118
+#: src/ui/edit_view/toolbar/toolbar.blp:121
 msgid "Format"
 msgstr "sitelen nasin"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:181
+#: src/ui/edit_view/toolbar/toolbar.blp:175
 msgid "Insert"
 msgstr "pana sitelen"
 
-#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:34
+#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:18
 #: src/ui/strings.vala:44 src/ui/strings.vala:58
 msgid "Cancel"
 msgstr "pini"
 
-#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:39
+#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:23
 msgid "Confirm"
 msgstr "toki lon"
 
@@ -454,37 +376,85 @@ msgstr "sitelen nasin"
 msgid "Navigation"
 msgstr "lawa tawa"
 
-#: src/ui/popup/shortcut_window.blp:102 src/ui/window/window.blp:216
+#: src/ui/popup/shortcut_window.blp:102 src/ui/window/window.blp:268
 msgid "Toggle Sidebar"
 msgstr "o ante e palisa poka"
 
-#: src/ui/popup/shortcut_window.blp:107 src/ui/window/window.blp:63
+#: src/ui/popup/shortcut_window.blp:107 src/ui/window/window.blp:70
 msgid "Search Notes"
 msgstr "lukin sitelen lili"
 
-#: data/app.gschema.xml:22 src/ui/preferences/preferences.blp:47
-msgid "Makes the dark theme pitch black"
-msgstr "pimeja li pimeja mute"
-
-#: data/app.gschema.xml:26 src/ui/preferences/preferences.blp:87
-msgid "Enable Toolbar"
-msgstr "palisa ilo"
-
-#: data/app.gschema.xml:31 src/ui/preferences/preferences.blp:98
-msgid "Enable Cheatsheet"
+#: src/ui/popup/shortcut_window.blp:114
+msgid "Display"
 msgstr ""
 
-#: data/app.gschema.xml:36 src/ui/preferences/preferences.blp:117
-msgid "3-Pane Layout"
-msgstr "nasin pi kipisi 3"
+#: src/ui/popup/shortcut_window.blp:117
+msgid "Full Screen"
+msgstr ""
 
-#: data/app.gschema.xml:41 src/ui/preferences/preferences.blp:185
-msgid "Notes Storage Location"
-msgstr "kulupu lipu"
+#: src/ui/popup/shortcut_window.blp:122
+msgid "Zoom In"
+msgstr ""
 
-#: data/app.gschema.xml:42 src/ui/preferences/preferences.blp:186
-msgid "Where the notebooks are stored (requires app restart)"
-msgstr "lipu sina li lon ni (wile kama sin)"
+#: src/ui/popup/shortcut_window.blp:127
+msgid "Zoom Out"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:31
+#, fuzzy
+msgid "Markdown URL Detection"
+msgstr "lipu pi nasin Markdown"
+
+#: src/ui/preferences/preferences.blp:32
+msgid ""
+"Determines the level of detection of URLs in\n"
+"free form text is used:\n"
+" - Aggressive tries to find all URLs\n"
+" - Strict requires a protocol identifier (ie http://)\n"
+" - Disabled turns detection off."
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:39
+msgid "Fonts"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:73
+msgid "Line Spacing"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:81
+msgid "Tools"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:133
+msgid "Layout"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:161
+msgid "Fixed Width To Use For Notes"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:162
+msgid "Sets the fixed width size of a note in px"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:167
+msgid "Sort Order For Notebooks"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:172
+msgid "Sort Order For Notes"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:179
+msgid "Files"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:197
+msgid ""
+"The trash folder is set as a hidden folder by default, this option makes it "
+"visible (requires app restart)"
+msgstr ""
 
 #: src/ui/strings.vala:4 src/ui/window/notebooks_bar/notebooks_bar.blp:129
 #: src/ui/window/notebooks_bar/notebooks_bar.blp:171
@@ -492,6 +462,7 @@ msgid "Trash"
 msgstr "jaki"
 
 #: src/ui/strings.vala:5
+#, c-format
 msgid "%d Notes"
 msgstr "sitelen %d"
 
@@ -499,7 +470,7 @@ msgstr "sitelen %d"
 msgid "Are you sure you want to delete everything in the trash?"
 msgstr "sina wawa ala wawa ni: sina wile weka e jaki ale?"
 
-#: src/ui/strings.vala:7 src/ui/window/window.blp:54
+#: src/ui/strings.vala:7 src/ui/window/window.blp:61
 msgid "Empty Trash"
 msgstr "o weka e jaki"
 
@@ -536,10 +507,12 @@ msgid "Move"
 msgstr "o tawa"
 
 #: src/ui/strings.vala:18
+#, c-format
 msgid "Note “%s” already exists in notebook “%s”"
 msgstr "pini la, sitelen “%s” li lon lipu “%s”"
 
 #: src/ui/strings.vala:19
+#, c-format
 msgid "Are you sure you want to delete the note “%s”?"
 msgstr "sina wawa ala wawa ni: sina wile weka e sitelen “%s”?"
 
@@ -548,6 +521,7 @@ msgid "Delete Note"
 msgstr "o weka e sitelen lili"
 
 #: src/ui/strings.vala:21
+#, c-format
 msgid "Are you sure you want to delete the notebook “%s”?"
 msgstr "sina wawa ala wawa ni: sina wile weka e lipu “%s”?"
 
@@ -556,34 +530,42 @@ msgid "Delete Notebook"
 msgstr "o weka e lipu"
 
 #: src/ui/strings.vala:24
-msgid "Note name shouldn’t contain “.” or “/”"
+#, fuzzy
+msgid "Note names cannot contain a “/”"
 msgstr "nimi sitelen li wile ala jo e “.”, e “/”"
 
 #: src/ui/strings.vala:25
-msgid "Note name shouldn’t be blank"
+#, fuzzy
+msgid "Note names cannot be blank"
 msgstr "nimi sitelen li wile ala jo ala"
 
 #: src/ui/strings.vala:26
+#, c-format
 msgid "Note “%s” already exists"
 msgstr "pini la, sitelen “%s” li lon"
 
 #: src/ui/strings.vala:27
-msgid "Couldn’t create note"
+#, fuzzy
+msgid "Could not create note"
 msgstr "pali ala e sitelen"
 
 #: src/ui/strings.vala:28
-msgid "Couldn’t change note"
+#, fuzzy
+msgid "Could not change note"
 msgstr "ante ala e sitelen"
 
 #: src/ui/strings.vala:29
-msgid "Couldn’t delete note"
+#, fuzzy
+msgid "Could not delete note"
 msgstr "weka ala e sitelen"
 
 #: src/ui/strings.vala:30
-msgid "Couldn’t restore note"
+#, fuzzy
+msgid "Could not restore note"
 msgstr "pona ala e sitelen"
 
 #: src/ui/strings.vala:31
+#, c-format
 msgid "Saved “%s” to “%s”"
 msgstr "awen e ijo “%s” lon “%s”"
 
@@ -592,27 +574,33 @@ msgid "Unknown error"
 msgstr "pakala pi sona ala"
 
 #: src/ui/strings.vala:33
-msgid "Notebook name shouldn’t contain “.” or “/”"
+#, fuzzy
+msgid "Notebook names cannot contain a “/”"
 msgstr "nimi lipu li wile ala jo e “.”, e “/”"
 
 #: src/ui/strings.vala:34
-msgid "Notebook name shouldn’t be blank"
+#, fuzzy
+msgid "Notebook names cannot be blank"
 msgstr "nimi lipu li wile ala jo ala"
 
 #: src/ui/strings.vala:35
+#, c-format
 msgid "Notebook “%s” already exists"
 msgstr "pini la, lipu “%s” li lon"
 
 #: src/ui/strings.vala:36
-msgid "Couldn’t create notebook"
+#, fuzzy
+msgid "Could not create notebook"
 msgstr "pali ala e lipu"
 
 #: src/ui/strings.vala:37
-msgid "Couldn’t change notebook"
+#, fuzzy
+msgid "Could not change notebook"
 msgstr "ante ala e lipu"
 
 #: src/ui/strings.vala:38
-msgid "Couldn’t delete notebook"
+#, fuzzy
+msgid "Could not delete notebook"
 msgstr "weka ala e lipu"
 
 #: src/ui/strings.vala:40
@@ -624,7 +612,7 @@ msgid "Rename"
 msgstr "o ante e nimi"
 
 #: src/ui/strings.vala:42
-msgid "Couldn’t find an app to handle file URIs"
+msgid "Could not find an app to handle file URIs"
 msgstr ""
 
 #: src/ui/strings.vala:43
@@ -634,6 +622,10 @@ msgstr "kepeken"
 #: src/ui/strings.vala:45
 msgid "Pick where the notebooks will be stored"
 msgstr "lipu sina li lon ni"
+
+#: src/ui/strings.vala:46
+msgid "Pick where the trash can will be stored"
+msgstr ""
 
 #: src/ui/strings.vala:47 src/ui/window/notebooks_bar/notebooks_bar.blp:59
 #: src/ui/window/notebooks_bar/notebooks_bar.blp:101
@@ -646,6 +638,110 @@ msgstr ""
 
 #: src/ui/strings.vala:50
 msgid "Extension"
+msgstr ""
+
+#: src/ui/strings.vala:51
+msgid "Unable to recognize URI"
+msgstr ""
+
+#: src/ui/strings.vala:52
+msgid "Pick primary font for notes"
+msgstr ""
+
+#: src/ui/strings.vala:53
+msgid "Pick monospace font for code"
+msgstr ""
+
+#: src/ui/strings.vala:54
+msgid "File Changed On Disk"
+msgstr ""
+
+#: src/ui/strings.vala:55
+msgid ""
+"The file has changed on disk since it was last saved/loaded by Folio.\n"
+"\n"
+"You may do one of the following:\n"
+"\n"
+" • Reload the file (discarding any changes you have made in Folio)\n"
+" • Overwrite the file (discarding any changes made outside of Folio)\n"
+" • Cancel the operation and manually resolve the issue\n"
+"\n"
+"Note: Canceling the save if you have already moved to a new note/notebook "
+"will discard your changes."
+msgstr ""
+
+#: src/ui/strings.vala:56
+msgid "Reload"
+msgstr ""
+
+#: src/ui/strings.vala:57
+msgid "Overwrite"
+msgstr ""
+
+#: src/ui/strings.vala:59
+msgid ""
+"The file has changed on disk by another application.\n"
+"\n"
+"You may do one of the following:\n"
+"\n"
+" • Reload the file (discarding any changes you have made in Folio)\n"
+" • Overwrite the file (discarding any changes made outside of Folio)"
+msgstr ""
+
+#: src/ui/strings.vala:61
+#, c-format
+msgid "Note %i"
+msgstr ""
+
+#: src/ui/strings.vala:62
+msgid "Modified Time - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:63
+msgid "Modified Time - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:64
+msgid "Alphabetical - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:65
+msgid "Alphabetical - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:66
+msgid "Natural - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:67
+msgid "Natural - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:68
+#, c-format
+msgid "Unable to launch external application for file %s."
+msgstr ""
+
+#: src/ui/strings.vala:69
+msgid "Aggressive"
+msgstr ""
+
+#: src/ui/strings.vala:70
+msgid "Strict"
+msgstr ""
+
+#: src/ui/strings.vala:71
+msgid "Disabled"
+msgstr ""
+
+#: src/ui/strings.vala:72
+#, fuzzy, c-format
+msgid "“%s” moved to trash"
+msgstr "o tawa lon jaki poki"
+
+#: src/ui/strings.vala:73
+#, c-format
+msgid "“%s” restored"
 msgstr ""
 
 #: src/ui/widgets/theme_selector/theme_selector.blp:15
@@ -677,40 +773,45 @@ msgid "_Keyboard Shortcuts"
 msgstr "ijo pi _tenpo lili pi ilo sitelen"
 
 #: src/ui/window/app_menu/app_menu.blp:43
-msgid "_About"
+#, fuzzy
+msgid "_About Folio"
 msgstr "_lon"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:54
-msgid "Notebook Name"
-msgstr "nimi lipu"
-
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:66
-msgid "Duplicate notebook names are not allowed!"
-msgstr ""
-
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:82
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:6
 msgid "First Characters"
 msgstr "sitelen kipisi wan"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:83
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:7
 msgid "Initials"
 msgstr "nimi kipisi wan"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:84
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:8
 msgid "Initials: camelCase"
 msgstr "nimi kipisi wan: camelCase"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:85
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:9
 msgid "Initials: snake_case"
 msgstr "nimi kipisi wan: snake_case"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:86
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:10
 msgid "Icon"
 msgstr "sitelen leko lili"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:116
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:11
+msgid "Custom"
+msgstr ""
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:16
 msgid "Notebook Color"
 msgstr "kule lipu"
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:58
+msgid "Notebook Name"
+msgstr "nimi lipu"
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:70
+msgid "Duplicate notebook names are not allowed!"
+msgstr ""
 
 #: src/ui/window/notebooks_bar/notebook_create_popup.blp:126
 msgid "Create Notebook"
@@ -728,11 +829,11 @@ msgstr "o tawa e ali lon jaki poki"
 msgid "Notebooks"
 msgstr ""
 
-#: src/ui/window/sidebar/note_create_popup.blp:37
+#: src/ui/window/sidebar/note_create_popup.blp:25
 msgid "Note Name"
 msgstr "nimi pi sitelen lili"
 
-#: src/ui/window/sidebar/note_create_popup.blp:45
+#: src/ui/window/sidebar/note_create_popup.blp:33
 msgid "Create Note"
 msgstr "o pali e sitelen"
 
@@ -756,30 +857,37 @@ msgstr "o tawa lon jaki poki"
 msgid "Open Containing Folder"
 msgstr "o open kulupu lipu poki"
 
-#: src/ui/window/window.blp:118
+#: src/ui/window/window.blp:123
 msgid "Get started writing"
 msgstr "o open sitelen"
 
-#: src/ui/window/window.blp:143
+#: src/ui/window/window.blp:152
+msgid "Open file in external application"
+msgstr ""
+
+#: src/ui/window/window.blp:160
+msgid "Open file"
+msgstr ""
+
+#: src/ui/window/window.blp:181
 msgid "Create a notebook"
 msgstr "o pali e lipu"
 
-#: src/ui/window/window.blp:168
+#: src/ui/window/window.blp:210
 msgid "Trash is empty"
 msgstr "jaki poki li ala"
 
-#: src/ui/window/window.blp:224
-msgid "Back"
-msgstr "monsi"
-
-#: src/ui/window/window.blp:239
+#: src/ui/window/window.blp:285
 msgid "Open in Notebook"
 msgstr "o open lon lipu"
 
-#: src/ui/window/window.blp:264
+#: src/ui/window/window.blp:312
 msgid "_Rename Note"
 msgstr "o ante e _nimi pi sitelen"
 
-#: src/ui/window/window.blp:270
+#: src/ui/window/window.blp:319
 msgid "_Export Note"
 msgstr "o awen _ete e sitelen lili"
+
+#~ msgid "Back"
+#~ msgstr "monsi"

--- a/po/tr.po
+++ b/po/tr.po
@@ -2,244 +2,16 @@
 # This file is distributed under the same license as the Folio package.
 msgid ""
 msgstr ""
+"Project-Id-Version: Folio\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-10-12 16:53+0200\n"
 "PO-Revision-Date: 2024-03-23 22:50:27+0000\n"
+"Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: GlotPress/4.0.0\n"
-"Language: tr\n"
-"Project-Id-Version: Folio\n"
-
-#: data/app.gschema.xml:76
-msgid "Notebook sort order"
-msgstr "Not defteri sıralama düzeni"
-
-#: data/app.gschema.xml:77
-msgid "The sort order of the notebook list"
-msgstr "Not defteri listelerinin sıralama düzeni"
-
-#: src/ui/preferences/preferences.blp:145
-msgid "Sort Order For Notebooks"
-msgstr "Not defterleri için sıralama düzeni"
-
-#: data/app.gschema.xml:71
-msgid "Note sort order"
-msgstr "Not sıralama düzeni"
-
-#: data/app.gschema.xml:72
-msgid "The sort order of the note list"
-msgstr "Not listesinin sıralama düzeni"
-
-#: src/ui/preferences/preferences.blp:150
-msgid "Sort Order For Notes"
-msgstr "Not listesinin sıralama düzeni"
-
-#: src/ui/strings.vala:62
-msgid "Modified Time - Ascending"
-msgstr "Değiştirilme Tarihi - Azalan"
-
-#: src/ui/strings.vala:63
-msgid "Modified Time - Descending"
-msgstr "Değiştirilme Tarihi - Artan"
-
-#: src/ui/strings.vala:64
-msgid "Alphabetical - Ascending"
-msgstr "Alfabetik - A-Z"
-
-#: src/ui/strings.vala:65
-msgid "Alphabetical - Descending"
-msgstr "Alfabetik - Z-A"
-
-#: src/ui/popup/shortcut_window.blp:114
-msgid "Display"
-msgstr "Göster"
-
-#: src/ui/popup/shortcut_window.blp:117
-msgid "Full Screen"
-msgstr "Tam Ekran"
-
-#: src/ui/popup/shortcut_window.blp:122
-msgid "Zoom In"
-msgstr "Yakınlaştır"
-
-#: src/ui/popup/shortcut_window.blp:127
-msgid "Zoom Out"
-msgstr "Uzaklaştır"
-
-#: src/ui/strings.vala:52
-msgid "Pick primary font for notes"
-msgstr "Notlar için birincil yazı tipini seç"
-
-#: src/ui/strings.vala:53
-msgid "Pick monospace font for code"
-msgstr "Kod için eş aralıklı yazı tipi seç"
-
-#: src/ui/strings.vala:54
-msgid "File Changed On Disk"
-msgstr "Diskteki Dosya Değiştirildi"
-
-#: src/ui/strings.vala:55
-msgid ""
-"The file has changed on disk since it was last saved/loaded by Folio.\n"
-"\n"
-"You may do one of the following:\n"
-"\n"
-" • Reload the file (discarding any changes you have made in Folio)\n"
-" • Overwrite the file (discarding any changes made outside of Folio)\n"
-" • Cancel the operation and manually resolve the issue\n"
-"\n"
-"Note: Canceling the save if you have already moved to a new note/notebook will discard your changes."
-msgstr ""
-"Dosya, Folio tarafından en son kaydedildiğinden/yüklendiğinden beri disk üzerinde değiştirildi.\n"
-"\n"
-"Aşağıdakilerden birini yapabilirsiniz:\n"
-"\n"
-" - Dosyayı yeniden yüklemek (Folio ile yaptığınız tüm değişiklikler gözden çıkarılır)\n"
-" - Dosyanın üzerine yazmak (Folio dışında yapılan tüm değişiklikler gözden çıkarılır)\n"
-" - İşlemi iptal etmek ve sorunu elle düzeltmek\n"
-"\n"
-"Not: Zaten yeni bir nota/deftere geçtiyseniz kaydetmezseniz değişiklikleriniz gözden çıkarılır."
-
-#: src/ui/strings.vala:56
-msgid "Reload"
-msgstr "Yeniden Yükle"
-
-#: src/ui/strings.vala:57
-msgid "Overwrite"
-msgstr "Üzerine Yaz"
-
-#: src/ui/strings.vala:59
-msgid ""
-"The file has changed on disk by another application.\n"
-"\n"
-"You may do one of the following:\n"
-"\n"
-" • Reload the file (discarding any changes you have made in Folio)\n"
-" • Overwrite the file (discarding any changes made outside of Folio)"
-msgstr ""
-"Dosya disk üzerinde başka bir uygulama tarafından değiştirildi.\n"
-"\n"
-"Aşağıdakilerden birini yapabilirsiniz:\n"
-"\n"
-" - Dosyayı yeniden yüklemek (Folio ile yaptığınız tüm değişiklikler gözden çıkarılır)\n"
-" - Dosyanın üzerine yazmak (Folio dışında yapılan tüm değişiklikler gözden çıkarılır)"
-
-#: src/ui/strings.vala:61
-msgid "Note %i"
-msgstr "Not %i"
-
-#: data/app.gschema.xml:46 src/ui/preferences/preferences.blp:213
-msgid "Trash Storage Location"
-msgstr "Çöp Depolama Konumu"
-
-#: data/app.gschema.xml:47 src/ui/preferences/preferences.blp:214
-msgid "Where the trash folder is located (requires app restart)"
-msgstr "Çöp kutusu klasörünün konumu (uygulamanın yeniden başlatılmasını gerektirir)"
-
-#: src/ui/strings.vala:46
-msgid "Pick where the trash can will be stored"
-msgstr "Çöp kutusunun nerede depolanacağını seçin"
-
-#: data/app.gschema.xml:16 src/ui/preferences/preferences.blp:128
-msgid "Use Fixed Width For Notes"
-msgstr "Notlar İçin Sabit Genişlik Kullan"
-
-#: data/app.gschema.xml:17 src/ui/preferences/preferences.blp:129
-msgid "Use a fixed width for the text area of a note"
-msgstr "Notun metin alanı için sabit genişlik kullan"
-
-#: data/app.gschema.xml:37 src/ui/preferences/preferences.blp:118
-msgid "Expands the notebook list to include the notebook name"
-msgstr "Not defteri listesini not defteri adını içerecek şekilde genişletir"
-
-#: data/app.gschema.xml:51 src/ui/preferences/preferences.blp:65
-msgid "Show line numbers"
-msgstr "Satır numaralarını göster"
-
-#: data/app.gschema.xml:52 src/ui/preferences/preferences.blp:66
-msgid "Displays line numbers at the left of the note"
-msgstr "Notun solunda satır numaralarını gösterir"
-
-#: data/app.gschema.xml:56 src/ui/preferences/preferences.blp:76
-msgid "Show all notes"
-msgstr "Tüm notları göster"
-
-#: data/app.gschema.xml:57 src/ui/preferences/preferences.blp:77
-msgid "Displays the \"All Notes\" notebook at the top of the notebook list"
-msgstr "\"Tüm Notlar\" not defterini not defteri listesinin en üstünde gösterir"
-
-#: data/app.gschema.xml:61 src/ui/preferences/preferences.blp:163
-msgid "Enable autosave"
-msgstr "Kendiliğinden kaydetmeyi etkinleştir"
-
-#: data/app.gschema.xml:62 src/ui/preferences/preferences.blp:164
-msgid "Automatically saves the current note every 30 seconds if the contents have changed (requires app restart)"
-msgstr "İçerik değiştiyse var olan notu 30 saniyede bir kendiliğinden kaydeder (uygulamanın yeniden başlatılmasını gerektirir)"
-
-#: data/app.gschema.xml:66 src/ui/preferences/preferences.blp:174
-msgid "Don't hide the Trash folder"
-msgstr "Çöp Kutusu klasörünü gizleme"
-
-#: data/app.gschema.xml:67
-msgid "The trash folder is set as a hidden folder by default, this option makes it visible"
-msgstr "Çöp klasörü öntanımlı olarak gizlidir, bu seçenek onu görünür hale getirir"
-
-#: data/app.metainfo.xml.in:367
-msgid "Main Folio window in light mode"
-msgstr "Açık kipte Folio ana penceresi"
-
-#: data/app.metainfo.xml.in:371
-msgid "Main Folio window in dark mode"
-msgstr "Koyu kipte Folio ana penceresi"
-
-#: data/app.metainfo.xml.in:375
-msgid "Folio on small/mobile screens"
-msgstr "Küçük/mobil ekranda Folio"
-
-#: data/app.metainfo.xml.in:379
-msgid "Folio preferences screen"
-msgstr "Folio tercihler penceresi"
-
-#: data/app.metainfo.xml.in:383
-msgid "Folio in three pane mode"
-msgstr "Folio üç bölmeli kipte"
-
-#: src/ui/preferences/preferences.blp:59
-msgid "Tools"
-msgstr "Araçlar"
-
-#: data/app.gschema.xml:27 src/ui/preferences/preferences.blp:88
-msgid "Displays the formatting toolbar at the bottom of the note"
-msgstr "Notun altındaki biçimlendirme araç çubuğunu gösterir"
-
-#: data/app.gschema.xml:32 src/ui/preferences/preferences.blp:99
-msgid "Adds a button to the markdown reference sheet on the right of the formatting toolbar"
-msgstr "Biçimlendirme araç çubuğunun sağındaki markdown referans sayfasına düğme ekler"
-
-#: src/ui/preferences/preferences.blp:111
-msgid "Layout"
-msgstr "Düzen"
-
-#: src/ui/preferences/preferences.blp:139
-msgid "Fixed Width To Use For Notes"
-msgstr "Notlar İçin Kullanılacak Sabit Genişlik"
-
-#: src/ui/preferences/preferences.blp:140
-msgid "Sets the fixed width size of a note in px"
-msgstr "Notun sabit genişlik boyutunu px cinsinden ayarlar"
-
-#: src/ui/preferences/preferences.blp:157
-msgid "Files"
-msgstr "Dosyalar"
-
-#: src/ui/preferences/preferences.blp:175
-msgid "The trash folder is set as a hidden folder by default, this option makes it visible (requires app restart)"
-msgstr "Çöp klasörü öntanımlı olarak gizlidir, bu seçenek onu görünür hale getirir (uygulamanın yeniden başlatılmasını gerektirir)"
-
-#: src/ui/strings.vala:51
-msgid "Unable to recognize URI"
-msgstr "URI tanınmadı"
 
 #: data/app.desktop.in:9 src/ui/strings.vala:3
 msgid "Folio"
@@ -255,21 +27,23 @@ msgstr "Notlar al"
 
 #: data/app.desktop.in:13
 msgid "Notebook;Note;Notes;Text;Markdown;Notepad;Write;School;Post-it;Sticky;"
-msgstr "Not defteri;not;notlar;metin;markdown;not defteri;yaz;okul;post-it;yapışkan not;yapışkan;"
+msgstr ""
+"Not defteri;not;notlar;metin;markdown;not defteri;yaz;okul;post-it;yapışkan "
+"not;yapışkan;"
 
 #: data/app.desktop.in:22 src/ui/popup/shortcut_window.blp:17
-#: src/ui/strings.vala:8 src/ui/window/window.blp:47
-#: src/ui/window/window.blp:124
+#: src/ui/strings.vala:8 src/ui/window/window.blp:54
+#: src/ui/window/window.blp:131
 msgid "New Note"
 msgstr "Yeni Not"
 
 #: data/app.desktop.in:26 src/ui/popup/shortcut_window.blp:37
-#: src/ui/strings.vala:14 src/ui/window/window.blp:149
+#: src/ui/strings.vala:14 src/ui/window/window.blp:189
 msgid "New Notebook"
 msgstr "Yeni Not Defteri"
 
-#: data/app.desktop.in:30 src/ui/edit_view/toolbar/toolbar.blp:90
-#: src/ui/strings.vala:39 src/ui/window/window.blp:245
+#: data/app.desktop.in:30 src/ui/edit_view/toolbar/toolbar.blp:92
+#: src/ui/strings.vala:39 src/ui/window/window.blp:291
 msgid "Markdown Cheatsheet"
 msgstr "Markdown İpucu Sayfası"
 
@@ -277,25 +51,154 @@ msgstr "Markdown İpucu Sayfası"
 msgid "Preferences"
 msgstr "Tercihler"
 
-#: data/app.gschema.xml:6 src/ui/preferences/preferences.blp:18
+#: data/app.gschema.xml:6 src/ui/preferences/preferences.blp:45
 msgid "Note Font"
 msgstr "Not Yazı Tipi"
 
-#: data/app.gschema.xml:7 src/ui/preferences/preferences.blp:19
+#: data/app.gschema.xml:7 src/ui/preferences/preferences.blp:46
 msgid "The font notes will be displayed in"
 msgstr "Notların görüntüleneceği yazı tipi"
 
-#: data/app.gschema.xml:11 src/ui/preferences/preferences.blp:31
+#: data/app.gschema.xml:11 src/ui/preferences/preferences.blp:58
 msgid "Monospace Font"
 msgstr "Eş Aralıklı Yazı Tipi"
 
-#: data/app.gschema.xml:12 src/ui/preferences/preferences.blp:32
+#: data/app.gschema.xml:12 src/ui/preferences/preferences.blp:59
 msgid "The font code will be displayed in"
 msgstr "Kodların görüntüleneceği yazı tipi"
 
-#: data/app.gschema.xml:21 src/ui/preferences/preferences.blp:46
+#: data/app.gschema.xml:16 src/ui/preferences/preferences.blp:150
+msgid "Use Fixed Width For Notes"
+msgstr "Notlar İçin Sabit Genişlik Kullan"
+
+#: data/app.gschema.xml:17 src/ui/preferences/preferences.blp:151
+msgid "Use a fixed width for the text area of a note"
+msgstr "Notun metin alanı için sabit genişlik kullan"
+
+#: data/app.gschema.xml:21 src/ui/preferences/preferences.blp:18
 msgid "OLED Mode"
 msgstr "OLED Kipi"
+
+#: data/app.gschema.xml:22 src/ui/preferences/preferences.blp:19
+msgid "Makes the dark theme pitch black"
+msgstr "Koyu temayı zifiri karanlık yapar"
+
+#: data/app.gschema.xml:26 src/ui/preferences/preferences.blp:109
+msgid "Enable Toolbar"
+msgstr "Araç Çubuğunu Etkinleştir"
+
+#: data/app.gschema.xml:27 src/ui/preferences/preferences.blp:110
+msgid "Displays the formatting toolbar at the bottom of the note"
+msgstr "Notun altındaki biçimlendirme araç çubuğunu gösterir"
+
+#: data/app.gschema.xml:31 src/ui/preferences/preferences.blp:120
+msgid "Enable Cheatsheet"
+msgstr "İpucu Sayfasını Etkinleştir"
+
+#: data/app.gschema.xml:32 src/ui/preferences/preferences.blp:121
+msgid ""
+"Adds a button to the markdown reference sheet on the right of the formatting "
+"toolbar"
+msgstr ""
+"Biçimlendirme araç çubuğunun sağındaki markdown referans sayfasına düğme "
+"ekler"
+
+#: data/app.gschema.xml:36 src/ui/preferences/preferences.blp:139
+msgid "3-Pane Layout"
+msgstr "3 Bölmeli Düzen"
+
+#: data/app.gschema.xml:37 src/ui/preferences/preferences.blp:140
+msgid "Expands the notebook list to include the notebook name"
+msgstr "Not defteri listesini not defteri adını içerecek şekilde genişletir"
+
+#: data/app.gschema.xml:41 src/ui/preferences/preferences.blp:207
+msgid "Notes Storage Location"
+msgstr "Not Depolama Konumu"
+
+#: data/app.gschema.xml:42 src/ui/preferences/preferences.blp:208
+msgid "Where the notebooks are stored (requires app restart)"
+msgstr "Notların depolanacağı dizin (uygulama yeniden başlatma gerektirir)"
+
+#: data/app.gschema.xml:46 src/ui/preferences/preferences.blp:235
+msgid "Trash Storage Location"
+msgstr "Çöp Depolama Konumu"
+
+#: data/app.gschema.xml:47 src/ui/preferences/preferences.blp:236
+msgid "Where the trash folder is located (requires app restart)"
+msgstr ""
+"Çöp kutusu klasörünün konumu (uygulamanın yeniden başlatılmasını gerektirir)"
+
+#: data/app.gschema.xml:51 src/ui/preferences/preferences.blp:87
+msgid "Show line numbers"
+msgstr "Satır numaralarını göster"
+
+#: data/app.gschema.xml:52 src/ui/preferences/preferences.blp:88
+msgid "Displays line numbers at the left of the note"
+msgstr "Notun solunda satır numaralarını gösterir"
+
+#: data/app.gschema.xml:56 src/ui/preferences/preferences.blp:98
+msgid "Show all notes"
+msgstr "Tüm notları göster"
+
+#: data/app.gschema.xml:57 src/ui/preferences/preferences.blp:99
+msgid "Displays the \"All Notes\" notebook at the top of the notebook list"
+msgstr ""
+"\"Tüm Notlar\" not defterini not defteri listesinin en üstünde gösterir"
+
+#: data/app.gschema.xml:61 src/ui/preferences/preferences.blp:185
+msgid "Enable autosave"
+msgstr "Kendiliğinden kaydetmeyi etkinleştir"
+
+#: data/app.gschema.xml:62 src/ui/preferences/preferences.blp:186
+msgid ""
+"Automatically saves the current note every 30 seconds if the contents have "
+"changed (requires app restart)"
+msgstr ""
+"İçerik değiştiyse var olan notu 30 saniyede bir kendiliğinden kaydeder "
+"(uygulamanın yeniden başlatılmasını gerektirir)"
+
+#: data/app.gschema.xml:66 src/ui/preferences/preferences.blp:196
+msgid "Don't hide the Trash folder"
+msgstr "Çöp Kutusu klasörünü gizleme"
+
+#: data/app.gschema.xml:67
+msgid ""
+"The trash folder is set as a hidden folder by default, this option makes it "
+"visible"
+msgstr ""
+"Çöp klasörü öntanımlı olarak gizlidir, bu seçenek onu görünür hale getirir"
+
+#: data/app.gschema.xml:71
+msgid "Note sort order"
+msgstr "Not sıralama düzeni"
+
+#: data/app.gschema.xml:72
+msgid "The sort order of the note list"
+msgstr "Not listesinin sıralama düzeni"
+
+#: data/app.gschema.xml:76
+msgid "Notebook sort order"
+msgstr "Not defteri sıralama düzeni"
+
+#: data/app.gschema.xml:77
+msgid "The sort order of the notebook list"
+msgstr "Not defteri listelerinin sıralama düzeni"
+
+#: data/app.gschema.xml:81
+msgid "URL detection level"
+msgstr ""
+
+#: data/app.gschema.xml:82
+msgid "How agressive to look for URLs in markdown text"
+msgstr ""
+
+#: data/app.gschema.xml:86
+msgid "Line spacing"
+msgstr ""
+
+#: data/app.gschema.xml:87 src/ui/preferences/preferences.blp:74
+msgid "The line spacing for the note text"
+msgstr ""
 
 #: data/app.metainfo.xml.in:5
 msgid "Take notes in Markdown"
@@ -329,103 +232,116 @@ msgstr "Not defteri rengine göre uygulama renklendirme"
 msgid "Trash can"
 msgstr "Çöp kutusu"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:23
-#: src/ui/edit_view/toolbar/toolbar.blp:131
+#: data/app.metainfo.xml.in:393
+msgid "Main Folio window in light mode"
+msgstr "Açık kipte Folio ana penceresi"
+
+#: data/app.metainfo.xml.in:397
+msgid "Main Folio window in dark mode"
+msgstr "Koyu kipte Folio ana penceresi"
+
+#: data/app.metainfo.xml.in:401
+msgid "Folio on small/mobile screens"
+msgstr "Küçük/mobil ekranda Folio"
+
+#: data/app.metainfo.xml.in:405
+msgid "Folio preferences screen"
+msgstr "Folio tercihler penceresi"
+
+#: data/app.metainfo.xml.in:409
+msgid "Folio in three pane mode"
+msgstr "Folio üç bölmeli kipte"
+
+#: src/ui/edit_view/toolbar/toolbar.blp:6
 #: src/ui/widgets/markdown/heading_popover.blp:48
 msgid "Plain Text"
 msgstr "Düz Metin"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:24
-#: src/ui/edit_view/toolbar/toolbar.blp:132
+#: src/ui/edit_view/toolbar/toolbar.blp:7
 #: src/ui/widgets/markdown/heading_popover.blp:12
 msgid "Heading 1"
 msgstr "Başlık 1"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:25
-#: src/ui/edit_view/toolbar/toolbar.blp:133
+#: src/ui/edit_view/toolbar/toolbar.blp:8
 #: src/ui/widgets/markdown/heading_popover.blp:18
 msgid "Heading 2"
 msgstr "Başlık 2"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:26
-#: src/ui/edit_view/toolbar/toolbar.blp:134
+#: src/ui/edit_view/toolbar/toolbar.blp:9
 #: src/ui/widgets/markdown/heading_popover.blp:24
 msgid "Heading 3"
 msgstr "Başlık 3"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:27
-#: src/ui/edit_view/toolbar/toolbar.blp:135
+#: src/ui/edit_view/toolbar/toolbar.blp:10
 #: src/ui/widgets/markdown/heading_popover.blp:30
 msgid "Heading 4"
 msgstr "Başlık 4"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:28
-#: src/ui/edit_view/toolbar/toolbar.blp:136
+#: src/ui/edit_view/toolbar/toolbar.blp:11
 #: src/ui/widgets/markdown/heading_popover.blp:36
 msgid "Heading 5"
 msgstr "Başlık 5"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:29
-#: src/ui/edit_view/toolbar/toolbar.blp:137
+#: src/ui/edit_view/toolbar/toolbar.blp:12
 #: src/ui/widgets/markdown/heading_popover.blp:42
 msgid "Heading 6"
 msgstr "Başlık 6"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:39
-#: src/ui/edit_view/toolbar/toolbar.blp:104
-#: src/ui/edit_view/toolbar/toolbar.blp:148
-#: src/ui/edit_view/toolbar/toolbar.blp:201 src/ui/popup/shortcut_window.blp:72
+#: src/ui/edit_view/toolbar/toolbar.blp:41
+#: src/ui/edit_view/toolbar/toolbar.blp:107
+#: src/ui/edit_view/toolbar/toolbar.blp:142
+#: src/ui/edit_view/toolbar/toolbar.blp:195 src/ui/popup/shortcut_window.blp:72
 msgid "Bold"
 msgstr "Kalın"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:45
-#: src/ui/edit_view/toolbar/toolbar.blp:111
-#: src/ui/edit_view/toolbar/toolbar.blp:155
-#: src/ui/edit_view/toolbar/toolbar.blp:202 src/ui/popup/shortcut_window.blp:77
+#: src/ui/edit_view/toolbar/toolbar.blp:47
+#: src/ui/edit_view/toolbar/toolbar.blp:114
+#: src/ui/edit_view/toolbar/toolbar.blp:149
+#: src/ui/edit_view/toolbar/toolbar.blp:196 src/ui/popup/shortcut_window.blp:77
 msgid "Italic"
 msgstr "Eğik"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:51
-#: src/ui/edit_view/toolbar/toolbar.blp:162
-#: src/ui/edit_view/toolbar/toolbar.blp:203 src/ui/popup/shortcut_window.blp:82
+#: src/ui/edit_view/toolbar/toolbar.blp:53
+#: src/ui/edit_view/toolbar/toolbar.blp:156
+#: src/ui/edit_view/toolbar/toolbar.blp:197 src/ui/popup/shortcut_window.blp:82
 msgid "Strikethrough"
 msgstr "Üstü çizili"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:57
-#: src/ui/edit_view/toolbar/toolbar.blp:169
-#: src/ui/edit_view/toolbar/toolbar.blp:204 src/ui/popup/shortcut_window.blp:87
+#: src/ui/edit_view/toolbar/toolbar.blp:59
+#: src/ui/edit_view/toolbar/toolbar.blp:163
+#: src/ui/edit_view/toolbar/toolbar.blp:198 src/ui/popup/shortcut_window.blp:87
 msgid "Highlight"
 msgstr "Vurgula"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:67
-#: src/ui/edit_view/toolbar/toolbar.blp:193 src/ui/popup/shortcut_window.blp:92
+#: src/ui/edit_view/toolbar/toolbar.blp:69
+#: src/ui/edit_view/toolbar/toolbar.blp:187 src/ui/popup/shortcut_window.blp:92
 msgid "Insert Link"
 msgstr "Bağlantı Ekle"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:73
-#: src/ui/edit_view/toolbar/toolbar.blp:194
+#: src/ui/edit_view/toolbar/toolbar.blp:75
+#: src/ui/edit_view/toolbar/toolbar.blp:188
 msgid "Insert Code"
 msgstr "Kod Ekle"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:79
-#: src/ui/edit_view/toolbar/toolbar.blp:195
+#: src/ui/edit_view/toolbar/toolbar.blp:81
+#: src/ui/edit_view/toolbar/toolbar.blp:189
 msgid "Insert Horizontal Rule"
 msgstr "Yatay Çizgi Ekle"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:118
+#: src/ui/edit_view/toolbar/toolbar.blp:121
 msgid "Format"
 msgstr "Biçim"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:181
+#: src/ui/edit_view/toolbar/toolbar.blp:175
 msgid "Insert"
 msgstr "Ekle"
 
-#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:34
+#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:18
 #: src/ui/strings.vala:44 src/ui/strings.vala:58
 msgid "Cancel"
 msgstr "İptal Et"
 
-#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:39
+#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:23
 msgid "Confirm"
 msgstr "Doğrula"
 
@@ -469,37 +385,87 @@ msgstr "Biçimlendirme"
 msgid "Navigation"
 msgstr "Gezinti"
 
-#: src/ui/popup/shortcut_window.blp:102 src/ui/window/window.blp:216
+#: src/ui/popup/shortcut_window.blp:102 src/ui/window/window.blp:268
 msgid "Toggle Sidebar"
 msgstr "Kenar Çubuğunu Aç/Kapa"
 
-#: src/ui/popup/shortcut_window.blp:107 src/ui/window/window.blp:63
+#: src/ui/popup/shortcut_window.blp:107 src/ui/window/window.blp:70
 msgid "Search Notes"
 msgstr "Notları Ara"
 
-#: data/app.gschema.xml:22 src/ui/preferences/preferences.blp:47
-msgid "Makes the dark theme pitch black"
-msgstr "Koyu temayı zifiri karanlık yapar"
+#: src/ui/popup/shortcut_window.blp:114
+msgid "Display"
+msgstr "Göster"
 
-#: data/app.gschema.xml:26 src/ui/preferences/preferences.blp:87
-msgid "Enable Toolbar"
-msgstr "Araç Çubuğunu Etkinleştir"
+#: src/ui/popup/shortcut_window.blp:117
+msgid "Full Screen"
+msgstr "Tam Ekran"
 
-#: data/app.gschema.xml:31 src/ui/preferences/preferences.blp:98
-msgid "Enable Cheatsheet"
-msgstr "İpucu Sayfasını Etkinleştir"
+#: src/ui/popup/shortcut_window.blp:122
+msgid "Zoom In"
+msgstr "Yakınlaştır"
 
-#: data/app.gschema.xml:36 src/ui/preferences/preferences.blp:117
-msgid "3-Pane Layout"
-msgstr "3 Bölmeli Düzen"
+#: src/ui/popup/shortcut_window.blp:127
+msgid "Zoom Out"
+msgstr "Uzaklaştır"
 
-#: data/app.gschema.xml:41 src/ui/preferences/preferences.blp:185
-msgid "Notes Storage Location"
-msgstr "Not Depolama Konumu"
+#: src/ui/preferences/preferences.blp:31
+#, fuzzy
+msgid "Markdown URL Detection"
+msgstr "Markdown İpucu Sayfası"
 
-#: data/app.gschema.xml:42 src/ui/preferences/preferences.blp:186
-msgid "Where the notebooks are stored (requires app restart)"
-msgstr "Notların depolanacağı dizin (uygulama yeniden başlatma gerektirir)"
+#: src/ui/preferences/preferences.blp:32
+msgid ""
+"Determines the level of detection of URLs in\n"
+"free form text is used:\n"
+" - Aggressive tries to find all URLs\n"
+" - Strict requires a protocol identifier (ie http://)\n"
+" - Disabled turns detection off."
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:39
+msgid "Fonts"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:73
+msgid "Line Spacing"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:81
+msgid "Tools"
+msgstr "Araçlar"
+
+#: src/ui/preferences/preferences.blp:133
+msgid "Layout"
+msgstr "Düzen"
+
+#: src/ui/preferences/preferences.blp:161
+msgid "Fixed Width To Use For Notes"
+msgstr "Notlar İçin Kullanılacak Sabit Genişlik"
+
+#: src/ui/preferences/preferences.blp:162
+msgid "Sets the fixed width size of a note in px"
+msgstr "Notun sabit genişlik boyutunu px cinsinden ayarlar"
+
+#: src/ui/preferences/preferences.blp:167
+msgid "Sort Order For Notebooks"
+msgstr "Not defterleri için sıralama düzeni"
+
+#: src/ui/preferences/preferences.blp:172
+msgid "Sort Order For Notes"
+msgstr "Not listesinin sıralama düzeni"
+
+#: src/ui/preferences/preferences.blp:179
+msgid "Files"
+msgstr "Dosyalar"
+
+#: src/ui/preferences/preferences.blp:197
+msgid ""
+"The trash folder is set as a hidden folder by default, this option makes it "
+"visible (requires app restart)"
+msgstr ""
+"Çöp klasörü öntanımlı olarak gizlidir, bu seçenek onu görünür hale getirir "
+"(uygulamanın yeniden başlatılmasını gerektirir)"
 
 #: src/ui/strings.vala:4 src/ui/window/notebooks_bar/notebooks_bar.blp:129
 #: src/ui/window/notebooks_bar/notebooks_bar.blp:171
@@ -507,6 +473,7 @@ msgid "Trash"
 msgstr "Çöp"
 
 #: src/ui/strings.vala:5
+#, c-format
 msgid "%d Notes"
 msgstr "%d Not"
 
@@ -514,7 +481,7 @@ msgstr "%d Not"
 msgid "Are you sure you want to delete everything in the trash?"
 msgstr "Çöp kutusundaki her şeyi silmek istediğinizden emin misiniz?"
 
-#: src/ui/strings.vala:7 src/ui/window/window.blp:54
+#: src/ui/strings.vala:7 src/ui/window/window.blp:61
 msgid "Empty Trash"
 msgstr "Çöpü Boşalt"
 
@@ -551,10 +518,12 @@ msgid "Move"
 msgstr "Taşı"
 
 #: src/ui/strings.vala:18
+#, c-format
 msgid "Note “%s” already exists in notebook “%s”"
 msgstr "“%s” notu “%s” not defterinde zaten var"
 
 #: src/ui/strings.vala:19
+#, c-format
 msgid "Are you sure you want to delete the note “%s”?"
 msgstr "“%s” notunu silmek istediğinizden emin misiniz?"
 
@@ -563,6 +532,7 @@ msgid "Delete Note"
 msgstr "Notu Sil"
 
 #: src/ui/strings.vala:21
+#, c-format
 msgid "Are you sure you want to delete the notebook “%s”?"
 msgstr "“%s” not defterini silmek istediğinizden emin misiniz?"
 
@@ -571,34 +541,42 @@ msgid "Delete Notebook"
 msgstr "Not Defterini Sil"
 
 #: src/ui/strings.vala:24
-msgid "Note name shouldn’t contain “.” or “/”"
+#, fuzzy
+msgid "Note names cannot contain a “/”"
 msgstr "Not adı “.” veya “/” içeremez"
 
 #: src/ui/strings.vala:25
-msgid "Note name shouldn’t be blank"
+#, fuzzy
+msgid "Note names cannot be blank"
 msgstr "Not adı boş olamaz"
 
 #: src/ui/strings.vala:26
+#, c-format
 msgid "Note “%s” already exists"
 msgstr "“%s” notu zaten var"
 
 #: src/ui/strings.vala:27
-msgid "Couldn’t create note"
+#, fuzzy
+msgid "Could not create note"
 msgstr "Not oluşturulamadı"
 
 #: src/ui/strings.vala:28
-msgid "Couldn’t change note"
+#, fuzzy
+msgid "Could not change note"
 msgstr "Not değiştirilemedi"
 
 #: src/ui/strings.vala:29
-msgid "Couldn’t delete note"
+#, fuzzy
+msgid "Could not delete note"
 msgstr "Not silinemedi"
 
 #: src/ui/strings.vala:30
-msgid "Couldn’t restore note"
+#, fuzzy
+msgid "Could not restore note"
 msgstr "Not geri yüklenemedi"
 
 #: src/ui/strings.vala:31
+#, c-format
 msgid "Saved “%s” to “%s”"
 msgstr "“%s”, “%s” içine kaydedildi"
 
@@ -607,27 +585,33 @@ msgid "Unknown error"
 msgstr "Bilinmeyen hata"
 
 #: src/ui/strings.vala:33
-msgid "Notebook name shouldn’t contain “.” or “/”"
+#, fuzzy
+msgid "Notebook names cannot contain a “/”"
 msgstr "Not defteri adı “.” veya “/” içeremez"
 
 #: src/ui/strings.vala:34
-msgid "Notebook name shouldn’t be blank"
+#, fuzzy
+msgid "Notebook names cannot be blank"
 msgstr "Not defteri adı boş olamaz"
 
 #: src/ui/strings.vala:35
+#, c-format
 msgid "Notebook “%s” already exists"
 msgstr "“%s” not defteri zaten var"
 
 #: src/ui/strings.vala:36
-msgid "Couldn’t create notebook"
+#, fuzzy
+msgid "Could not create notebook"
 msgstr "Not defteri oluşturulamadı"
 
 #: src/ui/strings.vala:37
-msgid "Couldn’t change notebook"
+#, fuzzy
+msgid "Could not change notebook"
 msgstr "Not defteri değiştirilemedi"
 
 #: src/ui/strings.vala:38
-msgid "Couldn’t delete notebook"
+#, fuzzy
+msgid "Could not delete notebook"
 msgstr "Not defteri silinemedi"
 
 #: src/ui/strings.vala:40
@@ -639,7 +623,8 @@ msgid "Rename"
 msgstr "Yeniden Adlandır"
 
 #: src/ui/strings.vala:42
-msgid "Couldn’t find an app to handle file URIs"
+#, fuzzy
+msgid "Could not find an app to handle file URIs"
 msgstr "Dosya URI'lerin işlemek için uygulama bulunamadı"
 
 #: src/ui/strings.vala:43
@@ -649,6 +634,10 @@ msgstr "Uygula"
 #: src/ui/strings.vala:45
 msgid "Pick where the notebooks will be stored"
 msgstr "Not defterlerinin nerede depolanacağını seçin"
+
+#: src/ui/strings.vala:46
+msgid "Pick where the trash can will be stored"
+msgstr "Çöp kutusunun nerede depolanacağını seçin"
 
 #: src/ui/strings.vala:47 src/ui/window/notebooks_bar/notebooks_bar.blp:59
 #: src/ui/window/notebooks_bar/notebooks_bar.blp:101
@@ -662,6 +651,133 @@ msgstr "Son Değiştirilme"
 #: src/ui/strings.vala:50
 msgid "Extension"
 msgstr "Uzantı"
+
+#: src/ui/strings.vala:51
+msgid "Unable to recognize URI"
+msgstr "URI tanınmadı"
+
+#: src/ui/strings.vala:52
+msgid "Pick primary font for notes"
+msgstr "Notlar için birincil yazı tipini seç"
+
+#: src/ui/strings.vala:53
+msgid "Pick monospace font for code"
+msgstr "Kod için eş aralıklı yazı tipi seç"
+
+#: src/ui/strings.vala:54
+msgid "File Changed On Disk"
+msgstr "Diskteki Dosya Değiştirildi"
+
+#: src/ui/strings.vala:55
+msgid ""
+"The file has changed on disk since it was last saved/loaded by Folio.\n"
+"\n"
+"You may do one of the following:\n"
+"\n"
+" • Reload the file (discarding any changes you have made in Folio)\n"
+" • Overwrite the file (discarding any changes made outside of Folio)\n"
+" • Cancel the operation and manually resolve the issue\n"
+"\n"
+"Note: Canceling the save if you have already moved to a new note/notebook "
+"will discard your changes."
+msgstr ""
+"Dosya, Folio tarafından en son kaydedildiğinden/yüklendiğinden beri disk "
+"üzerinde değiştirildi.\n"
+"\n"
+"Aşağıdakilerden birini yapabilirsiniz:\n"
+"\n"
+" - Dosyayı yeniden yüklemek (Folio ile yaptığınız tüm değişiklikler gözden "
+"çıkarılır)\n"
+" - Dosyanın üzerine yazmak (Folio dışında yapılan tüm değişiklikler gözden "
+"çıkarılır)\n"
+" - İşlemi iptal etmek ve sorunu elle düzeltmek\n"
+"\n"
+"Not: Zaten yeni bir nota/deftere geçtiyseniz kaydetmezseniz "
+"değişiklikleriniz gözden çıkarılır."
+
+#: src/ui/strings.vala:56
+msgid "Reload"
+msgstr "Yeniden Yükle"
+
+#: src/ui/strings.vala:57
+msgid "Overwrite"
+msgstr "Üzerine Yaz"
+
+#: src/ui/strings.vala:59
+msgid ""
+"The file has changed on disk by another application.\n"
+"\n"
+"You may do one of the following:\n"
+"\n"
+" • Reload the file (discarding any changes you have made in Folio)\n"
+" • Overwrite the file (discarding any changes made outside of Folio)"
+msgstr ""
+"Dosya disk üzerinde başka bir uygulama tarafından değiştirildi.\n"
+"\n"
+"Aşağıdakilerden birini yapabilirsiniz:\n"
+"\n"
+" - Dosyayı yeniden yüklemek (Folio ile yaptığınız tüm değişiklikler gözden "
+"çıkarılır)\n"
+" - Dosyanın üzerine yazmak (Folio dışında yapılan tüm değişiklikler gözden "
+"çıkarılır)"
+
+#: src/ui/strings.vala:61
+#, c-format
+msgid "Note %i"
+msgstr "Not %i"
+
+#: src/ui/strings.vala:62
+msgid "Modified Time - Ascending"
+msgstr "Değiştirilme Tarihi - Azalan"
+
+#: src/ui/strings.vala:63
+msgid "Modified Time - Descending"
+msgstr "Değiştirilme Tarihi - Artan"
+
+#: src/ui/strings.vala:64
+msgid "Alphabetical - Ascending"
+msgstr "Alfabetik - A-Z"
+
+#: src/ui/strings.vala:65
+msgid "Alphabetical - Descending"
+msgstr "Alfabetik - Z-A"
+
+#: src/ui/strings.vala:66
+#, fuzzy
+msgid "Natural - Ascending"
+msgstr "Alfabetik - A-Z"
+
+#: src/ui/strings.vala:67
+#, fuzzy
+msgid "Natural - Descending"
+msgstr "Alfabetik - Z-A"
+
+#: src/ui/strings.vala:68
+#, c-format
+msgid "Unable to launch external application for file %s."
+msgstr ""
+
+#: src/ui/strings.vala:69
+msgid "Aggressive"
+msgstr ""
+
+#: src/ui/strings.vala:70
+msgid "Strict"
+msgstr ""
+
+#: src/ui/strings.vala:71
+msgid "Disabled"
+msgstr ""
+
+#: src/ui/strings.vala:72
+#, fuzzy, c-format
+msgid "“%s” moved to trash"
+msgstr "Çöpe Taşı"
+
+#: src/ui/strings.vala:73
+#, c-format
+msgid "“%s” restored"
+msgstr ""
 
 #: src/ui/widgets/theme_selector/theme_selector.blp:15
 msgid "Follow system style"
@@ -692,40 +808,45 @@ msgid "_Keyboard Shortcuts"
 msgstr "_Klavye Kısayolları"
 
 #: src/ui/window/app_menu/app_menu.blp:43
-msgid "_About"
+#, fuzzy
+msgid "_About Folio"
 msgstr "_Hakkında"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:54
-msgid "Notebook Name"
-msgstr "Not Defteri Adı"
-
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:66
-msgid "Duplicate notebook names are not allowed!"
-msgstr "Yinelenen not defteri adlarına izin verilmiyor!"
-
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:82
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:6
 msgid "First Characters"
 msgstr "İlk Karakterler"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:83
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:7
 msgid "Initials"
 msgstr "Baş harfler"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:84
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:8
 msgid "Initials: camelCase"
 msgstr "Baş harfler: deveDüzeni"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:85
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:9
 msgid "Initials: snake_case"
 msgstr "Baş harfler: yılan_düzeni"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:86
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:10
 msgid "Icon"
 msgstr "Simge"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:116
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:11
+msgid "Custom"
+msgstr ""
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:16
 msgid "Notebook Color"
 msgstr "Not Defteri Rengi"
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:58
+msgid "Notebook Name"
+msgstr "Not Defteri Adı"
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:70
+msgid "Duplicate notebook names are not allowed!"
+msgstr "Yinelenen not defteri adlarına izin verilmiyor!"
 
 #: src/ui/window/notebooks_bar/notebook_create_popup.blp:126
 msgid "Create Notebook"
@@ -743,11 +864,11 @@ msgstr "Tümünü Çöpe Taşı"
 msgid "Notebooks"
 msgstr "Not Defterleri"
 
-#: src/ui/window/sidebar/note_create_popup.blp:37
+#: src/ui/window/sidebar/note_create_popup.blp:25
 msgid "Note Name"
 msgstr "Not Adı"
 
-#: src/ui/window/sidebar/note_create_popup.blp:45
+#: src/ui/window/sidebar/note_create_popup.blp:33
 msgid "Create Note"
 msgstr "Not Oluştur"
 
@@ -771,30 +892,37 @@ msgstr "Çöpe Taşı"
 msgid "Open Containing Folder"
 msgstr "İçeren Klasörü Aç"
 
-#: src/ui/window/window.blp:118
+#: src/ui/window/window.blp:123
 msgid "Get started writing"
 msgstr "Yazmaya başla"
 
-#: src/ui/window/window.blp:143
+#: src/ui/window/window.blp:152
+msgid "Open file in external application"
+msgstr ""
+
+#: src/ui/window/window.blp:160
+msgid "Open file"
+msgstr ""
+
+#: src/ui/window/window.blp:181
 msgid "Create a notebook"
 msgstr "Not defteri oluştur"
 
-#: src/ui/window/window.blp:168
+#: src/ui/window/window.blp:210
 msgid "Trash is empty"
 msgstr "Çöp boş"
 
-#: src/ui/window/window.blp:224
-msgid "Back"
-msgstr "Geri"
-
-#: src/ui/window/window.blp:239
+#: src/ui/window/window.blp:285
 msgid "Open in Notebook"
 msgstr "Not Defterinde Aç"
 
-#: src/ui/window/window.blp:264
+#: src/ui/window/window.blp:312
 msgid "_Rename Note"
 msgstr "Notu Yeniden _Adlandır"
 
-#: src/ui/window/window.blp:270
+#: src/ui/window/window.blp:319
 msgid "_Export Note"
 msgstr "Notu Dışa _Aktar"
+
+#~ msgid "Back"
+#~ msgstr "Geri"

--- a/po/uk.po
+++ b/po/uk.po
@@ -2,229 +2,17 @@
 # This file is distributed under the same license as the Folio package.
 msgid ""
 msgstr ""
+"Project-Id-Version: Folio\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-10-12 16:53+0200\n"
 "PO-Revision-Date: 2024-03-02 17:01:15+0000\n"
+"Language: uk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n % 10 == 1 && n % 100 != 11) ? 0 : ((n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % 100 > 14)) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n % 10 == 1 && n % 100 != 11) ? 0 : ((n % "
+"10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % 100 > 14)) ? 1 : 2);\n"
 "X-Generator: GlotPress/4.0.0\n"
-"Language: uk\n"
-"Project-Id-Version: Folio\n"
-
-#: data/app.gschema.xml:76
-msgid "Notebook sort order"
-msgstr ""
-
-#: data/app.gschema.xml:77
-msgid "The sort order of the notebook list"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:145
-msgid "Sort Order For Notebooks"
-msgstr ""
-
-#: data/app.gschema.xml:71
-msgid "Note sort order"
-msgstr ""
-
-#: data/app.gschema.xml:72
-msgid "The sort order of the note list"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:150
-msgid "Sort Order For Notes"
-msgstr ""
-
-#: src/ui/strings.vala:62
-msgid "Modified Time - Ascending"
-msgstr ""
-
-#: src/ui/strings.vala:63
-msgid "Modified Time - Descending"
-msgstr ""
-
-#: src/ui/strings.vala:64
-msgid "Alphabetical - Ascending"
-msgstr ""
-
-#: src/ui/strings.vala:65
-msgid "Alphabetical - Descending"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:114
-msgid "Display"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:117
-msgid "Full Screen"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:122
-msgid "Zoom In"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:127
-msgid "Zoom Out"
-msgstr ""
-
-#: src/ui/strings.vala:52
-msgid "Pick primary font for notes"
-msgstr ""
-
-#: src/ui/strings.vala:53
-msgid "Pick monospace font for code"
-msgstr ""
-
-#: src/ui/strings.vala:54
-msgid "File Changed On Disk"
-msgstr ""
-
-#: src/ui/strings.vala:55
-msgid ""
-"The file has changed on disk since it was last saved/loaded by Folio.\n"
-"\n"
-"You may do one of the following:\n"
-"\n"
-" • Reload the file (discarding any changes you have made in Folio)\n"
-" • Overwrite the file (discarding any changes made outside of Folio)\n"
-" • Cancel the operation and manually resolve the issue\n"
-"\n"
-"Note: Canceling the save if you have already moved to a new note/notebook will discard your changes."
-msgstr ""
-
-#: src/ui/strings.vala:56
-msgid "Reload"
-msgstr ""
-
-#: src/ui/strings.vala:57
-msgid "Overwrite"
-msgstr ""
-
-#: src/ui/strings.vala:59
-msgid ""
-"The file has changed on disk by another application.\n"
-"\n"
-"You may do one of the following:\n"
-"\n"
-" • Reload the file (discarding any changes you have made in Folio)\n"
-" • Overwrite the file (discarding any changes made outside of Folio)"
-msgstr ""
-
-#: src/ui/strings.vala:61
-msgid "Note %i"
-msgstr ""
-
-#: data/app.gschema.xml:46 src/ui/preferences/preferences.blp:213
-msgid "Trash Storage Location"
-msgstr ""
-
-#: data/app.gschema.xml:47 src/ui/preferences/preferences.blp:214
-msgid "Where the trash folder is located (requires app restart)"
-msgstr ""
-
-#: src/ui/strings.vala:46
-msgid "Pick where the trash can will be stored"
-msgstr ""
-
-#: data/app.gschema.xml:16 src/ui/preferences/preferences.blp:128
-msgid "Use Fixed Width For Notes"
-msgstr ""
-
-#: data/app.gschema.xml:17 src/ui/preferences/preferences.blp:129
-msgid "Use a fixed width for the text area of a note"
-msgstr ""
-
-#: data/app.gschema.xml:37 src/ui/preferences/preferences.blp:118
-msgid "Expands the notebook list to include the notebook name"
-msgstr ""
-
-#: data/app.gschema.xml:51 src/ui/preferences/preferences.blp:65
-msgid "Show line numbers"
-msgstr ""
-
-#: data/app.gschema.xml:52 src/ui/preferences/preferences.blp:66
-msgid "Displays line numbers at the left of the note"
-msgstr ""
-
-#: data/app.gschema.xml:56 src/ui/preferences/preferences.blp:76
-msgid "Show all notes"
-msgstr ""
-
-#: data/app.gschema.xml:57 src/ui/preferences/preferences.blp:77
-msgid "Displays the \"All Notes\" notebook at the top of the notebook list"
-msgstr ""
-
-#: data/app.gschema.xml:61 src/ui/preferences/preferences.blp:163
-msgid "Enable autosave"
-msgstr ""
-
-#: data/app.gschema.xml:62 src/ui/preferences/preferences.blp:164
-msgid "Automatically saves the current note every 30 seconds if the contents have changed (requires app restart)"
-msgstr ""
-
-#: data/app.gschema.xml:66 src/ui/preferences/preferences.blp:174
-msgid "Don't hide the Trash folder"
-msgstr ""
-
-#: data/app.gschema.xml:67
-msgid "The trash folder is set as a hidden folder by default, this option makes it visible"
-msgstr ""
-
-#: data/app.metainfo.xml.in:367
-msgid "Main Folio window in light mode"
-msgstr ""
-
-#: data/app.metainfo.xml.in:371
-msgid "Main Folio window in dark mode"
-msgstr ""
-
-#: data/app.metainfo.xml.in:375
-msgid "Folio on small/mobile screens"
-msgstr ""
-
-#: data/app.metainfo.xml.in:379
-msgid "Folio preferences screen"
-msgstr ""
-
-#: data/app.metainfo.xml.in:383
-msgid "Folio in three pane mode"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:59
-msgid "Tools"
-msgstr ""
-
-#: data/app.gschema.xml:27 src/ui/preferences/preferences.blp:88
-msgid "Displays the formatting toolbar at the bottom of the note"
-msgstr ""
-
-#: data/app.gschema.xml:32 src/ui/preferences/preferences.blp:99
-msgid "Adds a button to the markdown reference sheet on the right of the formatting toolbar"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:111
-msgid "Layout"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:139
-msgid "Fixed Width To Use For Notes"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:140
-msgid "Sets the fixed width size of a note in px"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:157
-msgid "Files"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:175
-msgid "The trash folder is set as a hidden folder by default, this option makes it visible (requires app restart)"
-msgstr ""
-
-#: src/ui/strings.vala:51
-msgid "Unable to recognize URI"
-msgstr ""
 
 #: data/app.desktop.in:9 src/ui/strings.vala:3
 msgid "Folio"
@@ -240,21 +28,23 @@ msgstr "Робіть нотатки"
 
 #: data/app.desktop.in:13
 msgid "Notebook;Note;Notes;Text;Markdown;Notepad;Write;School;Post-it;Sticky;"
-msgstr "Блокнот;Нотатка;Нотатки;Текст;Markdown;Блокнот;Писати;Школа;Пости це;Липкі замітки;"
+msgstr ""
+"Блокнот;Нотатка;Нотатки;Текст;Markdown;Блокнот;Писати;Школа;Пости це;Липкі "
+"замітки;"
 
 #: data/app.desktop.in:22 src/ui/popup/shortcut_window.blp:17
-#: src/ui/strings.vala:8 src/ui/window/window.blp:47
-#: src/ui/window/window.blp:124
+#: src/ui/strings.vala:8 src/ui/window/window.blp:54
+#: src/ui/window/window.blp:131
 msgid "New Note"
 msgstr "Нова нотатка"
 
 #: data/app.desktop.in:26 src/ui/popup/shortcut_window.blp:37
-#: src/ui/strings.vala:14 src/ui/window/window.blp:149
+#: src/ui/strings.vala:14 src/ui/window/window.blp:189
 msgid "New Notebook"
 msgstr "Новий блокнот"
 
-#: data/app.desktop.in:30 src/ui/edit_view/toolbar/toolbar.blp:90
-#: src/ui/strings.vala:39 src/ui/window/window.blp:245
+#: data/app.desktop.in:30 src/ui/edit_view/toolbar/toolbar.blp:92
+#: src/ui/strings.vala:39 src/ui/window/window.blp:291
 msgid "Markdown Cheatsheet"
 msgstr "Шпаргалка Markdown"
 
@@ -262,25 +52,147 @@ msgstr "Шпаргалка Markdown"
 msgid "Preferences"
 msgstr "Налаштування"
 
-#: data/app.gschema.xml:6 src/ui/preferences/preferences.blp:18
+#: data/app.gschema.xml:6 src/ui/preferences/preferences.blp:45
 msgid "Note Font"
 msgstr "Шрифт нотатки"
 
-#: data/app.gschema.xml:7 src/ui/preferences/preferences.blp:19
+#: data/app.gschema.xml:7 src/ui/preferences/preferences.blp:46
 msgid "The font notes will be displayed in"
 msgstr "Шрифт, яким відображатимуться нотатки"
 
-#: data/app.gschema.xml:11 src/ui/preferences/preferences.blp:31
+#: data/app.gschema.xml:11 src/ui/preferences/preferences.blp:58
 msgid "Monospace Font"
 msgstr "Шрифт коду"
 
-#: data/app.gschema.xml:12 src/ui/preferences/preferences.blp:32
+#: data/app.gschema.xml:12 src/ui/preferences/preferences.blp:59
 msgid "The font code will be displayed in"
 msgstr "Шрифт, яким відображатиметься код"
 
-#: data/app.gschema.xml:21 src/ui/preferences/preferences.blp:46
+#: data/app.gschema.xml:16 src/ui/preferences/preferences.blp:150
+msgid "Use Fixed Width For Notes"
+msgstr ""
+
+#: data/app.gschema.xml:17 src/ui/preferences/preferences.blp:151
+msgid "Use a fixed width for the text area of a note"
+msgstr ""
+
+#: data/app.gschema.xml:21 src/ui/preferences/preferences.blp:18
 msgid "OLED Mode"
 msgstr "OLED Режим"
+
+#: data/app.gschema.xml:22 src/ui/preferences/preferences.blp:19
+msgid "Makes the dark theme pitch black"
+msgstr "Робить темну тему абсолютно чорною"
+
+#: data/app.gschema.xml:26 src/ui/preferences/preferences.blp:109
+msgid "Enable Toolbar"
+msgstr "Увімкнути панель інструментів"
+
+#: data/app.gschema.xml:27 src/ui/preferences/preferences.blp:110
+msgid "Displays the formatting toolbar at the bottom of the note"
+msgstr ""
+
+#: data/app.gschema.xml:31 src/ui/preferences/preferences.blp:120
+msgid "Enable Cheatsheet"
+msgstr ""
+
+#: data/app.gschema.xml:32 src/ui/preferences/preferences.blp:121
+msgid ""
+"Adds a button to the markdown reference sheet on the right of the formatting "
+"toolbar"
+msgstr ""
+
+#: data/app.gschema.xml:36 src/ui/preferences/preferences.blp:139
+msgid "3-Pane Layout"
+msgstr "3-панельний макет"
+
+#: data/app.gschema.xml:37 src/ui/preferences/preferences.blp:140
+msgid "Expands the notebook list to include the notebook name"
+msgstr ""
+
+#: data/app.gschema.xml:41 src/ui/preferences/preferences.blp:207
+msgid "Notes Storage Location"
+msgstr "Місце зберігання нотаток"
+
+#: data/app.gschema.xml:42 src/ui/preferences/preferences.blp:208
+msgid "Where the notebooks are stored (requires app restart)"
+msgstr "Де зберігаються блокноти (потрібно перезапустити застосунок)"
+
+#: data/app.gschema.xml:46 src/ui/preferences/preferences.blp:235
+msgid "Trash Storage Location"
+msgstr ""
+
+#: data/app.gschema.xml:47 src/ui/preferences/preferences.blp:236
+msgid "Where the trash folder is located (requires app restart)"
+msgstr ""
+
+#: data/app.gschema.xml:51 src/ui/preferences/preferences.blp:87
+msgid "Show line numbers"
+msgstr ""
+
+#: data/app.gschema.xml:52 src/ui/preferences/preferences.blp:88
+msgid "Displays line numbers at the left of the note"
+msgstr ""
+
+#: data/app.gschema.xml:56 src/ui/preferences/preferences.blp:98
+msgid "Show all notes"
+msgstr ""
+
+#: data/app.gschema.xml:57 src/ui/preferences/preferences.blp:99
+msgid "Displays the \"All Notes\" notebook at the top of the notebook list"
+msgstr ""
+
+#: data/app.gschema.xml:61 src/ui/preferences/preferences.blp:185
+msgid "Enable autosave"
+msgstr ""
+
+#: data/app.gschema.xml:62 src/ui/preferences/preferences.blp:186
+msgid ""
+"Automatically saves the current note every 30 seconds if the contents have "
+"changed (requires app restart)"
+msgstr ""
+
+#: data/app.gschema.xml:66 src/ui/preferences/preferences.blp:196
+msgid "Don't hide the Trash folder"
+msgstr ""
+
+#: data/app.gschema.xml:67
+msgid ""
+"The trash folder is set as a hidden folder by default, this option makes it "
+"visible"
+msgstr ""
+
+#: data/app.gschema.xml:71
+msgid "Note sort order"
+msgstr ""
+
+#: data/app.gschema.xml:72
+msgid "The sort order of the note list"
+msgstr ""
+
+#: data/app.gschema.xml:76
+msgid "Notebook sort order"
+msgstr ""
+
+#: data/app.gschema.xml:77
+msgid "The sort order of the notebook list"
+msgstr ""
+
+#: data/app.gschema.xml:81
+msgid "URL detection level"
+msgstr ""
+
+#: data/app.gschema.xml:82
+msgid "How agressive to look for URLs in markdown text"
+msgstr ""
+
+#: data/app.gschema.xml:86
+msgid "Line spacing"
+msgstr ""
+
+#: data/app.gschema.xml:87 src/ui/preferences/preferences.blp:74
+msgid "The line spacing for the note text"
+msgstr ""
 
 #: data/app.metainfo.xml.in:5
 msgid "Take notes in Markdown"
@@ -314,103 +226,116 @@ msgstr ""
 msgid "Trash can"
 msgstr "Смітник"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:23
-#: src/ui/edit_view/toolbar/toolbar.blp:131
+#: data/app.metainfo.xml.in:393
+msgid "Main Folio window in light mode"
+msgstr ""
+
+#: data/app.metainfo.xml.in:397
+msgid "Main Folio window in dark mode"
+msgstr ""
+
+#: data/app.metainfo.xml.in:401
+msgid "Folio on small/mobile screens"
+msgstr ""
+
+#: data/app.metainfo.xml.in:405
+msgid "Folio preferences screen"
+msgstr ""
+
+#: data/app.metainfo.xml.in:409
+msgid "Folio in three pane mode"
+msgstr ""
+
+#: src/ui/edit_view/toolbar/toolbar.blp:6
 #: src/ui/widgets/markdown/heading_popover.blp:48
 msgid "Plain Text"
 msgstr "Звичайний текст"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:24
-#: src/ui/edit_view/toolbar/toolbar.blp:132
+#: src/ui/edit_view/toolbar/toolbar.blp:7
 #: src/ui/widgets/markdown/heading_popover.blp:12
 msgid "Heading 1"
 msgstr "Заголовок 1"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:25
-#: src/ui/edit_view/toolbar/toolbar.blp:133
+#: src/ui/edit_view/toolbar/toolbar.blp:8
 #: src/ui/widgets/markdown/heading_popover.blp:18
 msgid "Heading 2"
 msgstr "Заголовок 2"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:26
-#: src/ui/edit_view/toolbar/toolbar.blp:134
+#: src/ui/edit_view/toolbar/toolbar.blp:9
 #: src/ui/widgets/markdown/heading_popover.blp:24
 msgid "Heading 3"
 msgstr "Заголовок 3"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:27
-#: src/ui/edit_view/toolbar/toolbar.blp:135
+#: src/ui/edit_view/toolbar/toolbar.blp:10
 #: src/ui/widgets/markdown/heading_popover.blp:30
 msgid "Heading 4"
 msgstr "Заголовок 4"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:28
-#: src/ui/edit_view/toolbar/toolbar.blp:136
+#: src/ui/edit_view/toolbar/toolbar.blp:11
 #: src/ui/widgets/markdown/heading_popover.blp:36
 msgid "Heading 5"
 msgstr "Заголовок 5"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:29
-#: src/ui/edit_view/toolbar/toolbar.blp:137
+#: src/ui/edit_view/toolbar/toolbar.blp:12
 #: src/ui/widgets/markdown/heading_popover.blp:42
 msgid "Heading 6"
 msgstr "Заголовок 6"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:39
-#: src/ui/edit_view/toolbar/toolbar.blp:104
-#: src/ui/edit_view/toolbar/toolbar.blp:148
-#: src/ui/edit_view/toolbar/toolbar.blp:201 src/ui/popup/shortcut_window.blp:72
+#: src/ui/edit_view/toolbar/toolbar.blp:41
+#: src/ui/edit_view/toolbar/toolbar.blp:107
+#: src/ui/edit_view/toolbar/toolbar.blp:142
+#: src/ui/edit_view/toolbar/toolbar.blp:195 src/ui/popup/shortcut_window.blp:72
 msgid "Bold"
 msgstr "Жирний"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:45
-#: src/ui/edit_view/toolbar/toolbar.blp:111
-#: src/ui/edit_view/toolbar/toolbar.blp:155
-#: src/ui/edit_view/toolbar/toolbar.blp:202 src/ui/popup/shortcut_window.blp:77
+#: src/ui/edit_view/toolbar/toolbar.blp:47
+#: src/ui/edit_view/toolbar/toolbar.blp:114
+#: src/ui/edit_view/toolbar/toolbar.blp:149
+#: src/ui/edit_view/toolbar/toolbar.blp:196 src/ui/popup/shortcut_window.blp:77
 msgid "Italic"
 msgstr "Курсив"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:51
-#: src/ui/edit_view/toolbar/toolbar.blp:162
-#: src/ui/edit_view/toolbar/toolbar.blp:203 src/ui/popup/shortcut_window.blp:82
+#: src/ui/edit_view/toolbar/toolbar.blp:53
+#: src/ui/edit_view/toolbar/toolbar.blp:156
+#: src/ui/edit_view/toolbar/toolbar.blp:197 src/ui/popup/shortcut_window.blp:82
 msgid "Strikethrough"
 msgstr "Закреслений"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:57
-#: src/ui/edit_view/toolbar/toolbar.blp:169
-#: src/ui/edit_view/toolbar/toolbar.blp:204 src/ui/popup/shortcut_window.blp:87
+#: src/ui/edit_view/toolbar/toolbar.blp:59
+#: src/ui/edit_view/toolbar/toolbar.blp:163
+#: src/ui/edit_view/toolbar/toolbar.blp:198 src/ui/popup/shortcut_window.blp:87
 msgid "Highlight"
 msgstr "Виділення"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:67
-#: src/ui/edit_view/toolbar/toolbar.blp:193 src/ui/popup/shortcut_window.blp:92
+#: src/ui/edit_view/toolbar/toolbar.blp:69
+#: src/ui/edit_view/toolbar/toolbar.blp:187 src/ui/popup/shortcut_window.blp:92
 msgid "Insert Link"
 msgstr "Вставити посилання"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:73
-#: src/ui/edit_view/toolbar/toolbar.blp:194
+#: src/ui/edit_view/toolbar/toolbar.blp:75
+#: src/ui/edit_view/toolbar/toolbar.blp:188
 msgid "Insert Code"
 msgstr "Вставити код"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:79
-#: src/ui/edit_view/toolbar/toolbar.blp:195
+#: src/ui/edit_view/toolbar/toolbar.blp:81
+#: src/ui/edit_view/toolbar/toolbar.blp:189
 msgid "Insert Horizontal Rule"
 msgstr "Вставити горизонтальну лінію"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:118
+#: src/ui/edit_view/toolbar/toolbar.blp:121
 msgid "Format"
 msgstr "Форматування"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:181
+#: src/ui/edit_view/toolbar/toolbar.blp:175
 msgid "Insert"
 msgstr "Вставити"
 
-#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:34
+#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:18
 #: src/ui/strings.vala:44 src/ui/strings.vala:58
 msgid "Cancel"
 msgstr "Скасувати"
 
-#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:39
+#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:23
 msgid "Confirm"
 msgstr "Підтвердити"
 
@@ -454,37 +379,85 @@ msgstr "Форматування"
 msgid "Navigation"
 msgstr "Навігація"
 
-#: src/ui/popup/shortcut_window.blp:102 src/ui/window/window.blp:216
+#: src/ui/popup/shortcut_window.blp:102 src/ui/window/window.blp:268
 msgid "Toggle Sidebar"
 msgstr "Перемкнути бічну панель"
 
-#: src/ui/popup/shortcut_window.blp:107 src/ui/window/window.blp:63
+#: src/ui/popup/shortcut_window.blp:107 src/ui/window/window.blp:70
 msgid "Search Notes"
 msgstr "Пошук нотаток"
 
-#: data/app.gschema.xml:22 src/ui/preferences/preferences.blp:47
-msgid "Makes the dark theme pitch black"
-msgstr "Робить темну тему абсолютно чорною"
-
-#: data/app.gschema.xml:26 src/ui/preferences/preferences.blp:87
-msgid "Enable Toolbar"
-msgstr "Увімкнути панель інструментів"
-
-#: data/app.gschema.xml:31 src/ui/preferences/preferences.blp:98
-msgid "Enable Cheatsheet"
+#: src/ui/popup/shortcut_window.blp:114
+msgid "Display"
 msgstr ""
 
-#: data/app.gschema.xml:36 src/ui/preferences/preferences.blp:117
-msgid "3-Pane Layout"
-msgstr "3-панельний макет"
+#: src/ui/popup/shortcut_window.blp:117
+msgid "Full Screen"
+msgstr ""
 
-#: data/app.gschema.xml:41 src/ui/preferences/preferences.blp:185
-msgid "Notes Storage Location"
-msgstr "Місце зберігання нотаток"
+#: src/ui/popup/shortcut_window.blp:122
+msgid "Zoom In"
+msgstr ""
 
-#: data/app.gschema.xml:42 src/ui/preferences/preferences.blp:186
-msgid "Where the notebooks are stored (requires app restart)"
-msgstr "Де зберігаються блокноти (потрібно перезапустити застосунок)"
+#: src/ui/popup/shortcut_window.blp:127
+msgid "Zoom Out"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:31
+#, fuzzy
+msgid "Markdown URL Detection"
+msgstr "Шпаргалка Markdown"
+
+#: src/ui/preferences/preferences.blp:32
+msgid ""
+"Determines the level of detection of URLs in\n"
+"free form text is used:\n"
+" - Aggressive tries to find all URLs\n"
+" - Strict requires a protocol identifier (ie http://)\n"
+" - Disabled turns detection off."
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:39
+msgid "Fonts"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:73
+msgid "Line Spacing"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:81
+msgid "Tools"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:133
+msgid "Layout"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:161
+msgid "Fixed Width To Use For Notes"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:162
+msgid "Sets the fixed width size of a note in px"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:167
+msgid "Sort Order For Notebooks"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:172
+msgid "Sort Order For Notes"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:179
+msgid "Files"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:197
+msgid ""
+"The trash folder is set as a hidden folder by default, this option makes it "
+"visible (requires app restart)"
+msgstr ""
 
 #: src/ui/strings.vala:4 src/ui/window/notebooks_bar/notebooks_bar.blp:129
 #: src/ui/window/notebooks_bar/notebooks_bar.blp:171
@@ -492,6 +465,7 @@ msgid "Trash"
 msgstr "Кошик"
 
 #: src/ui/strings.vala:5
+#, c-format
 msgid "%d Notes"
 msgstr "%d Нотатки"
 
@@ -499,7 +473,7 @@ msgstr "%d Нотатки"
 msgid "Are you sure you want to delete everything in the trash?"
 msgstr "Ви впевнені, що хочете видалити все в кошику?"
 
-#: src/ui/strings.vala:7 src/ui/window/window.blp:54
+#: src/ui/strings.vala:7 src/ui/window/window.blp:61
 msgid "Empty Trash"
 msgstr "Очистити кошик"
 
@@ -536,10 +510,12 @@ msgid "Move"
 msgstr "Перемістити"
 
 #: src/ui/strings.vala:18
+#, c-format
 msgid "Note “%s” already exists in notebook “%s”"
 msgstr "Нотатка “%s” вже існує в блокноті “%s”"
 
 #: src/ui/strings.vala:19
+#, c-format
 msgid "Are you sure you want to delete the note “%s”?"
 msgstr "Ви впевнені, що хочете видалити нотатку “%s”?"
 
@@ -548,6 +524,7 @@ msgid "Delete Note"
 msgstr "Видалити нотатку"
 
 #: src/ui/strings.vala:21
+#, c-format
 msgid "Are you sure you want to delete the notebook “%s”?"
 msgstr "Ви впевнені, що хочете видалити блокнот “%s”?"
 
@@ -556,34 +533,42 @@ msgid "Delete Notebook"
 msgstr "Видалити блокнот"
 
 #: src/ui/strings.vala:24
-msgid "Note name shouldn’t contain “.” or “/”"
+#, fuzzy
+msgid "Note names cannot contain a “/”"
 msgstr "Назва нотатки не повинна містити “.” або “/”"
 
 #: src/ui/strings.vala:25
-msgid "Note name shouldn’t be blank"
+#, fuzzy
+msgid "Note names cannot be blank"
 msgstr "Необхідно вказати назву нотатки"
 
 #: src/ui/strings.vala:26
+#, c-format
 msgid "Note “%s” already exists"
 msgstr "Нотатка “%s” вже існує"
 
 #: src/ui/strings.vala:27
-msgid "Couldn’t create note"
+#, fuzzy
+msgid "Could not create note"
 msgstr "Не вдалося створити нотатку"
 
 #: src/ui/strings.vala:28
-msgid "Couldn’t change note"
+#, fuzzy
+msgid "Could not change note"
 msgstr "Не вдалося змінити нотатку"
 
 #: src/ui/strings.vala:29
-msgid "Couldn’t delete note"
+#, fuzzy
+msgid "Could not delete note"
 msgstr "Не вдалося видалити нотатку"
 
 #: src/ui/strings.vala:30
-msgid "Couldn’t restore note"
+#, fuzzy
+msgid "Could not restore note"
 msgstr "Не вдалося відновити нотатку"
 
 #: src/ui/strings.vala:31
+#, c-format
 msgid "Saved “%s” to “%s”"
 msgstr "Збережено “%s” в “%s”"
 
@@ -592,27 +577,33 @@ msgid "Unknown error"
 msgstr "Невідома помилка"
 
 #: src/ui/strings.vala:33
-msgid "Notebook name shouldn’t contain “.” or “/”"
+#, fuzzy
+msgid "Notebook names cannot contain a “/”"
 msgstr "Назва блокноту не повинна містити “.” або “/”"
 
 #: src/ui/strings.vala:34
-msgid "Notebook name shouldn’t be blank"
+#, fuzzy
+msgid "Notebook names cannot be blank"
 msgstr "Необхідно вказати назву блокнота"
 
 #: src/ui/strings.vala:35
+#, c-format
 msgid "Notebook “%s” already exists"
 msgstr "Блокнот “%s” уже існує"
 
 #: src/ui/strings.vala:36
-msgid "Couldn’t create notebook"
+#, fuzzy
+msgid "Could not create notebook"
 msgstr "Не вдалося створити блокнот"
 
 #: src/ui/strings.vala:37
-msgid "Couldn’t change notebook"
+#, fuzzy
+msgid "Could not change notebook"
 msgstr "Не вдалося змінити блокнот"
 
 #: src/ui/strings.vala:38
-msgid "Couldn’t delete notebook"
+#, fuzzy
+msgid "Could not delete notebook"
 msgstr "Не вдалося видалити блокнот"
 
 #: src/ui/strings.vala:40
@@ -624,7 +615,7 @@ msgid "Rename"
 msgstr "Перейменувати"
 
 #: src/ui/strings.vala:42
-msgid "Couldn’t find an app to handle file URIs"
+msgid "Could not find an app to handle file URIs"
 msgstr ""
 
 #: src/ui/strings.vala:43
@@ -634,6 +625,10 @@ msgstr "Застосувати"
 #: src/ui/strings.vala:45
 msgid "Pick where the notebooks will be stored"
 msgstr "Виберіть, де зберігатимуться блокноти"
+
+#: src/ui/strings.vala:46
+msgid "Pick where the trash can will be stored"
+msgstr ""
 
 #: src/ui/strings.vala:47 src/ui/window/notebooks_bar/notebooks_bar.blp:59
 #: src/ui/window/notebooks_bar/notebooks_bar.blp:101
@@ -646,6 +641,110 @@ msgstr ""
 
 #: src/ui/strings.vala:50
 msgid "Extension"
+msgstr ""
+
+#: src/ui/strings.vala:51
+msgid "Unable to recognize URI"
+msgstr ""
+
+#: src/ui/strings.vala:52
+msgid "Pick primary font for notes"
+msgstr ""
+
+#: src/ui/strings.vala:53
+msgid "Pick monospace font for code"
+msgstr ""
+
+#: src/ui/strings.vala:54
+msgid "File Changed On Disk"
+msgstr ""
+
+#: src/ui/strings.vala:55
+msgid ""
+"The file has changed on disk since it was last saved/loaded by Folio.\n"
+"\n"
+"You may do one of the following:\n"
+"\n"
+" • Reload the file (discarding any changes you have made in Folio)\n"
+" • Overwrite the file (discarding any changes made outside of Folio)\n"
+" • Cancel the operation and manually resolve the issue\n"
+"\n"
+"Note: Canceling the save if you have already moved to a new note/notebook "
+"will discard your changes."
+msgstr ""
+
+#: src/ui/strings.vala:56
+msgid "Reload"
+msgstr ""
+
+#: src/ui/strings.vala:57
+msgid "Overwrite"
+msgstr ""
+
+#: src/ui/strings.vala:59
+msgid ""
+"The file has changed on disk by another application.\n"
+"\n"
+"You may do one of the following:\n"
+"\n"
+" • Reload the file (discarding any changes you have made in Folio)\n"
+" • Overwrite the file (discarding any changes made outside of Folio)"
+msgstr ""
+
+#: src/ui/strings.vala:61
+#, c-format
+msgid "Note %i"
+msgstr ""
+
+#: src/ui/strings.vala:62
+msgid "Modified Time - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:63
+msgid "Modified Time - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:64
+msgid "Alphabetical - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:65
+msgid "Alphabetical - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:66
+msgid "Natural - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:67
+msgid "Natural - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:68
+#, c-format
+msgid "Unable to launch external application for file %s."
+msgstr ""
+
+#: src/ui/strings.vala:69
+msgid "Aggressive"
+msgstr ""
+
+#: src/ui/strings.vala:70
+msgid "Strict"
+msgstr ""
+
+#: src/ui/strings.vala:71
+msgid "Disabled"
+msgstr ""
+
+#: src/ui/strings.vala:72
+#, fuzzy, c-format
+msgid "“%s” moved to trash"
+msgstr "Перемістити в кошик"
+
+#: src/ui/strings.vala:73
+#, c-format
+msgid "“%s” restored"
 msgstr ""
 
 #: src/ui/widgets/theme_selector/theme_selector.blp:15
@@ -677,40 +776,45 @@ msgid "_Keyboard Shortcuts"
 msgstr "_Комбінації клавіш"
 
 #: src/ui/window/app_menu/app_menu.blp:43
-msgid "_About"
+#, fuzzy
+msgid "_About Folio"
 msgstr "_Про застосунок"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:54
-msgid "Notebook Name"
-msgstr "Назва блокноту"
-
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:66
-msgid "Duplicate notebook names are not allowed!"
-msgstr ""
-
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:82
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:6
 msgid "First Characters"
 msgstr "Перші букви"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:83
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:7
 msgid "Initials"
 msgstr "Ініціали"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:84
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:8
 msgid "Initials: camelCase"
 msgstr "Ініціали: camelCase"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:85
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:9
 msgid "Initials: snake_case"
 msgstr "Ініціали: snake_case"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:86
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:10
 msgid "Icon"
 msgstr "Значок"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:116
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:11
+msgid "Custom"
+msgstr ""
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:16
 msgid "Notebook Color"
 msgstr "Колір блокноту"
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:58
+msgid "Notebook Name"
+msgstr "Назва блокноту"
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:70
+msgid "Duplicate notebook names are not allowed!"
+msgstr ""
 
 #: src/ui/window/notebooks_bar/notebook_create_popup.blp:126
 msgid "Create Notebook"
@@ -728,11 +832,11 @@ msgstr "Перемістити все в кошик"
 msgid "Notebooks"
 msgstr ""
 
-#: src/ui/window/sidebar/note_create_popup.blp:37
+#: src/ui/window/sidebar/note_create_popup.blp:25
 msgid "Note Name"
 msgstr "Назва нотатки"
 
-#: src/ui/window/sidebar/note_create_popup.blp:45
+#: src/ui/window/sidebar/note_create_popup.blp:33
 msgid "Create Note"
 msgstr "Створити нотатку"
 
@@ -756,30 +860,37 @@ msgstr "Перемістити в кошик"
 msgid "Open Containing Folder"
 msgstr "Відкрийте папку, що містить"
 
-#: src/ui/window/window.blp:118
+#: src/ui/window/window.blp:123
 msgid "Get started writing"
 msgstr "Почніть писати"
 
-#: src/ui/window/window.blp:143
+#: src/ui/window/window.blp:152
+msgid "Open file in external application"
+msgstr ""
+
+#: src/ui/window/window.blp:160
+msgid "Open file"
+msgstr ""
+
+#: src/ui/window/window.blp:181
 msgid "Create a notebook"
 msgstr "Створити блокнот"
 
-#: src/ui/window/window.blp:168
+#: src/ui/window/window.blp:210
 msgid "Trash is empty"
 msgstr "Кошик порожній"
 
-#: src/ui/window/window.blp:224
-msgid "Back"
-msgstr "Назад"
-
-#: src/ui/window/window.blp:239
+#: src/ui/window/window.blp:285
 msgid "Open in Notebook"
 msgstr "Відкрити в блокноті"
 
-#: src/ui/window/window.blp:264
+#: src/ui/window/window.blp:312
 msgid "_Rename Note"
 msgstr "_Перейменувати нотатку"
 
-#: src/ui/window/window.blp:270
+#: src/ui/window/window.blp:319
 msgid "_Export Note"
 msgstr "_Експортувати нотатку"
+
+#~ msgid "Back"
+#~ msgstr "Назад"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -2,229 +2,16 @@
 # This file is distributed under the same license as the Folio package.
 msgid ""
 msgstr ""
+"Project-Id-Version: Folio\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-10-12 16:53+0200\n"
 "PO-Revision-Date: 2024-03-02 16:55:21+0000\n"
+"Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: GlotPress/4.0.0\n"
-"Language: zh_CN\n"
-"Project-Id-Version: Folio\n"
-
-#: data/app.gschema.xml:76
-msgid "Notebook sort order"
-msgstr ""
-
-#: data/app.gschema.xml:77
-msgid "The sort order of the notebook list"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:145
-msgid "Sort Order For Notebooks"
-msgstr ""
-
-#: data/app.gschema.xml:71
-msgid "Note sort order"
-msgstr ""
-
-#: data/app.gschema.xml:72
-msgid "The sort order of the note list"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:150
-msgid "Sort Order For Notes"
-msgstr ""
-
-#: src/ui/strings.vala:62
-msgid "Modified Time - Ascending"
-msgstr ""
-
-#: src/ui/strings.vala:63
-msgid "Modified Time - Descending"
-msgstr ""
-
-#: src/ui/strings.vala:64
-msgid "Alphabetical - Ascending"
-msgstr ""
-
-#: src/ui/strings.vala:65
-msgid "Alphabetical - Descending"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:114
-msgid "Display"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:117
-msgid "Full Screen"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:122
-msgid "Zoom In"
-msgstr ""
-
-#: src/ui/popup/shortcut_window.blp:127
-msgid "Zoom Out"
-msgstr ""
-
-#: src/ui/strings.vala:52
-msgid "Pick primary font for notes"
-msgstr ""
-
-#: src/ui/strings.vala:53
-msgid "Pick monospace font for code"
-msgstr ""
-
-#: src/ui/strings.vala:54
-msgid "File Changed On Disk"
-msgstr ""
-
-#: src/ui/strings.vala:55
-msgid ""
-"The file has changed on disk since it was last saved/loaded by Folio.\n"
-"\n"
-"You may do one of the following:\n"
-"\n"
-" • Reload the file (discarding any changes you have made in Folio)\n"
-" • Overwrite the file (discarding any changes made outside of Folio)\n"
-" • Cancel the operation and manually resolve the issue\n"
-"\n"
-"Note: Canceling the save if you have already moved to a new note/notebook will discard your changes."
-msgstr ""
-
-#: src/ui/strings.vala:56
-msgid "Reload"
-msgstr ""
-
-#: src/ui/strings.vala:57
-msgid "Overwrite"
-msgstr ""
-
-#: src/ui/strings.vala:59
-msgid ""
-"The file has changed on disk by another application.\n"
-"\n"
-"You may do one of the following:\n"
-"\n"
-" • Reload the file (discarding any changes you have made in Folio)\n"
-" • Overwrite the file (discarding any changes made outside of Folio)"
-msgstr ""
-
-#: src/ui/strings.vala:61
-msgid "Note %i"
-msgstr ""
-
-#: data/app.gschema.xml:46 src/ui/preferences/preferences.blp:213
-msgid "Trash Storage Location"
-msgstr ""
-
-#: data/app.gschema.xml:47 src/ui/preferences/preferences.blp:214
-msgid "Where the trash folder is located (requires app restart)"
-msgstr ""
-
-#: src/ui/strings.vala:46
-msgid "Pick where the trash can will be stored"
-msgstr ""
-
-#: data/app.gschema.xml:16 src/ui/preferences/preferences.blp:128
-msgid "Use Fixed Width For Notes"
-msgstr ""
-
-#: data/app.gschema.xml:17 src/ui/preferences/preferences.blp:129
-msgid "Use a fixed width for the text area of a note"
-msgstr ""
-
-#: data/app.gschema.xml:37 src/ui/preferences/preferences.blp:118
-msgid "Expands the notebook list to include the notebook name"
-msgstr ""
-
-#: data/app.gschema.xml:51 src/ui/preferences/preferences.blp:65
-msgid "Show line numbers"
-msgstr ""
-
-#: data/app.gschema.xml:52 src/ui/preferences/preferences.blp:66
-msgid "Displays line numbers at the left of the note"
-msgstr ""
-
-#: data/app.gschema.xml:56 src/ui/preferences/preferences.blp:76
-msgid "Show all notes"
-msgstr ""
-
-#: data/app.gschema.xml:57 src/ui/preferences/preferences.blp:77
-msgid "Displays the \"All Notes\" notebook at the top of the notebook list"
-msgstr ""
-
-#: data/app.gschema.xml:61 src/ui/preferences/preferences.blp:163
-msgid "Enable autosave"
-msgstr ""
-
-#: data/app.gschema.xml:62 src/ui/preferences/preferences.blp:164
-msgid "Automatically saves the current note every 30 seconds if the contents have changed (requires app restart)"
-msgstr ""
-
-#: data/app.gschema.xml:66 src/ui/preferences/preferences.blp:174
-msgid "Don't hide the Trash folder"
-msgstr ""
-
-#: data/app.gschema.xml:67
-msgid "The trash folder is set as a hidden folder by default, this option makes it visible"
-msgstr ""
-
-#: data/app.metainfo.xml.in:367
-msgid "Main Folio window in light mode"
-msgstr ""
-
-#: data/app.metainfo.xml.in:371
-msgid "Main Folio window in dark mode"
-msgstr ""
-
-#: data/app.metainfo.xml.in:375
-msgid "Folio on small/mobile screens"
-msgstr ""
-
-#: data/app.metainfo.xml.in:379
-msgid "Folio preferences screen"
-msgstr ""
-
-#: data/app.metainfo.xml.in:383
-msgid "Folio in three pane mode"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:59
-msgid "Tools"
-msgstr ""
-
-#: data/app.gschema.xml:27 src/ui/preferences/preferences.blp:88
-msgid "Displays the formatting toolbar at the bottom of the note"
-msgstr ""
-
-#: data/app.gschema.xml:32 src/ui/preferences/preferences.blp:99
-msgid "Adds a button to the markdown reference sheet on the right of the formatting toolbar"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:111
-msgid "Layout"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:139
-msgid "Fixed Width To Use For Notes"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:140
-msgid "Sets the fixed width size of a note in px"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:157
-msgid "Files"
-msgstr ""
-
-#: src/ui/preferences/preferences.blp:175
-msgid "The trash folder is set as a hidden folder by default, this option makes it visible (requires app restart)"
-msgstr ""
-
-#: src/ui/strings.vala:51
-msgid "Unable to recognize URI"
-msgstr ""
 
 #: data/app.desktop.in:9 src/ui/strings.vala:3
 msgid "Folio"
@@ -243,18 +30,18 @@ msgid "Notebook;Note;Notes;Text;Markdown;Notepad;Write;School;Post-it;Sticky;"
 msgstr "笔记本;笔记;札记;文本;Markdown;记事本;书写;学校;便利贴;便签"
 
 #: data/app.desktop.in:22 src/ui/popup/shortcut_window.blp:17
-#: src/ui/strings.vala:8 src/ui/window/window.blp:47
-#: src/ui/window/window.blp:124
+#: src/ui/strings.vala:8 src/ui/window/window.blp:54
+#: src/ui/window/window.blp:131
 msgid "New Note"
 msgstr "新建笔记"
 
 #: data/app.desktop.in:26 src/ui/popup/shortcut_window.blp:37
-#: src/ui/strings.vala:14 src/ui/window/window.blp:149
+#: src/ui/strings.vala:14 src/ui/window/window.blp:189
 msgid "New Notebook"
 msgstr "新建笔记本"
 
-#: data/app.desktop.in:30 src/ui/edit_view/toolbar/toolbar.blp:90
-#: src/ui/strings.vala:39 src/ui/window/window.blp:245
+#: data/app.desktop.in:30 src/ui/edit_view/toolbar/toolbar.blp:92
+#: src/ui/strings.vala:39 src/ui/window/window.blp:291
 msgid "Markdown Cheatsheet"
 msgstr "Markdown 备忘录"
 
@@ -262,25 +49,147 @@ msgstr "Markdown 备忘录"
 msgid "Preferences"
 msgstr "首选项"
 
-#: data/app.gschema.xml:6 src/ui/preferences/preferences.blp:18
+#: data/app.gschema.xml:6 src/ui/preferences/preferences.blp:45
 msgid "Note Font"
 msgstr "笔记字体"
 
-#: data/app.gschema.xml:7 src/ui/preferences/preferences.blp:19
+#: data/app.gschema.xml:7 src/ui/preferences/preferences.blp:46
 msgid "The font notes will be displayed in"
 msgstr "这个字体将会展示在"
 
-#: data/app.gschema.xml:11 src/ui/preferences/preferences.blp:31
+#: data/app.gschema.xml:11 src/ui/preferences/preferences.blp:58
 msgid "Monospace Font"
 msgstr ""
 
-#: data/app.gschema.xml:12 src/ui/preferences/preferences.blp:32
+#: data/app.gschema.xml:12 src/ui/preferences/preferences.blp:59
 msgid "The font code will be displayed in"
 msgstr ""
 
-#: data/app.gschema.xml:21 src/ui/preferences/preferences.blp:46
+#: data/app.gschema.xml:16 src/ui/preferences/preferences.blp:150
+msgid "Use Fixed Width For Notes"
+msgstr ""
+
+#: data/app.gschema.xml:17 src/ui/preferences/preferences.blp:151
+msgid "Use a fixed width for the text area of a note"
+msgstr ""
+
+#: data/app.gschema.xml:21 src/ui/preferences/preferences.blp:18
 msgid "OLED Mode"
 msgstr "OLED 模式"
+
+#: data/app.gschema.xml:22 src/ui/preferences/preferences.blp:19
+msgid "Makes the dark theme pitch black"
+msgstr "使暗黑主题颜色更深"
+
+#: data/app.gschema.xml:26 src/ui/preferences/preferences.blp:109
+msgid "Enable Toolbar"
+msgstr ""
+
+#: data/app.gschema.xml:27 src/ui/preferences/preferences.blp:110
+msgid "Displays the formatting toolbar at the bottom of the note"
+msgstr ""
+
+#: data/app.gschema.xml:31 src/ui/preferences/preferences.blp:120
+msgid "Enable Cheatsheet"
+msgstr ""
+
+#: data/app.gschema.xml:32 src/ui/preferences/preferences.blp:121
+msgid ""
+"Adds a button to the markdown reference sheet on the right of the formatting "
+"toolbar"
+msgstr ""
+
+#: data/app.gschema.xml:36 src/ui/preferences/preferences.blp:139
+msgid "3-Pane Layout"
+msgstr ""
+
+#: data/app.gschema.xml:37 src/ui/preferences/preferences.blp:140
+msgid "Expands the notebook list to include the notebook name"
+msgstr ""
+
+#: data/app.gschema.xml:41 src/ui/preferences/preferences.blp:207
+msgid "Notes Storage Location"
+msgstr "笔记本存储位置"
+
+#: data/app.gschema.xml:42 src/ui/preferences/preferences.blp:208
+msgid "Where the notebooks are stored (requires app restart)"
+msgstr "笔记本应该存储在哪里（需要重启本 app）"
+
+#: data/app.gschema.xml:46 src/ui/preferences/preferences.blp:235
+msgid "Trash Storage Location"
+msgstr ""
+
+#: data/app.gschema.xml:47 src/ui/preferences/preferences.blp:236
+msgid "Where the trash folder is located (requires app restart)"
+msgstr ""
+
+#: data/app.gschema.xml:51 src/ui/preferences/preferences.blp:87
+msgid "Show line numbers"
+msgstr ""
+
+#: data/app.gschema.xml:52 src/ui/preferences/preferences.blp:88
+msgid "Displays line numbers at the left of the note"
+msgstr ""
+
+#: data/app.gschema.xml:56 src/ui/preferences/preferences.blp:98
+msgid "Show all notes"
+msgstr ""
+
+#: data/app.gschema.xml:57 src/ui/preferences/preferences.blp:99
+msgid "Displays the \"All Notes\" notebook at the top of the notebook list"
+msgstr ""
+
+#: data/app.gschema.xml:61 src/ui/preferences/preferences.blp:185
+msgid "Enable autosave"
+msgstr ""
+
+#: data/app.gschema.xml:62 src/ui/preferences/preferences.blp:186
+msgid ""
+"Automatically saves the current note every 30 seconds if the contents have "
+"changed (requires app restart)"
+msgstr ""
+
+#: data/app.gschema.xml:66 src/ui/preferences/preferences.blp:196
+msgid "Don't hide the Trash folder"
+msgstr ""
+
+#: data/app.gschema.xml:67
+msgid ""
+"The trash folder is set as a hidden folder by default, this option makes it "
+"visible"
+msgstr ""
+
+#: data/app.gschema.xml:71
+msgid "Note sort order"
+msgstr ""
+
+#: data/app.gschema.xml:72
+msgid "The sort order of the note list"
+msgstr ""
+
+#: data/app.gschema.xml:76
+msgid "Notebook sort order"
+msgstr ""
+
+#: data/app.gschema.xml:77
+msgid "The sort order of the notebook list"
+msgstr ""
+
+#: data/app.gschema.xml:81
+msgid "URL detection level"
+msgstr ""
+
+#: data/app.gschema.xml:82
+msgid "How agressive to look for URLs in markdown text"
+msgstr ""
+
+#: data/app.gschema.xml:86
+msgid "Line spacing"
+msgstr ""
+
+#: data/app.gschema.xml:87 src/ui/preferences/preferences.blp:74
+msgid "The line spacing for the note text"
+msgstr ""
 
 #: data/app.metainfo.xml.in:5
 msgid "Take notes in Markdown"
@@ -314,103 +223,116 @@ msgstr ""
 msgid "Trash can"
 msgstr "垃圾桶"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:23
-#: src/ui/edit_view/toolbar/toolbar.blp:131
+#: data/app.metainfo.xml.in:393
+msgid "Main Folio window in light mode"
+msgstr ""
+
+#: data/app.metainfo.xml.in:397
+msgid "Main Folio window in dark mode"
+msgstr ""
+
+#: data/app.metainfo.xml.in:401
+msgid "Folio on small/mobile screens"
+msgstr ""
+
+#: data/app.metainfo.xml.in:405
+msgid "Folio preferences screen"
+msgstr ""
+
+#: data/app.metainfo.xml.in:409
+msgid "Folio in three pane mode"
+msgstr ""
+
+#: src/ui/edit_view/toolbar/toolbar.blp:6
 #: src/ui/widgets/markdown/heading_popover.blp:48
 msgid "Plain Text"
 msgstr "平文本"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:24
-#: src/ui/edit_view/toolbar/toolbar.blp:132
+#: src/ui/edit_view/toolbar/toolbar.blp:7
 #: src/ui/widgets/markdown/heading_popover.blp:12
 msgid "Heading 1"
 msgstr "1 级标题"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:25
-#: src/ui/edit_view/toolbar/toolbar.blp:133
+#: src/ui/edit_view/toolbar/toolbar.blp:8
 #: src/ui/widgets/markdown/heading_popover.blp:18
 msgid "Heading 2"
 msgstr "2 级标题"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:26
-#: src/ui/edit_view/toolbar/toolbar.blp:134
+#: src/ui/edit_view/toolbar/toolbar.blp:9
 #: src/ui/widgets/markdown/heading_popover.blp:24
 msgid "Heading 3"
 msgstr "3级标题"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:27
-#: src/ui/edit_view/toolbar/toolbar.blp:135
+#: src/ui/edit_view/toolbar/toolbar.blp:10
 #: src/ui/widgets/markdown/heading_popover.blp:30
 msgid "Heading 4"
 msgstr "4 级标题"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:28
-#: src/ui/edit_view/toolbar/toolbar.blp:136
+#: src/ui/edit_view/toolbar/toolbar.blp:11
 #: src/ui/widgets/markdown/heading_popover.blp:36
 msgid "Heading 5"
 msgstr "5 级标题"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:29
-#: src/ui/edit_view/toolbar/toolbar.blp:137
+#: src/ui/edit_view/toolbar/toolbar.blp:12
 #: src/ui/widgets/markdown/heading_popover.blp:42
 msgid "Heading 6"
 msgstr "6 级标题"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:39
-#: src/ui/edit_view/toolbar/toolbar.blp:104
-#: src/ui/edit_view/toolbar/toolbar.blp:148
-#: src/ui/edit_view/toolbar/toolbar.blp:201 src/ui/popup/shortcut_window.blp:72
+#: src/ui/edit_view/toolbar/toolbar.blp:41
+#: src/ui/edit_view/toolbar/toolbar.blp:107
+#: src/ui/edit_view/toolbar/toolbar.blp:142
+#: src/ui/edit_view/toolbar/toolbar.blp:195 src/ui/popup/shortcut_window.blp:72
 msgid "Bold"
 msgstr "粗体"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:45
-#: src/ui/edit_view/toolbar/toolbar.blp:111
-#: src/ui/edit_view/toolbar/toolbar.blp:155
-#: src/ui/edit_view/toolbar/toolbar.blp:202 src/ui/popup/shortcut_window.blp:77
+#: src/ui/edit_view/toolbar/toolbar.blp:47
+#: src/ui/edit_view/toolbar/toolbar.blp:114
+#: src/ui/edit_view/toolbar/toolbar.blp:149
+#: src/ui/edit_view/toolbar/toolbar.blp:196 src/ui/popup/shortcut_window.blp:77
 msgid "Italic"
 msgstr "斜体"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:51
-#: src/ui/edit_view/toolbar/toolbar.blp:162
-#: src/ui/edit_view/toolbar/toolbar.blp:203 src/ui/popup/shortcut_window.blp:82
+#: src/ui/edit_view/toolbar/toolbar.blp:53
+#: src/ui/edit_view/toolbar/toolbar.blp:156
+#: src/ui/edit_view/toolbar/toolbar.blp:197 src/ui/popup/shortcut_window.blp:82
 msgid "Strikethrough"
 msgstr "删除线"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:57
-#: src/ui/edit_view/toolbar/toolbar.blp:169
-#: src/ui/edit_view/toolbar/toolbar.blp:204 src/ui/popup/shortcut_window.blp:87
+#: src/ui/edit_view/toolbar/toolbar.blp:59
+#: src/ui/edit_view/toolbar/toolbar.blp:163
+#: src/ui/edit_view/toolbar/toolbar.blp:198 src/ui/popup/shortcut_window.blp:87
 msgid "Highlight"
 msgstr "高亮"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:67
-#: src/ui/edit_view/toolbar/toolbar.blp:193 src/ui/popup/shortcut_window.blp:92
+#: src/ui/edit_view/toolbar/toolbar.blp:69
+#: src/ui/edit_view/toolbar/toolbar.blp:187 src/ui/popup/shortcut_window.blp:92
 msgid "Insert Link"
 msgstr "插入链接"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:73
-#: src/ui/edit_view/toolbar/toolbar.blp:194
+#: src/ui/edit_view/toolbar/toolbar.blp:75
+#: src/ui/edit_view/toolbar/toolbar.blp:188
 msgid "Insert Code"
 msgstr "插入代码"
 
-#: src/ui/edit_view/toolbar/toolbar.blp:79
-#: src/ui/edit_view/toolbar/toolbar.blp:195
+#: src/ui/edit_view/toolbar/toolbar.blp:81
+#: src/ui/edit_view/toolbar/toolbar.blp:189
 msgid "Insert Horizontal Rule"
 msgstr ""
 
-#: src/ui/edit_view/toolbar/toolbar.blp:118
+#: src/ui/edit_view/toolbar/toolbar.blp:121
 msgid "Format"
 msgstr ""
 
-#: src/ui/edit_view/toolbar/toolbar.blp:181
+#: src/ui/edit_view/toolbar/toolbar.blp:175
 msgid "Insert"
 msgstr ""
 
-#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:34
+#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:18
 #: src/ui/strings.vala:44 src/ui/strings.vala:58
 msgid "Cancel"
 msgstr "取消"
 
-#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:39
+#: src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp:23
 msgid "Confirm"
 msgstr "确认"
 
@@ -454,37 +376,85 @@ msgstr "格式化"
 msgid "Navigation"
 msgstr "导航栏"
 
-#: src/ui/popup/shortcut_window.blp:102 src/ui/window/window.blp:216
+#: src/ui/popup/shortcut_window.blp:102 src/ui/window/window.blp:268
 msgid "Toggle Sidebar"
 msgstr "切换侧栏"
 
-#: src/ui/popup/shortcut_window.blp:107 src/ui/window/window.blp:63
+#: src/ui/popup/shortcut_window.blp:107 src/ui/window/window.blp:70
 msgid "Search Notes"
 msgstr "搜索笔记"
 
-#: data/app.gschema.xml:22 src/ui/preferences/preferences.blp:47
-msgid "Makes the dark theme pitch black"
-msgstr "使暗黑主题颜色更深"
-
-#: data/app.gschema.xml:26 src/ui/preferences/preferences.blp:87
-msgid "Enable Toolbar"
+#: src/ui/popup/shortcut_window.blp:114
+msgid "Display"
 msgstr ""
 
-#: data/app.gschema.xml:31 src/ui/preferences/preferences.blp:98
-msgid "Enable Cheatsheet"
+#: src/ui/popup/shortcut_window.blp:117
+msgid "Full Screen"
 msgstr ""
 
-#: data/app.gschema.xml:36 src/ui/preferences/preferences.blp:117
-msgid "3-Pane Layout"
+#: src/ui/popup/shortcut_window.blp:122
+msgid "Zoom In"
 msgstr ""
 
-#: data/app.gschema.xml:41 src/ui/preferences/preferences.blp:185
-msgid "Notes Storage Location"
-msgstr "笔记本存储位置"
+#: src/ui/popup/shortcut_window.blp:127
+msgid "Zoom Out"
+msgstr ""
 
-#: data/app.gschema.xml:42 src/ui/preferences/preferences.blp:186
-msgid "Where the notebooks are stored (requires app restart)"
-msgstr "笔记本应该存储在哪里（需要重启本 app）"
+#: src/ui/preferences/preferences.blp:31
+#, fuzzy
+msgid "Markdown URL Detection"
+msgstr "Markdown 备忘录"
+
+#: src/ui/preferences/preferences.blp:32
+msgid ""
+"Determines the level of detection of URLs in\n"
+"free form text is used:\n"
+" - Aggressive tries to find all URLs\n"
+" - Strict requires a protocol identifier (ie http://)\n"
+" - Disabled turns detection off."
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:39
+msgid "Fonts"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:73
+msgid "Line Spacing"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:81
+msgid "Tools"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:133
+msgid "Layout"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:161
+msgid "Fixed Width To Use For Notes"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:162
+msgid "Sets the fixed width size of a note in px"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:167
+msgid "Sort Order For Notebooks"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:172
+msgid "Sort Order For Notes"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:179
+msgid "Files"
+msgstr ""
+
+#: src/ui/preferences/preferences.blp:197
+msgid ""
+"The trash folder is set as a hidden folder by default, this option makes it "
+"visible (requires app restart)"
+msgstr ""
 
 #: src/ui/strings.vala:4 src/ui/window/notebooks_bar/notebooks_bar.blp:129
 #: src/ui/window/notebooks_bar/notebooks_bar.blp:171
@@ -492,6 +462,7 @@ msgid "Trash"
 msgstr "垃圾"
 
 #: src/ui/strings.vala:5
+#, c-format
 msgid "%d Notes"
 msgstr "%d 笔记"
 
@@ -499,7 +470,7 @@ msgstr "%d 笔记"
 msgid "Are you sure you want to delete everything in the trash?"
 msgstr "您想删除垃圾桶里的一切嘛？"
 
-#: src/ui/strings.vala:7 src/ui/window/window.blp:54
+#: src/ui/strings.vala:7 src/ui/window/window.blp:61
 msgid "Empty Trash"
 msgstr "清空垃圾桶"
 
@@ -536,10 +507,12 @@ msgid "Move"
 msgstr "移动"
 
 #: src/ui/strings.vala:18
+#, c-format
 msgid "Note “%s” already exists in notebook “%s”"
 msgstr "笔记 “%s” 已经存在于 “%s”笔记本中"
 
 #: src/ui/strings.vala:19
+#, c-format
 msgid "Are you sure you want to delete the note “%s”?"
 msgstr "您真的想删除笔记 “%s” 嘛？"
 
@@ -548,6 +521,7 @@ msgid "Delete Note"
 msgstr "删除笔记"
 
 #: src/ui/strings.vala:21
+#, c-format
 msgid "Are you sure you want to delete the notebook “%s”?"
 msgstr "您真的想删除笔记本 “%s” 嘛？"
 
@@ -556,34 +530,42 @@ msgid "Delete Notebook"
 msgstr "删除笔记本"
 
 #: src/ui/strings.vala:24
-msgid "Note name shouldn’t contain “.” or “/”"
+#, fuzzy
+msgid "Note names cannot contain a “/”"
 msgstr "笔记名称不应该包含 “.”或者 “/”"
 
 #: src/ui/strings.vala:25
-msgid "Note name shouldn’t be blank"
+#, fuzzy
+msgid "Note names cannot be blank"
 msgstr "笔记名称不应该为空"
 
 #: src/ui/strings.vala:26
+#, c-format
 msgid "Note “%s” already exists"
 msgstr "笔记 “%s” 已经存在"
 
 #: src/ui/strings.vala:27
-msgid "Couldn’t create note"
+#, fuzzy
+msgid "Could not create note"
 msgstr "无法创建笔记"
 
 #: src/ui/strings.vala:28
-msgid "Couldn’t change note"
+#, fuzzy
+msgid "Could not change note"
 msgstr "无法更改笔记"
 
 #: src/ui/strings.vala:29
-msgid "Couldn’t delete note"
+#, fuzzy
+msgid "Could not delete note"
 msgstr "无法删除笔记"
 
 #: src/ui/strings.vala:30
-msgid "Couldn’t restore note"
+#, fuzzy
+msgid "Could not restore note"
 msgstr "无法存储笔记"
 
 #: src/ui/strings.vala:31
+#, c-format
 msgid "Saved “%s” to “%s”"
 msgstr "保存 “%s” 到 “%s”"
 
@@ -592,27 +574,33 @@ msgid "Unknown error"
 msgstr "未知错误"
 
 #: src/ui/strings.vala:33
-msgid "Notebook name shouldn’t contain “.” or “/”"
+#, fuzzy
+msgid "Notebook names cannot contain a “/”"
 msgstr "笔记本名称不应该包含 “.” 或 “/”?"
 
 #: src/ui/strings.vala:34
-msgid "Notebook name shouldn’t be blank"
+#, fuzzy
+msgid "Notebook names cannot be blank"
 msgstr "笔记本名称不应为空"
 
 #: src/ui/strings.vala:35
+#, c-format
 msgid "Notebook “%s” already exists"
 msgstr "笔记本 “%s” 已经存在"
 
 #: src/ui/strings.vala:36
-msgid "Couldn’t create notebook"
+#, fuzzy
+msgid "Could not create notebook"
 msgstr "无法创建笔记本"
 
 #: src/ui/strings.vala:37
-msgid "Couldn’t change notebook"
+#, fuzzy
+msgid "Could not change notebook"
 msgstr "无法更改笔记本"
 
 #: src/ui/strings.vala:38
-msgid "Couldn’t delete notebook"
+#, fuzzy
+msgid "Could not delete notebook"
 msgstr "无法删除笔记本"
 
 #: src/ui/strings.vala:40
@@ -624,7 +612,7 @@ msgid "Rename"
 msgstr "重命名"
 
 #: src/ui/strings.vala:42
-msgid "Couldn’t find an app to handle file URIs"
+msgid "Could not find an app to handle file URIs"
 msgstr ""
 
 #: src/ui/strings.vala:43
@@ -634,6 +622,10 @@ msgstr "应用"
 #: src/ui/strings.vala:45
 msgid "Pick where the notebooks will be stored"
 msgstr "选择笔记本的存储位置"
+
+#: src/ui/strings.vala:46
+msgid "Pick where the trash can will be stored"
+msgstr ""
 
 #: src/ui/strings.vala:47 src/ui/window/notebooks_bar/notebooks_bar.blp:59
 #: src/ui/window/notebooks_bar/notebooks_bar.blp:101
@@ -646,6 +638,110 @@ msgstr ""
 
 #: src/ui/strings.vala:50
 msgid "Extension"
+msgstr ""
+
+#: src/ui/strings.vala:51
+msgid "Unable to recognize URI"
+msgstr ""
+
+#: src/ui/strings.vala:52
+msgid "Pick primary font for notes"
+msgstr ""
+
+#: src/ui/strings.vala:53
+msgid "Pick monospace font for code"
+msgstr ""
+
+#: src/ui/strings.vala:54
+msgid "File Changed On Disk"
+msgstr ""
+
+#: src/ui/strings.vala:55
+msgid ""
+"The file has changed on disk since it was last saved/loaded by Folio.\n"
+"\n"
+"You may do one of the following:\n"
+"\n"
+" • Reload the file (discarding any changes you have made in Folio)\n"
+" • Overwrite the file (discarding any changes made outside of Folio)\n"
+" • Cancel the operation and manually resolve the issue\n"
+"\n"
+"Note: Canceling the save if you have already moved to a new note/notebook "
+"will discard your changes."
+msgstr ""
+
+#: src/ui/strings.vala:56
+msgid "Reload"
+msgstr ""
+
+#: src/ui/strings.vala:57
+msgid "Overwrite"
+msgstr ""
+
+#: src/ui/strings.vala:59
+msgid ""
+"The file has changed on disk by another application.\n"
+"\n"
+"You may do one of the following:\n"
+"\n"
+" • Reload the file (discarding any changes you have made in Folio)\n"
+" • Overwrite the file (discarding any changes made outside of Folio)"
+msgstr ""
+
+#: src/ui/strings.vala:61
+#, c-format
+msgid "Note %i"
+msgstr ""
+
+#: src/ui/strings.vala:62
+msgid "Modified Time - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:63
+msgid "Modified Time - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:64
+msgid "Alphabetical - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:65
+msgid "Alphabetical - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:66
+msgid "Natural - Ascending"
+msgstr ""
+
+#: src/ui/strings.vala:67
+msgid "Natural - Descending"
+msgstr ""
+
+#: src/ui/strings.vala:68
+#, c-format
+msgid "Unable to launch external application for file %s."
+msgstr ""
+
+#: src/ui/strings.vala:69
+msgid "Aggressive"
+msgstr ""
+
+#: src/ui/strings.vala:70
+msgid "Strict"
+msgstr ""
+
+#: src/ui/strings.vala:71
+msgid "Disabled"
+msgstr ""
+
+#: src/ui/strings.vala:72
+#, fuzzy, c-format
+msgid "“%s” moved to trash"
+msgstr "移动到垃圾桶"
+
+#: src/ui/strings.vala:73
+#, c-format
+msgid "“%s” restored"
 msgstr ""
 
 #: src/ui/widgets/theme_selector/theme_selector.blp:15
@@ -677,40 +773,45 @@ msgid "_Keyboard Shortcuts"
 msgstr "_快捷键"
 
 #: src/ui/window/app_menu/app_menu.blp:43
-msgid "_About"
+#, fuzzy
+msgid "_About Folio"
 msgstr "_关于"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:54
-msgid "Notebook Name"
-msgstr "笔记本名称"
-
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:66
-msgid "Duplicate notebook names are not allowed!"
-msgstr ""
-
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:82
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:6
 msgid "First Characters"
 msgstr "首字符"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:83
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:7
 msgid "Initials"
 msgstr "缩写"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:84
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:8
 msgid "Initials: camelCase"
 msgstr "缩写：camelCase"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:85
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:9
 msgid "Initials: snake_case"
 msgstr "缩写：snake_case"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:86
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:10
 msgid "Icon"
 msgstr "图标"
 
-#: src/ui/window/notebooks_bar/notebook_create_popup.blp:116
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:11
+msgid "Custom"
+msgstr ""
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:16
 msgid "Notebook Color"
 msgstr "笔记颜色"
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:58
+msgid "Notebook Name"
+msgstr "笔记本名称"
+
+#: src/ui/window/notebooks_bar/notebook_create_popup.blp:70
+msgid "Duplicate notebook names are not allowed!"
+msgstr ""
 
 #: src/ui/window/notebooks_bar/notebook_create_popup.blp:126
 msgid "Create Notebook"
@@ -728,11 +829,11 @@ msgstr "移动所有的笔记到垃圾桶"
 msgid "Notebooks"
 msgstr ""
 
-#: src/ui/window/sidebar/note_create_popup.blp:37
+#: src/ui/window/sidebar/note_create_popup.blp:25
 msgid "Note Name"
 msgstr "笔记名称"
 
-#: src/ui/window/sidebar/note_create_popup.blp:45
+#: src/ui/window/sidebar/note_create_popup.blp:33
 msgid "Create Note"
 msgstr "创建笔记"
 
@@ -756,30 +857,37 @@ msgstr "移动到垃圾桶"
 msgid "Open Containing Folder"
 msgstr "在文件夹中打开"
 
-#: src/ui/window/window.blp:118
+#: src/ui/window/window.blp:123
 msgid "Get started writing"
 msgstr "开始书写"
 
-#: src/ui/window/window.blp:143
+#: src/ui/window/window.blp:152
+msgid "Open file in external application"
+msgstr ""
+
+#: src/ui/window/window.blp:160
+msgid "Open file"
+msgstr ""
+
+#: src/ui/window/window.blp:181
 msgid "Create a notebook"
 msgstr "创建笔记本"
 
-#: src/ui/window/window.blp:168
+#: src/ui/window/window.blp:210
 msgid "Trash is empty"
 msgstr "垃圾桶空空如也"
 
-#: src/ui/window/window.blp:224
-msgid "Back"
-msgstr "返回"
-
-#: src/ui/window/window.blp:239
+#: src/ui/window/window.blp:285
 msgid "Open in Notebook"
 msgstr "在笔记本中打开"
 
-#: src/ui/window/window.blp:264
+#: src/ui/window/window.blp:312
 msgid "_Rename Note"
 msgstr "_重命名笔记"
 
-#: src/ui/window/window.blp:270
+#: src/ui/window/window.blp:319
 msgid "_Export Note"
 msgstr "_导出笔记"
+
+#~ msgid "Back"
+#~ msgstr "返回"

--- a/src/application.vala
+++ b/src/application.vala
@@ -140,7 +140,7 @@ public class Folio.Application : Adw.Application {
 	}
 
 	private void on_about_action () {
-		var about = new Adw.AboutWindow ();
+		var about = new Adw.AboutDialog ();
 		about.application_icon = Config.APP_ID;
 		about.application_name = "Folio";
 		about.developers = {"Greg Ross <greg@toolstack.com>", "Zagura"};
@@ -171,7 +171,6 @@ rene-coty
 		about.license_type = Gtk.License.GPL_3_0;
 		about.version = Config.VERSION;
 		about.website = "https://github.com/toolstack/Folio";
-		about.transient_for = this.active_window;
 		about.set_release_notes ("""
         <p>Changes:</p>
 <ul>
@@ -185,16 +184,13 @@ rene-coty
 </ul>
 """
 		);
-		about.present ();
+		about.present (this.active_window);
 	}
 
 	private void on_preferences_action () {
 		activate ();
-		var w = new PreferencesWindow (this);
-		w.destroy_with_parent = true;
-		w.transient_for = active_window;
-		w.modal = true;
-		w.present ();
+		var w = new PreferencesWindow (this, active_window);
+		w.present (active_window);
 	}
 
 	private void on_quit_action () {
@@ -204,10 +200,7 @@ rene-coty
 
 	private void on_markdown_cheatsheet () {
 		var w = new MarkdownCheatsheet (this);
-		w.destroy_with_parent = true;
-		w.transient_for = active_window;
-		w.modal = true;
-		w.present ();
+		w.present (active_window);
 	}
 
 	private void on_empty_trash () {

--- a/src/css/style-black.css
+++ b/src/css/style-black.css
@@ -16,6 +16,6 @@
 
 @define-color borders alpha(shade(@theme_color, 1.6), 0.25);
 
-window:not(.tiled-left):not(.tiled-right):not(.tiled-bottom) {
+window:not(.tiled-left):not(.tiled-right):not(.tiled-bottom), dialog {
   outline: solid 1px @borders;
 }

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -415,3 +415,7 @@ headerbar.overlaid {
   margin: 6px 8px;
   font-size: .62em;
 }
+
+dialog.cheatsheet headerbar {
+	background: @view_bg_color;
+}

--- a/src/ui/edit_view/cheatsheet/markdown_cheatsheet.blp
+++ b/src/ui/edit_view/cheatsheet/markdown_cheatsheet.blp
@@ -1,42 +1,33 @@
 using Gtk 4.0;
 using Adw 1;
 
-template $FolioMarkdownCheatsheet : Gtk.Window {
+template $FolioMarkdownCheatsheet : Adw.Dialog {
+  styles [ "cheatsheet" ]
+  content-width: 500;
+  content-height: 440;
 
-  default-width: 500;
-  default-height: 440;
-  titlebar: Adw.HeaderBar {};
+  child: Adw.ToolbarView {
 
-  ShortcutController {
+    [top]
+    Adw.HeaderBar {}
 
-    scope: managed;
+    content: ScrolledWindow {
+      $GtkMarkdownView text_view {
+        tab-width: 4;
+        auto-indent: true;
+        wrap-mode: word-char;
+        bottom-margin: 18;
+        left-margin: 18;
+        right-margin: 18;
+        top-margin: 18;
+        hexpand: true;
+        vexpand: true;
+        editable: false;
+        cursor-visible: false;
+        show-gutter: false;
 
-    Shortcut {
-      trigger: "Escape";
-      action: "action(window.close)";
-    }
-  }
-
-  Adw.StatusPage {
-
-    css-name: _("status_page");
-
-    $GtkMarkdownView text_view {
-
-      tab-width: 4;
-      auto-indent: true;
-      wrap-mode: word-char;
-      bottom-margin: 18;
-      left-margin: 18;
-      right-margin: 18;
-      top-margin: 18;
-      hexpand: true;
-      vexpand: true;
-      editable: false;
-      cursor-visible: false;
-      show-gutter: false;
-
-      styles ["note-font"]
-    }
-  }
+        styles ["note-font"]
+      }
+    };
+  };
 }

--- a/src/ui/edit_view/cheatsheet/markdown_cheatsheet.vala
+++ b/src/ui/edit_view/cheatsheet/markdown_cheatsheet.vala
@@ -17,15 +17,14 @@
  */
 
 [GtkTemplate (ui = "/com/toolstack/Folio/markdown_cheatsheet.ui")]
-public class Folio.MarkdownCheatsheet : Gtk.Window {
+public class Folio.MarkdownCheatsheet : Adw.Dialog {
 
 	[GtkChild]
 	unowned GtkMarkdown.View text_view;
 
 	public MarkdownCheatsheet (Application app) {
 		Object (
-			title: Strings.MARKDOWN_CHEATSHEET,
-			icon_name: Config.APP_ID
+			title: Strings.MARKDOWN_CHEATSHEET
 		);
 
 		try {

--- a/src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp
+++ b/src/ui/popup/notebook_selection_popup/notebook_selection_popup.blp
@@ -1,30 +1,14 @@
 using Gtk 4.0;
 using Adw 1;
 
-template $FolioNotebookSelectionPopup : Adw.Window {
+template $FolioNotebookSelectionPopup : Adw.Dialog {
 
-  default-width: 360;
-  default-height: 420;
-  resizable: true;
-  modal: true;
+  content-width: 360;
+  content-height: 420;
 
-  ShortcutController {
-
-    scope: managed;
-
-    Shortcut {
-      trigger: "Escape";
-      action: "action(window.close)";
-    }
-  }
-
-  Box {
-
-    orientation: vertical;
-    hexpand: true;
-
+  child: Adw.ToolbarView {
+    [top]
     Adw.HeaderBar headerbar {
-
       hexpand: true;
       show-start-title-buttons: false;
       show-end-title-buttons: false;
@@ -41,15 +25,15 @@ template $FolioNotebookSelectionPopup : Adw.Window {
       }
     }
 
-    ScrolledWindow scrolled_window {
+    content: ScrolledWindow scrolled_window {
 
       hexpand: true;
       vexpand: true;
 
       ListView notebooks_list {
         hexpand: true;
-        styles ["notebook-list"]
+        styles ["boxed-list", "notebook-list"]
       }
-    }
-  }
+    };
+  };
 }

--- a/src/ui/popup/notebook_selection_popup/notebook_selection_popup.vala
+++ b/src/ui/popup/notebook_selection_popup/notebook_selection_popup.vala
@@ -2,7 +2,7 @@
 public delegate void Folio.OnNotebookSelected (Notebook notebook);
 
 [GtkTemplate (ui = "/com/toolstack/Folio/popup/notebook_selection_popup.ui")]
-public class Folio.NotebookSelectionPopup : Adw.Window {
+public class Folio.NotebookSelectionPopup : Adw.Dialog {
 
 	[GtkChild]
 	unowned Gtk.ListView notebooks_list;
@@ -26,7 +26,7 @@ public class Folio.NotebookSelectionPopup : Adw.Window {
 		this.title = title;
 		this.button_confirm.label = action_name;
 		this.callback = (owned) callback;
-		button_cancel.clicked.connect (close);
+		button_cancel.clicked.connect (() => { this.close (); });
 		var model = new Gtk.SingleSelection (provider);
 		var factory = new Gtk.SignalListItemFactory ();
 		factory.setup.connect (obj => {

--- a/src/ui/preferences/preferences.blp
+++ b/src/ui/preferences/preferences.blp
@@ -1,12 +1,12 @@
 using Gtk 4.0;
 using Adw 1;
 
-template $FolioPreferencesWindow : Adw.PreferencesWindow {
+template $FolioPreferencesWindow : Adw.PreferencesDialog {
 
-  default-width: 560;
-  default-height: 470;
+  content-width: 560;
+  content-height: 470;
   search-enabled: false;
-  modal: true;
+
 
   Adw.PreferencesPage {
     title: _("General");

--- a/src/ui/preferences/preferences.vala
+++ b/src/ui/preferences/preferences.vala
@@ -1,6 +1,6 @@
 
 [GtkTemplate (ui = "/com/toolstack/Folio/preferences.ui")]
-public class Folio.PreferencesWindow : Adw.PreferencesWindow {
+public class Folio.PreferencesWindow : Adw.PreferencesDialog {
 
 	[GtkChild] unowned Gtk.FontDialogButton font_button;
 	[GtkChild] unowned Gtk.FontDialogButton font_button_monospace;
@@ -25,7 +25,7 @@ public class Folio.PreferencesWindow : Adw.PreferencesWindow {
 	[GtkChild] unowned Adw.ComboRow notebook_sort_order;
 	[GtkChild] unowned Adw.ComboRow line_spacing;
 
-	public PreferencesWindow (Application app) {
+	public PreferencesWindow (Application app, Gtk.Window window) {
 		Object ();
 
 		var settings = new Settings (Config.APP_ID);
@@ -163,7 +163,7 @@ public class Folio.PreferencesWindow : Adw.PreferencesWindow {
 			chooser.set_modal (true);
 			chooser.set_title (Strings.PICK_NOTES_DIR);
 			chooser.set_initial_folder (File.new_for_path (notes_dir));
-			chooser.select_folder.begin (this, null, (obj, res) => {
+			chooser.select_folder.begin (window, null, (obj, res) => {
                 try {
                     var folder = chooser.select_folder.end(res);
 					if (folder.query_exists ()) {
@@ -190,7 +190,7 @@ public class Folio.PreferencesWindow : Adw.PreferencesWindow {
 			chooser.set_modal (true);
 			chooser.set_title (Strings.PICK_TRASH_DIR);
 			chooser.set_initial_folder (File.new_for_path (trash_dir));
-			chooser.select_folder.begin (this, null, (obj, res) => {
+			chooser.select_folder.begin (window, null, (obj, res) => {
                 try {
                     var folder = chooser.select_folder.end(res);
 					if (folder.query_exists ()) {

--- a/src/ui/strings.vala
+++ b/src/ui/strings.vala
@@ -70,4 +70,5 @@ public class Folio.Strings {
 	public abstract const string URL_DETECTION_STRICT = _("Strict");
 	public abstract const string URL_DETECTION_DISABLED = _("Disabled");
 	public abstract const string NOTE_TRASHED = _("“%s” moved to trash");
+	public abstract const string NOTE_RESTORED = _("“%s” restored");
 }

--- a/src/ui/strings.vala
+++ b/src/ui/strings.vala
@@ -69,4 +69,5 @@ public class Folio.Strings {
 	public abstract const string URL_DETECTION_AGGRESSIVE = _("Aggressive");
 	public abstract const string URL_DETECTION_STRICT = _("Strict");
 	public abstract const string URL_DETECTION_DISABLED = _("Disabled");
+	public abstract const string NOTE_TRASHED = _("“%s” moved to trash");
 }

--- a/src/ui/window/app_menu/app_menu.blp
+++ b/src/ui/window/app_menu/app_menu.blp
@@ -40,7 +40,7 @@ menu primary_menu {
       action: "win.show-help-overlay";
     }
     item {
-      label: _("_About");
+      label: _("_About Folio");
       action: "app.about";
     }
   }

--- a/src/ui/window/notebooks_bar/notebook_create_popup.blp
+++ b/src/ui/window/notebooks_bar/notebook_create_popup.blp
@@ -17,21 +17,9 @@ Gtk.ColorDialog color_dialog {
   modal: true;
 }
 
-template $FolioNotebookCreatePopup : Adw.Window {
+template $FolioNotebookCreatePopup : Adw.Dialog {
 
-  default-width: 320;
-  resizable: false;
-  modal: true;
-
-  ShortcutController {
-
-    scope: managed;
-
-    Shortcut {
-      trigger: "Escape";
-      action: "action(window.close)";
-    }
-  }
+  content-width: 320;
 
   WindowHandle {
     Box {

--- a/src/ui/window/notebooks_bar/notebook_create_popup.vala
+++ b/src/ui/window/notebooks_bar/notebook_create_popup.vala
@@ -1,6 +1,6 @@
 
 [GtkTemplate (ui = "/com/toolstack/Folio/notebooks_bar/create_popup.ui")]
-public class Folio.NotebookCreatePopup : Adw.Window {
+public class Folio.NotebookCreatePopup : Adw.Dialog {
 
 	[GtkChild]
 	unowned Gtk.Entry entry;

--- a/src/ui/window/sidebar/note_card.vala
+++ b/src/ui/window/sidebar/note_card.vala
@@ -86,6 +86,8 @@ public class Folio.NoteCard : Gtk.Box {
 			// handler will run and steal the focus away again.  So instead, just add a slight
 			//delay to get the default handler to run before calling the rename request.
 			GLib.Timeout.add_once (100, () => { request_rename (); });
+		} else if (n_press == 1) {
+			GLib.Timeout.add_once (100, () => { _window.navigate_to_edit_view (); });
 		}
 	}
 

--- a/src/ui/window/sidebar/note_card.vala
+++ b/src/ui/window/sidebar/note_card.vala
@@ -41,6 +41,7 @@ public class Folio.NoteCard : Gtk.Box {
 	private Window _window;
 	private Note _note;
 	private Gtk.Popover? current_popover = null;
+	private bool clickthrough = false;
 
 	construct {
 		var long_press = new Gtk.GestureLongPress ();
@@ -66,6 +67,7 @@ public class Folio.NoteCard : Gtk.Box {
 		var double_click = new Gtk.GestureClick ();
 		double_click.button = Gdk.BUTTON_PRIMARY;
 		double_click.pressed.connect (check_double_click);
+		double_click.released.connect (note_navigate);
 		add_controller (double_click);
 
 		button_edit.clicked.connect (request_rename);
@@ -81,13 +83,26 @@ public class Folio.NoteCard : Gtk.Box {
 	}
 
 	public void check_double_click (int n_press, double x, double y) {
+		clickthrough = true;
 		if (n_press == 2) {
-			// We can't just call the rename request here as after this code runs the default
-			// handler will run and steal the focus away again.  So instead, just add a slight
-			//delay to get the default handler to run before calling the rename request.
-			GLib.Timeout.add_once (100, () => { request_rename (); });
-		} else if (n_press == 1) {
-			GLib.Timeout.add_once (100, () => { _window.navigate_to_edit_view (); });
+				// We can't just call the rename request here as after this code runs the default
+				// handler will run and steal the focus away again.  So instead, just add a slight
+				// delay to get the default handler to run before calling the rename request.
+			GLib.Timeout.add_once (100, () => {
+				clickthrough = false;
+				request_rename ();
+			});
+		}
+	}
+
+	public void note_navigate (int n_press, double x, double y) {
+		print (n_press.to_string ());
+		if (n_press == 1 && clickthrough) {
+			GLib.Timeout.add_once (175, () => {
+				if (clickthrough) {
+					_window.navigate_to_edit_view ();
+				}
+			});
 		}
 	}
 
@@ -125,6 +140,7 @@ public class Folio.NoteCard : Gtk.Box {
 	}
 
 	private void show_popup (double x, double y) {
+		clickthrough = false;
 		if (current_popover != null) {
 			current_popover.popdown();
 		}

--- a/src/ui/window/sidebar/note_create_popup.blp
+++ b/src/ui/window/sidebar/note_create_popup.blp
@@ -1,23 +1,13 @@
 using Gtk 4.0;
 using Adw 1;
 
-template $FolioNoteCreatePopup : Adw.Window {
+template $FolioNoteCreatePopup : Adw.Dialog {
 
-  default-width: 320;
+  content-width: 320;
   resizable: false;
   modal: true;
 
-  ShortcutController {
-
-    scope: managed;
-
-    Shortcut {
-      trigger: "Escape";
-      action: "action(window.close)";
-    }
-  }
-
-  WindowHandle {
+  child: WindowHandle {
     Box {
 
       spacing: 16;
@@ -49,5 +39,5 @@ template $FolioNoteCreatePopup : Adw.Window {
         styles ["suggested-action"]
       }
     }
-  }
+  };
 }

--- a/src/ui/window/sidebar/note_create_popup.blp
+++ b/src/ui/window/sidebar/note_create_popup.blp
@@ -4,8 +4,6 @@ using Adw 1;
 template $FolioNoteCreatePopup : Adw.Dialog {
 
   content-width: 320;
-  resizable: false;
-  modal: true;
 
   child: WindowHandle {
     Box {

--- a/src/ui/window/sidebar/note_create_popup.vala
+++ b/src/ui/window/sidebar/note_create_popup.vala
@@ -1,6 +1,6 @@
 
 [GtkTemplate (ui = "/com/toolstack/Folio/sidebar/create_popup.ui")]
-public class Folio.NoteCreatePopup : Adw.Window {
+public class Folio.NoteCreatePopup : Adw.Dialog {
 
 	[GtkChild]
 	unowned Gtk.Entry entry;

--- a/src/ui/window/sidebar/note_menu.vala
+++ b/src/ui/window/sidebar/note_menu.vala
@@ -36,7 +36,7 @@ public class Folio.NoteMenuPopover : Gtk.Popover {
 			});
 			button_delete.clicked.connect (() => {
 				popdown ();
-				window.request_delete_note (note);
+				window.request_delete_note (note, true);
 			});
 		} else {
 			button_recover.visible = false;

--- a/src/ui/window/window.blp
+++ b/src/ui/window/window.blp
@@ -18,6 +18,7 @@ template $FolioWindow: Adw.ApplicationWindow {
           leaflet.collapsed: true;
           toggle_sidebar.visible: false;
           headerbar_edit_view.show-back-button: true;
+          leaflet.show-content: true;
         }
       }
 

--- a/src/ui/window/window.blp
+++ b/src/ui/window/window.blp
@@ -1,279 +1,301 @@
 using Gtk 4.0;
 using Adw 1;
 
-template $FolioWindow : Adw.ApplicationWindow {
-
-  styles ["transparent"]
+template $FolioWindow: Adw.ApplicationWindow {
+  styles [
+    "transparent"
+  ]
 
   Adw.ToastOverlay toast_overlay {
+    Adw.BreakpointBin {
+      width-request: 360;
+      height-request: 360;
 
-    Adw.Leaflet leaflet {
+      Adw.Breakpoint {
+        condition ("max-width: 600sp")
 
-      Adw.LeafletPage sidebar {
+        setters {
+          leaflet.collapsed: true;
+          toggle_sidebar.visible: false;
+          headerbar_edit_view.show-back-button: true;
+        }
+      }
 
-        navigatable: false;
+      child: Adw.NavigationSplitView leaflet {
+        min-sidebar-width: 264;
 
-        child: Revealer sidebar_revealer {
+        [sidebar]
+        Adw.NavigationPage sidebar {
+          child: Revealer sidebar_revealer {
+            transition-type: slide_right;
+            reveal-child: true;
 
-          transition-type: slide_right;
-          reveal-child: true;
+            child: Adw.ToolbarView {
+              content: Box {
+                $FolioNotebooksBar notebooks_bar {}
 
-          child: Box {
+                Box {
+                  orientation: vertical;
+                  hexpand: true;
+                  vexpand: true;
 
-            orientation: horizontal;
-            hexpand: false;
+                  styles [
+                    "notebook-sidebar"
+                  ]
+
+                  Adw.HeaderBar headerbar_sidebar {
+                    show-start-title-buttons: bind notebooks_bar.paned inverted;
+                    show-end-title-buttons: bind leaflet.collapsed;
+
+                    [start]
+                    Button button_create_note {
+                      icon-name: "list-add-symbolic";
+                      action-name: "app.new-note";
+                      tooltip-text: _("New Note");
+                    }
+
+                    [start]
+                    Button button_empty_trash {
+                      icon-name: "empty-trash-symbolic";
+                      action-name: "app.empty-trash";
+                      tooltip-text: _("Empty Trash");
+                    }
+
+                    [title]
+                    Adw.WindowTitle notebook_title {}
+
+                    [end]
+                    ToggleButton {
+                      icon-name: "system-search-symbolic";
+                      tooltip-text: _("Search Notes");
+                      active: bind notes_search_bar.search-mode-enabled bidirectional;
+                    }
+                  }
+
+                  SearchBar notes_search_bar {
+                    SearchEntry notes_search_entry {}
+                  }
+
+                  ScrolledWindow notebook_notes_list_scroller {
+                    hexpand: true;
+                    vexpand: true;
+                    hscrollbar-policy: never;
+                    vscrollbar-policy: automatic;
+
+                    ListView notebook_notes_list {
+                      accessibility {
+                        labelled-by: notebook_title;
+                      }
+                    }
+                  }
+                }
+              };
+            };
+          };
+        }
+
+        [content]
+        Adw.NavigationPage edit_view_page {
+          child: Overlay {
+            hexpand: true;
             vexpand: true;
-            width-request: 224;
+            width-request: 320;
 
-            $FolioNotebooksBar notebooks_bar {}
+            styles [
+              "text-area"
+            ]
 
-            Box {
-
-              orientation: vertical;
+            [overlay]
+            $FolioEditView edit_view {
               hexpand: true;
               vexpand: true;
+            }
 
-              styles ["notebook-sidebar"]
+            [overlay]
+            Box text_view_empty_notebook {
+              hexpand: true;
+              vexpand: true;
+              orientation: vertical;
+              halign: center;
+              valign: center;
 
-              Adw.HeaderBar headerbar_sidebar {
+              Label {
+                label: _("Get started writing");
 
-                show-start-title-buttons: bind notebooks_bar.paned inverted;
-                show-end-title-buttons: bind leaflet.folded;
+                styles [
+                  "title-1"
+                ]
+              }
 
-                [start]
-                Button button_create_note {
-                  icon-name: "list-add-symbolic";
-                  action-name: "app.new-note";
-                  tooltip-text: _("New Note");
-                }
+              Button {
+                label: _("New Note");
+                action-name: "app.new-note";
+                margin-bottom: 32;
+                margin-top: 32;
 
-                [start]
-                Button button_empty_trash {
-                  icon-name: "empty-trash-symbolic";
-                  action-name: "app.empty-trash";
-                  tooltip-text: _("Empty Trash");
-                }
+                styles [
+                  "pill",
+                  "suggested-action"
+                ]
+              }
+            }
+
+            [overlay]
+            Box external_file_type_notebook {
+              hexpand: true;
+              vexpand: true;
+              orientation: vertical;
+              halign: center;
+              valign: center;
+
+              Label {
+                label: _("Open file in external application");
+
+                styles [
+                  "title-1"
+                ]
+              }
+
+              Button {
+                label: _("Open file");
+                action-name: "app.open-external-file";
+                margin-bottom: 32;
+                margin-top: 32;
+
+                styles [
+                  "pill",
+                  "suggested-action"
+                ]
+              }
+            }
+
+            [overlay]
+            Box text_view_no_notebook {
+              hexpand: true;
+              vexpand: true;
+              orientation: vertical;
+              halign: center;
+              valign: center;
+
+              Label {
+                label: _("Create a notebook");
+
+                styles [
+                  "title-1"
+                ]
+              }
+
+              Button {
+                label: _("New Notebook");
+                action-name: "app.new-notebook";
+                margin-bottom: 32;
+                margin-top: 32;
+
+                styles [
+                  "pill",
+                  "suggested-action"
+                ]
+              }
+            }
+
+            [overlay]
+            Box text_view_empty_trash {
+              hexpand: true;
+              vexpand: true;
+              orientation: vertical;
+              halign: center;
+              valign: center;
+
+              Label {
+                label: _("Trash is empty");
+
+                styles [
+                  "title-1"
+                ]
+              }
+            }
+
+            [overlay]
+            Revealer headerbar_edit_view_revealer {
+              valign: start;
+              reveal-child: true;
+              transition-type: crossfade;
+
+              child: Adw.HeaderBar headerbar_edit_view {
+                hexpand: true;
+                vexpand: false;
+                visible: true;
+                show-back-button: false;
 
                 [title]
-                Adw.WindowTitle notebook_title {}
+                Box {
+                  orientation: vertical;
+                  valign: center;
+
+                  CenterBox {
+                    orientation: horizontal;
+                    halign: center;
+
+                    styles [
+                      "title"
+                    ]
+
+                    [start]
+                    Label save_indicator {
+                      label: "•";
+                      visible: false;
+                      hexpand: false;
+                      halign: end;
+                      margin-end: 6;
+                    }
+
+                    [center]
+                    Label note_title {
+                      halign: fill;
+                    }
+                  }
+
+                  Label note_subtitle {
+                    styles [
+                      "subtitle"
+                    ]
+                  }
+                }
+
+                [start]
+                ToggleButton toggle_sidebar {
+                  icon-name: "sidebar-show-symbolic";
+                  tooltip-text: _("Toggle Sidebar");
+                  active: bind leaflet.collapsed inverted bidirectional;
+                  visible: true;
+                }
 
                 [end]
-                ToggleButton {
-                  icon-name: "system-search-symbolic";
-                  tooltip-text: _("Search Notes");
-                  active: bind notes_search_bar.search-mode-enabled bidirectional;
+                MenuButton button_more_menu {
+                  icon-name: "view-more-symbolic";
+
+                  popover: PopoverMenu more_popover {
+                    menu-model: more_menu;
+                  };
                 }
-              }
 
-              SearchBar notes_search_bar {
-                SearchEntry notes_search_entry {}
-              }
-
-              ScrolledWindow notebook_notes_list_scroller {
-
-                hexpand: true;
-                vexpand: true;
-                hscrollbar-policy: never;
-                vscrollbar-policy: automatic;
-
-                ListView notebook_notes_list {
-                  accessibility {
-                    labelled-by: notebook_title;
-                  }
+                [end]
+                Button button_open_in_notebook {
+                  icon-name: "document-edit-symbolic";
+                  tooltip-text: _("Open in Notebook");
                 }
-              }
+
+                [end]
+                Button button_md_cheatsheet_headerbar {
+                  icon-name: "dialog-information-symbolic";
+                  tooltip-text: _("Markdown Cheatsheet");
+                  action-name: "app.markdown-cheatsheet";
+                }
+              };
             }
           };
-        };
-      }
-
-      Adw.LeafletPage edit_view_page {
-
-        navigatable: true;
-
-        child: Overlay {
-
-          hexpand: true;
-          vexpand: true;
-          width-request: 320;
-
-          styles ["text-area"]
-
-          [overlay]
-          $FolioEditView edit_view {
-            hexpand: true;
-            vexpand: true;
-          }
-
-          [overlay]
-          Box text_view_empty_notebook {
-
-            hexpand: true;
-            vexpand: true;
-            orientation: vertical;
-            halign: center;
-            valign: center;
-
-            Label {
-              label: _("Get started writing");
-              styles ["title-1"]
-            }
-
-            Button {
-
-              label: _("New Note");
-              action-name: "app.new-note";
-              margin-bottom: 32;
-              margin-top: 32;
-
-              styles ["pill", "suggested-action"]
-            }
-          }
-
-          [overlay]
-          Box external_file_type_notebook {
-
-            hexpand: true;
-            vexpand: true;
-            orientation: vertical;
-            halign: center;
-            valign: center;
-
-            Label {
-              label: _("Open file in external application");
-              styles ["title-1"]
-            }
-
-            Button {
-
-              label: _("Open file");
-              action-name: "app.open-external-file";
-              margin-bottom: 32;
-              margin-top: 32;
-
-              styles ["pill", "suggested-action"]
-            }
-          }
-
-          [overlay]
-          Box text_view_no_notebook {
-
-            hexpand: true;
-            vexpand: true;
-            orientation: vertical;
-            halign: center;
-            valign: center;
-
-            Label {
-              label: _("Create a notebook");
-              styles ["title-1"]
-            }
-
-            Button {
-
-              label: _("New Notebook");
-              action-name: "app.new-notebook";
-              margin-bottom: 32;
-              margin-top: 32;
-
-              styles ["pill", "suggested-action"]
-            }
-          }
-
-          [overlay]
-          Box text_view_empty_trash {
-
-            hexpand: true;
-            vexpand: true;
-            orientation: vertical;
-            halign: center;
-            valign: center;
-
-            Label {
-              label: _("Trash is empty");
-              styles ["title-1"]
-            }
-          }
-
-          [overlay]
-          Revealer headerbar_edit_view_revealer {
-            valign: start;
-            reveal-child: true;
-            transition-type: crossfade;
-
-            child: Adw.HeaderBar headerbar_edit_view {
-
-              hexpand: true;
-              vexpand: false;
-              visible: true;
-
-              [title]
-              Box {
-                orientation: vertical;
-                valign: center;
-                CenterBox {
-                  orientation: horizontal;
-                  halign: center;
-
-                  styles ["title"]
-
-                  [start]
-                  Label save_indicator {
-                    label: "•";
-                    visible: false;
-                    hexpand: false;
-                    halign: end;
-                    margin-end: 6;
-                  }
-                  [center]
-                  Label note_title {
-                    halign: fill;
-                  }
-                }
-                Label note_subtitle {
-                  styles ["subtitle"]
-                }
-              }
-
-              [start]
-              ToggleButton {
-                icon-name: "sidebar-show-symbolic";
-                tooltip-text: _("Toggle Sidebar");
-                active: bind sidebar_revealer.reveal-child bidirectional;
-                visible: bind leaflet.folded inverted;
-              }
-
-              [start]
-              Button button_back {
-                icon-name: "go-previous-symbolic";
-                tooltip-text: _("Back");
-                visible: bind leaflet.folded;
-              }
-
-              [end]
-              MenuButton button_more_menu {
-                icon-name: "view-more-symbolic";
-                popover: PopoverMenu more_popover {
-                  menu-model: more_menu;
-                };
-              }
-
-              [end]
-              Button button_open_in_notebook {
-                icon-name: "document-edit-symbolic";
-                tooltip-text: _("Open in Notebook");
-              }
-
-              [end]
-              Button button_md_cheatsheet_headerbar {
-                icon-name: "dialog-information-symbolic";
-                tooltip-text: _("Markdown Cheatsheet");
-                action-name: "app.markdown-cheatsheet";
-              }
-            };
-          }
-        };
-      }
+        }
+      };
     }
   }
 }
@@ -284,12 +306,14 @@ menu more_menu {
       custom: "font-scale";
     }
   }
+
   section {
     item {
       label: _("_Rename Note");
       action: "app.edit-note";
     }
   }
+
   section {
     item {
       label: _("_Export Note");

--- a/src/ui/window/window.vala
+++ b/src/ui/window/window.vala
@@ -86,6 +86,7 @@ public class Folio.Window : Adw.ApplicationWindow {
 		window_model.note_changed.connect (on_update_note);
 		window_model.state_changed.connect (on_update_state);
 		window_model.present_dialog.connect (on_present_dialog);
+		window_model.navigate_to_notes.connect (navigate_to_notes);
 		window_model.notify["notes-model"].connect (() => {
 			notebook_notes_list.model = window_model.notes_model;
 			if (window_model.state == WindowModel.State.TRASH) {
@@ -201,6 +202,8 @@ public class Folio.Window : Adw.ApplicationWindow {
 				return true;
 			}, 0 );
 		}
+
+		leaflet.show_content = false; // Don't start in note view.
 	}
 
 	private void toggle_fullscreen () {

--- a/src/ui/window/window.vala
+++ b/src/ui/window/window.vala
@@ -458,9 +458,8 @@ public class Folio.Window : Adw.ApplicationWindow {
 
 	public void request_edit_note (Note note) {
 		var popup = new NoteCreatePopup (this, note);
-		popup.transient_for = this;
 		popup.title = Strings.RENAME_NOTE;
-		popup.present ();
+		popup.present (this);
 	}
 
 	public void request_move_note (Note note) {
@@ -473,8 +472,7 @@ public class Folio.Window : Adw.ApplicationWindow {
 					toast (Strings.NOTE_X_ALREADY_EXISTS_IN_X.printf (note.name, dest_notebook.name));
 			}
 		);
-		popup.transient_for = this;
-		popup.present ();
+		popup.present (this);
 	}
 
 	public void request_delete_note (Note note) {
@@ -697,8 +695,7 @@ public class Folio.Window : Adw.ApplicationWindow {
 		string action_description,
 		owned Runnable callback
 	) {
-		var dialog = new Adw.MessageDialog (
-			this,
+		var dialog = new Adw.AlertDialog (
 			action_title,
 			action_description
 		);
@@ -715,7 +712,7 @@ public class Folio.Window : Adw.ApplicationWindow {
 			}
 			dialog.close ();
 		});
-		dialog.present ();
+		dialog.present (this);
 	}
 
 	public void resize_toolbar () {

--- a/src/ui/window/window.vala
+++ b/src/ui/window/window.vala
@@ -498,16 +498,14 @@ public class Folio.Window : Adw.ApplicationWindow {
 
 	public void request_new_notebook () {
 		var popup = new NotebookCreatePopup (this);
-		popup.transient_for = this;
 		popup.title = Strings.NEW_NOTEBOOK;
-		popup.present ();
+		popup.present (this);
 	}
 
 	public void request_edit_notebook (Notebook notebook) {
 		var popup = new NotebookCreatePopup (this, notebook);
-		popup.transient_for = this;
 		popup.title = Strings.EDIT_NOTEBOOK;
-		popup.present ();
+		popup.present (this);
 	}
 
 	public void request_delete_notebook (Notebook notebook) {

--- a/src/ui/window/window_model.vala
+++ b/src/ui/window/window_model.vala
@@ -93,30 +93,23 @@ public class Folio.WindowModel : Object {
 			bool result = note.validate_save ();
 
 			if (!result) {
-				var confirm = new Gtk.AlertDialog ("");
-				confirm.set_message (Strings.FILE_CHANGED_ON_DISK);
-				confirm.set_detail (Strings.FILE_CHANGED_DIALOG_TRIPLE);
-				confirm.set_buttons ({
-					Strings.FILE_CHANGED_RELOAD,
-					Strings.FILE_CHANGED_OVERWRITE,
-					Strings.FILE_CHANGED_CANCEL
-					});
-				confirm.set_cancel_button (2);
-				confirm.set_default_button (2);
-				confirm.set_modal (true);
-				confirm.choose.begin (window, null, (obj, res) => {
-					int button_result = 2;
-					try {
-						button_result = confirm.choose.end (res);
-					} catch (Error e) {}
-
-					switch (button_result) {
-						case 0:
+				var confirm = new Adw.AlertDialog (
+					Strings.FILE_CHANGED_ON_DISK,
+					Strings.FILE_CHANGED_DIALOG_TRIPLE);
+				confirm.add_responses (
+					"reload", Strings.FILE_CHANGED_RELOAD,
+					"overwrite", Strings.FILE_CHANGED_OVERWRITE,
+					"cancel", Strings.FILE_CHANGED_CANCEL);
+				confirm.set_default_response ("reload");
+				confirm.set_close_response ("cancel");
+				confirm.response.connect (response => {
+					switch (response) {
+						case "reload":
 							note.save (note.load_text());
 							is_unsaved = false;
 							_update_note_list_item_timestamp (window);
 							break;
-						case 1:
+						case "overwrite":
 							note.save (current_buffer.get_all_text ());
 							is_unsaved = false;
 							_update_note_list_item_timestamp (window);
@@ -125,6 +118,7 @@ public class Folio.WindowModel : Object {
 							break;
 					}
 				});
+				confirm.present (window);
 			} else {
 				note.save (current_buffer.get_all_text ());
 				is_unsaved = false;

--- a/src/ui/window/window_model.vala
+++ b/src/ui/window/window_model.vala
@@ -4,6 +4,7 @@ public class Folio.WindowModel : Object {
 	public signal void state_changed (State state, NoteContainer? container, bool is_clicked = false);
 	public signal void note_changed (Note? note);
 	public signal void present_dialog (Adw.Dialog dialog);
+	public signal void navigate_to_notes ();
 
 	public Provider notebook_provider;
 
@@ -130,7 +131,10 @@ public class Folio.WindowModel : Object {
 
 	public void select_note_at (uint i) requires (notes_model != null) {
 		if (i == -1) notes_model.unselect_item (notes_model.selected);
-		else notes_model.select_item (i, true);
+		else {
+			notes_model.select_item (i, true);
+			navigate_to_notes ();
+		}
 	}
 
 	public void select_notebook_at (uint i) requires (notebooks_model != null) {
@@ -161,6 +165,7 @@ public class Folio.WindowModel : Object {
 			.first_match ((it) => it.name == note.name);
 		int i = note_container.loaded_notes.index_of (n);
 		select_note_at (i);
+		navigate_to_notes ();
 	}
 
 	public void update_selected_note () requires (notes_model != null) {

--- a/src/ui/window/window_model.vala
+++ b/src/ui/window/window_model.vala
@@ -1,7 +1,7 @@
 
 public class Folio.WindowModel : Object {
 
-	public signal void state_changed (State state, NoteContainer? container);
+	public signal void state_changed (State state, NoteContainer? container, bool is_clicked = false);
 	public signal void note_changed (Note? note);
 
 	public Provider notebook_provider;


### PR DESCRIPTION
This pull request contains a refreshing of widgets to move to modern widgets… among other things. I got distracted. :P

An oversight of the features is as follows:

1) New `AdwDialog`s throughout the app:
<img width=400 alt="Skjermbilde fra 2024-10-12 16-55-59" src="https://github.com/user-attachments/assets/58e46f77-e2f6-40e6-89ee-83ad00b9d20d">

2) Notification after moving note to trash
<img width=400 alt="Skjermbilde fra 2024-10-12 16-59-54" src="https://github.com/user-attachments/assets/d651c7ed-f464-44d1-a22e-242c8b0a433c">

3) `AdwBreakpoint`s and `AdwNavigationView`: see screen recording of the changing sizes [here](https://github.com/user-attachments/assets/be6d2079-4eb6-4b67-8439-dd7a5a0176e9)

There's still things to do here, such as figuring out the click gestures.
