### PR TITLE
Empty note should be empty string not null.

### DIFF
--- a/lib/note.vala
+++ b/lib/note.vala
@@ -76,7 +76,7 @@ public class Folio.Note : Object {
 		if (text_data.length > 0) {
 			return (string)text_data;
 		}
-		return null;
+		return "";
 	}
 
 	public bool validate_save () {


### PR DESCRIPTION
This avoids the markdown editor from creating random strings in new notes sometimes (hopefully).

Resolves #207.