### PR TITLE
Fixed some memory errors identified with valgrind.

### DIFF
--- a/lib/note.vala
+++ b/lib/note.vala
@@ -67,7 +67,11 @@ public class Folio.Note : Object {
 				string etag_out;
 				file.load_contents (null, out text_data, out etag_out);
 				// Make sure the last character of the file is a return, otherwise some of the regex's will break.
-				if (text_data[text_data.length - 1] != 10) { text_data += 10; }
+				if (text_data.length > 0 && text_data[text_data.length - 1] != 10) {
+					text_data += 10;
+				}
+				// Null terminate
+				text_data += 0;
 			}
 			update_note_time ();
 		} catch (Error e) {

--- a/src/application.vala
+++ b/src/application.vala
@@ -368,6 +368,7 @@ Sunniva Løvstad
 			{ "open-note", 'n', 0, OptionArg.STRING, ref open_note, "Open a note", null },
 			{ "launch-search", 's', 0, OptionArg.STRING, ref launch_search, "Search notes", null },
 			{ "file", 'f', 0, OptionArg.FILENAME, ref file, "Edit file", null },
+			null
 		};
 
 


### PR DESCRIPTION
This fixes a few memory errors identified with valgrind.

From a user perspective, it seems to fix the issue of garbage characters sometimes appearing at the end of notes that do not end in a newline character (as discussed in e.g. #272).

### Notes (for future self, or other contributors)

After compiling Folio, you can run it under valgrind with the following:
```
valgrind src/com.toolstack.Folio
```
However, there is a lot of `Conditional jump or move depends on uninitialised value(s)` noise when you do this. I haven't been able to track down the source of that as it's not giving source locations for these reports, for me. It may be related to a library dependency rather than Folio itself, however.

You can suppress these by putting the following in a file, call it `suppressions.supp`, say:
```
{
   cond
   Memcheck:Cond
   obj:*
   obj:*
}
```
Then run valgrind with:
```
valgrind --suppressions=suppressions.supp src/com.toolstack.Folio
```