### PR TITLE
Add @bindir@ to Exec entry in desktop files

### DIFF
--- a/data/app.desktop.in
+++ b/data/app.desktop.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Terminal=false
-Exec=@app_id@
+Exec=@bindir@/@app_id@
 DBusActivatable=true
 StartupWMClass=@app_id@
 
@@ -19,16 +19,16 @@ Actions=new-note;new-notebook;markdown-cheatsheet;preferences;
 
 [Desktop Action new-note]
 Name=New Note
-Exec=@app_id@ --new-note
+Exec=@bindir@/@app_id@ --new-note
 
 [Desktop Action new-notebook]
 Name=New Notebook
-Exec=@app_id@ --new-notebook
+Exec=@bindir@/@app_id@ --new-notebook
 
 [Desktop Action markdown-cheatsheet]
 Name=Markdown Cheatsheet
-Exec=@app_id@ --markdown-cheatsheet
+Exec=@bindir@/@app_id@ --markdown-cheatsheet
 
 [Desktop Action preferences]
 Name=Preferences
-Exec=@app_id@ --preferences
+Exec=@bindir@/@app_id@ --preferences

--- a/data/editor.desktop.in
+++ b/data/editor.desktop.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Terminal=false
-Exec=@app_id@ --file %u
+Exec=@bindir@/@app_id@ --file %u
 NoDisplay=true
 
 Name=Folio
@@ -9,3 +9,4 @@ Name=Folio
 Icon=@app_id@
 StartupNotify=true
 MimeType=text/x-markdown;text/markdown;
+


### PR DESCRIPTION
A small change to add the full path of the installed Folio executable to desktop entry files.

This is needed when doing a local install, to e.g. `$HOME/.local`:
```
meson build --prefix=$HOME/.local
cd build
meson compile
meson install
```
where `$HOME/.local` is added to the `$PATH` environment variable in e.g. a `.bashrc` file.

Without this, what happens is that GNOME can't find the executable when building its menu, and so Folio won't appear in the menu. I don't know the details of the process exactly, but I guess the `$PATH` variable may be modified after GNOME builds the menu.
