### PR TITLE
Fix short note cut off when switching from longer note that has been scrolled down

### DIFF
--- a/src/ui/edit_view/edit_view.vala
+++ b/src/ui/edit_view/edit_view.vala
@@ -507,7 +507,6 @@ public class Folio.EditView : Gtk.Box {
 		Gtk.TextIter start;
 		markdown_view.buffer.get_start_iter (out start);
 		markdown_view.buffer.place_cursor (start);
-		scrolled_window.vadjustment.value = 0;
 		markdown_view.grab_focus ();
 	}
 }


### PR DESCRIPTION
Closes #293. I can't say why this works exactly. Possibly it's about the order in which events are handled, or Gtk has changed behavior behind the scenes since this bit of code was written.

Here's a video after the fix (compare against that in #293):

https://github.com/user-attachments/assets/ab6ea6b8-f045-4be6-bfa9-a8b7bfe25a69

